### PR TITLE
feat: Restrict admin-only actions with toast feedback

### DIFF
--- a/conductor.json
+++ b/conductor.json
@@ -1,0 +1,6 @@
+{
+  "scripts": {
+    "setup": "cp \"$CONDUCTOR_ROOT_PATH/.env\" . && bun install",
+    "run": "bun run dev"
+  }
+}

--- a/features/workspace/archive/DialogArchiveEntity.tsx
+++ b/features/workspace/archive/DialogArchiveEntity.tsx
@@ -72,20 +72,19 @@ export default function DialogArchiveEntity({
   }
 
   return (
-    <Dialog
-      open={open}
-      onOpenChange={(newOpen) => {
-        if (newOpen && !isAdmin) {
-          toast.error("Insufficient privileges, contact Admin");
-          return;
-        }
-        setOpen(newOpen);
-      }}
-    >
+    <Dialog open={open} onOpenChange={setOpen}>
       <DialogTrigger>
         <Button
           variant="secondary"
           size="sm"
+          onClick={(e) => {
+            if (!isAdmin) {
+              e.preventDefault();
+              e.stopPropagation();
+              toast.error("Insufficient privileges, contact Admin");
+              return;
+            }
+          }}
         >
           <PiArchiveDuotone />
           Archive

--- a/features/workspace/archive/DialogArchiveEntity.tsx
+++ b/features/workspace/archive/DialogArchiveEntity.tsx
@@ -72,18 +72,20 @@ export default function DialogArchiveEntity({
   }
 
   return (
-    <Dialog open={open} onOpenChange={setOpen}>
+    <Dialog
+      open={open}
+      onOpenChange={(newOpen) => {
+        if (newOpen && !isAdmin) {
+          toast.error("Insufficient privileges, contact Admin");
+          return;
+        }
+        setOpen(newOpen);
+      }}
+    >
       <DialogTrigger>
         <Button
           variant="secondary"
           size="sm"
-          onClick={(e) => {
-            if (!isAdmin) {
-              e.preventDefault();
-              e.stopPropagation();
-              toast.error("Insufficient privileges, contact Admin");
-            }
-          }}
         >
           <PiArchiveDuotone />
           Archive

--- a/features/workspace/archive/DialogArchiveEntity.tsx
+++ b/features/workspace/archive/DialogArchiveEntity.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { toast } from "sonner";
+import { useAuth } from "react-oidc-context";
 import { useId, useMemo, useState } from "react";
 import { CircleAlert as CircleAlertIcon } from "lucide-react";
 
@@ -20,11 +22,6 @@ import { useArchiveDepartment } from "@/hooks/department/useArchiveDepartment";
 import { useArchiveProject } from "@/hooks/project/useArchiveProject";
 import { PiArchiveDuotone } from "react-icons/pi";
 import { Spinner } from "@/components/ui/spinner";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
 
 export type ArchiveEntityType = "project" | "department";
 
@@ -42,6 +39,9 @@ export default function DialogArchiveEntity({
   const inputId = useId();
   const [value, setValue] = useState("");
   const [open, setOpen] = useState(false);
+
+  const auth = useAuth();
+  const isAdmin = auth.user?.profile?.userType === "admin";
 
   // Prepare mutations
   const departmentArchive = useArchiveDepartment();
@@ -61,6 +61,10 @@ export default function DialogArchiveEntity({
   const disabled = value.trim() !== entityName.trim() || isPending;
 
   async function handleConfirm() {
+    if (!isAdmin) {
+      toast.error("Insufficient privileges, contact Admin");
+      return;
+    }
     if (disabled) return;
     await mutateAsync(id);
     setOpen(false);
@@ -70,20 +74,20 @@ export default function DialogArchiveEntity({
   return (
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogTrigger>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <Button variant="secondary" size="sm">
-              <PiArchiveDuotone />
-              Archive
-            </Button>
-          </TooltipTrigger>
-          <TooltipContent>
-            <p>
-              Archive{" "}
-              {entityType.slice(0, 1).toUpperCase() + entityType.slice(1)}
-            </p>
-          </TooltipContent>
-        </Tooltip>
+        <Button
+          variant="secondary"
+          size="sm"
+          onClick={(e) => {
+            if (!isAdmin) {
+              e.preventDefault();
+              e.stopPropagation();
+              toast.error("Insufficient privileges, contact Admin");
+            }
+          }}
+        >
+          <PiArchiveDuotone />
+          Archive
+        </Button>
       </DialogTrigger>
       <DialogContent>
         <div className="flex flex-col items-start gap-2">

--- a/features/workspace/archive/departments/ArchivedDepartmentsTable.tsx
+++ b/features/workspace/archive/departments/ArchivedDepartmentsTable.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { toast } from "sonner";
+import { useAuth } from "react-oidc-context";
 import {
   ColumnDef,
   flexRender,
@@ -117,6 +119,17 @@ export function ArchivedDepartmentsTable({
   });
 
   const [sorting, setSorting] = useState<SortingState>([]);
+
+  const auth = useAuth();
+  const isAdmin = auth.user?.profile?.userType === "admin";
+
+  const handleRestore = (item: DepartmentArchiveRow) => {
+    if (!isAdmin) {
+      toast.error("Insufficient privileges, contact Admin");
+      return;
+    }
+    onRestore(item);
+  };
 
   const columns: ColumnDef<DepartmentArchiveRow>[] = useMemo(() => {
     return [
@@ -237,7 +250,7 @@ export function ArchivedDepartmentsTable({
                 disabled={isLoading}
                 onClick={(e) => {
                   e.stopPropagation();
-                  onRestore(row.original);
+                  handleRestore(row.original);
                 }}
               >
                 {isLoading ? (

--- a/features/workspace/archive/projects/ArchivedProjectsTable.tsx
+++ b/features/workspace/archive/projects/ArchivedProjectsTable.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { toast } from "sonner";
+import { useAuth } from "react-oidc-context";
 import {
   ColumnDef,
   flexRender,
@@ -113,6 +115,17 @@ export function ArchivedProjectsTable({
   });
 
   const [sorting, setSorting] = useState<SortingState>([]);
+
+  const auth = useAuth();
+  const isAdmin = auth.user?.profile?.userType === "admin";
+
+  const handleRestore = (item: ProjectArchiveRow) => {
+    if (!isAdmin) {
+      toast.error("Insufficient privileges, contact Admin");
+      return;
+    }
+    onRestore(item);
+  };
 
   const columns: ColumnDef<ProjectArchiveRow>[] = useMemo(() => {
     return [
@@ -251,7 +264,7 @@ export function ArchivedProjectsTable({
                 disabled={isLoading}
                 onClick={(e) => {
                   e.stopPropagation();
-                  onRestore(row.original);
+                  handleRestore(row.original);
                 }}
               >
                 {isLoading ? (

--- a/features/workspace/departments/AddUsersInDepartmentDropdown.tsx
+++ b/features/workspace/departments/AddUsersInDepartmentDropdown.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { toast } from "sonner";
+import { useAuth } from "react-oidc-context";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -30,6 +32,22 @@ export default function AddUsersInDepartmentDropdown({
   selectedUsers = [],
   users = [],
 }: AddUsersInDepartmentDropdownProps) {
+  const auth = useAuth();
+  const isAdmin = auth.user?.profile?.userType === "admin";
+
+  const handleUserClick = (user: User) => {
+    if (!isAdmin) {
+      toast.error("Insufficient privileges, contact Admin");
+      return;
+    }
+    const isSelected = selectedUsers.some((u) => u._id === user._id);
+    if (isSelected) {
+      onRemoveUser?.(user);
+    } else {
+      onAddUser(user);
+    }
+  };
+
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
@@ -44,9 +62,7 @@ export default function AddUsersInDepartmentDropdown({
           return (
             <DropdownMenuItem
               key={user._id}
-              onClick={() =>
-                isSelected ? onRemoveUser?.(user) : onAddUser(user)
-              }
+              onClick={() => handleUserClick(user)}
               className="flex items-center justify-between gap-2"
             >
               <div className="flex items-center gap-2">

--- a/features/workspace/departments/CreateDepartmentDialog.tsx
+++ b/features/workspace/departments/CreateDepartmentDialog.tsx
@@ -129,19 +129,21 @@ export default function CreateDepartmentDialog() {
   }
 
   return (
-    <Dialog open={open} onOpenChange={setOpen}>
+    <Dialog
+      open={open}
+      onOpenChange={(newOpen) => {
+        if (newOpen && !isAdmin) {
+          toast.error("Insufficient privileges, contact Admin");
+          return;
+        }
+        setOpen(newOpen);
+      }}
+    >
       <DialogTrigger asChild>
         <Button
           variant="default"
           size="sm"
           className="flex items-center gap-2"
-          onClick={(e) => {
-            if (!isAdmin) {
-              e.preventDefault();
-              e.stopPropagation();
-              toast.error("Insufficient privileges, contact Admin");
-            }
-          }}
         >
           <PiPlusCircleDuotone className="w-5 h-5" />
           Create Department

--- a/features/workspace/departments/CreateDepartmentDialog.tsx
+++ b/features/workspace/departments/CreateDepartmentDialog.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { toast } from "sonner";
 import { useId, useState } from "react";
 import { useForm } from "react-hook-form";
 import { ImagePlusIcon, XIcon } from "lucide-react";
@@ -59,6 +60,7 @@ export default function CreateDepartmentDialog() {
   const auth = useAuth();
   const userId = auth?.user?.profile?.userId;
   const workspaceId = auth?.user?.profile?.workspaceId;
+  const isAdmin = auth.user?.profile?.userType === "admin";
   const users = usersData?.data;
 
   const {
@@ -129,7 +131,18 @@ export default function CreateDepartmentDialog() {
   return (
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogTrigger asChild>
-        <Button variant="default" size="sm" className="flex items-center gap-2">
+        <Button
+          variant="default"
+          size="sm"
+          className="flex items-center gap-2"
+          onClick={(e) => {
+            if (!isAdmin) {
+              e.preventDefault();
+              e.stopPropagation();
+              toast.error("Insufficient privileges, contact Admin");
+            }
+          }}
+        >
           <PiPlusCircleDuotone className="w-5 h-5" />
           Create Department
         </Button>

--- a/features/workspace/departments/CreateDepartmentDialog.tsx
+++ b/features/workspace/departments/CreateDepartmentDialog.tsx
@@ -129,21 +129,20 @@ export default function CreateDepartmentDialog() {
   }
 
   return (
-    <Dialog
-      open={open}
-      onOpenChange={(newOpen) => {
-        if (newOpen && !isAdmin) {
-          toast.error("Insufficient privileges, contact Admin");
-          return;
-        }
-        setOpen(newOpen);
-      }}
-    >
+    <Dialog open={open} onOpenChange={setOpen}>
       <DialogTrigger asChild>
         <Button
           variant="default"
           size="sm"
           className="flex items-center gap-2"
+          onClick={(e) => {
+            if (!isAdmin) {
+              e.preventDefault();
+              e.stopPropagation();
+              toast.error("Insufficient privileges, contact Admin");
+              return;
+            }
+          }}
         >
           <PiPlusCircleDuotone className="w-5 h-5" />
           Create Department

--- a/features/workspace/departments/UpdateDepartmentDialog.tsx
+++ b/features/workspace/departments/UpdateDepartmentDialog.tsx
@@ -144,19 +144,21 @@ export default function UpdateDepartmentDialog({
   };
 
   return (
-    <Dialog open={open} onOpenChange={setOpen}>
+    <Dialog
+      open={open}
+      onOpenChange={(newOpen) => {
+        if (newOpen && !isAdmin) {
+          toast.error("Insufficient privileges, contact Admin");
+          return;
+        }
+        setOpen(newOpen);
+      }}
+    >
       <DialogTrigger asChild>
         <Button
           variant="secondary"
           size="sm"
           className="flex items-center gap-2"
-          onClick={(e) => {
-            if (!isAdmin) {
-              e.preventDefault();
-              e.stopPropagation();
-              toast.error("Insufficient privileges, contact Admin");
-            }
-          }}
         >
           <PiPencilCircleDuotone className="w-4 h-4" />
           Update

--- a/features/workspace/departments/UpdateDepartmentDialog.tsx
+++ b/features/workspace/departments/UpdateDepartmentDialog.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { toast } from "sonner";
+import { useAuth } from "react-oidc-context";
 import { useId, useState, useEffect } from "react";
 import { useForm, SubmitHandler } from "react-hook-form";
 import { ImagePlusIcon, XIcon } from "lucide-react";
@@ -75,6 +77,8 @@ export default function UpdateDepartmentDialog({
   const [uploadingImage, setUploadingImage] = useState(false);
 
   const { mutate: updateDepartment, isPending } = useUpdateDepartment();
+  const auth = useAuth();
+  const isAdmin = auth.user?.profile?.userType === "admin";
 
   const {
     register,
@@ -146,6 +150,13 @@ export default function UpdateDepartmentDialog({
           variant="secondary"
           size="sm"
           className="flex items-center gap-2"
+          onClick={(e) => {
+            if (!isAdmin) {
+              e.preventDefault();
+              e.stopPropagation();
+              toast.error("Insufficient privileges, contact Admin");
+            }
+          }}
         >
           <PiPencilCircleDuotone className="w-4 h-4" />
           Update

--- a/features/workspace/departments/UpdateDepartmentDialog.tsx
+++ b/features/workspace/departments/UpdateDepartmentDialog.tsx
@@ -144,21 +144,20 @@ export default function UpdateDepartmentDialog({
   };
 
   return (
-    <Dialog
-      open={open}
-      onOpenChange={(newOpen) => {
-        if (newOpen && !isAdmin) {
-          toast.error("Insufficient privileges, contact Admin");
-          return;
-        }
-        setOpen(newOpen);
-      }}
-    >
+    <Dialog open={open} onOpenChange={setOpen}>
       <DialogTrigger asChild>
         <Button
           variant="secondary"
           size="sm"
           className="flex items-center gap-2"
+          onClick={(e) => {
+            if (!isAdmin) {
+              e.preventDefault();
+              e.stopPropagation();
+              toast.error("Insufficient privileges, contact Admin");
+              return;
+            }
+          }}
         >
           <PiPencilCircleDuotone className="w-4 h-4" />
           Update

--- a/features/workspace/products/product/ProductHeader.tsx
+++ b/features/workspace/products/product/ProductHeader.tsx
@@ -293,10 +293,10 @@ export function ProductHeader() {
         <SidebarTrigger className="text-muted-foreground hover:text-muted-foreground bg-muted" />
 
         <Separator orientation="vertical" className="h-4" />
-        {/* <p className="text-xs font-semibold text-muted-foreground">
+        <p className="text-sm font-semibold text-foreground">
           {product?.productName}
         </p>
-        <Separator orientation="vertical" className="h-4" /> */}
+        <Separator orientation="vertical" className="h-4" />
         <div className="flex items-center gap-2">
           <Select
             onValueChange={(value) => {

--- a/features/workspace/projects/AddUsersInProjectDropdown.tsx
+++ b/features/workspace/projects/AddUsersInProjectDropdown.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { toast } from "sonner";
+import { useAuth } from "react-oidc-context";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -30,6 +32,22 @@ export default function AddUsersInProjectDropdown({
   selectedUsers = [],
   users = [],
 }: AddUsersInProjectDropdownProps) {
+  const auth = useAuth();
+  const isAdmin = auth.user?.profile?.userType === "admin";
+
+  const handleUserClick = (user: User) => {
+    if (!isAdmin) {
+      toast.error("Insufficient privileges, contact Admin");
+      return;
+    }
+    const isSelected = selectedUsers.some((u) => u._id === user._id);
+    if (isSelected) {
+      onRemoveUser?.(user);
+    } else {
+      onAddUser(user);
+    }
+  };
+
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
@@ -44,9 +62,7 @@ export default function AddUsersInProjectDropdown({
           return (
             <DropdownMenuItem
               key={user._id}
-              onClick={() =>
-                isSelected ? onRemoveUser?.(user) : onAddUser(user)
-              }
+              onClick={() => handleUserClick(user)}
               className="flex items-center justify-between gap-2"
             >
               <div className="flex items-center gap-2">

--- a/features/workspace/projects/ProjectCreateDialog.tsx
+++ b/features/workspace/projects/ProjectCreateDialog.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -78,6 +79,7 @@ export default function ProjectCreateDialog({
   const auth = useAuth();
   const userId = auth?.user?.profile?.userId;
   const workspaceId = auth?.user?.profile?.workspaceId;
+  const isAdmin = auth.user?.profile?.userType === "admin";
 
   const departments = departmentsData?.result?.departments || [];
   const users = usersData?.data;
@@ -158,7 +160,18 @@ export default function ProjectCreateDialog({
   return (
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogTrigger asChild>
-        <Button variant="default" size="sm" className="flex items-center gap-2">
+        <Button
+          variant="default"
+          size="sm"
+          className="flex items-center gap-2"
+          onClick={(e) => {
+            if (!isAdmin) {
+              e.preventDefault();
+              e.stopPropagation();
+              toast.error("Insufficient privileges, contact Admin");
+            }
+          }}
+        >
           <PiPlusCircleDuotone className="w-5 h-5" />
           Create Project
         </Button>

--- a/features/workspace/projects/ProjectCreateDialog.tsx
+++ b/features/workspace/projects/ProjectCreateDialog.tsx
@@ -158,21 +158,20 @@ export default function ProjectCreateDialog({
   }
 
   return (
-    <Dialog
-      open={open}
-      onOpenChange={(newOpen) => {
-        if (newOpen && !isAdmin) {
-          toast.error("Insufficient privileges, contact Admin");
-          return;
-        }
-        setOpen(newOpen);
-      }}
-    >
+    <Dialog open={open} onOpenChange={setOpen}>
       <DialogTrigger asChild>
         <Button
           variant="default"
           size="sm"
           className="flex items-center gap-2"
+          onClick={(e) => {
+            if (!isAdmin) {
+              e.preventDefault();
+              e.stopPropagation();
+              toast.error("Insufficient privileges, contact Admin");
+              return;
+            }
+          }}
         >
           <PiPlusCircleDuotone className="w-5 h-5" />
           Create Project

--- a/features/workspace/projects/ProjectCreateDialog.tsx
+++ b/features/workspace/projects/ProjectCreateDialog.tsx
@@ -158,19 +158,21 @@ export default function ProjectCreateDialog({
   }
 
   return (
-    <Dialog open={open} onOpenChange={setOpen}>
+    <Dialog
+      open={open}
+      onOpenChange={(newOpen) => {
+        if (newOpen && !isAdmin) {
+          toast.error("Insufficient privileges, contact Admin");
+          return;
+        }
+        setOpen(newOpen);
+      }}
+    >
       <DialogTrigger asChild>
         <Button
           variant="default"
           size="sm"
           className="flex items-center gap-2"
-          onClick={(e) => {
-            if (!isAdmin) {
-              e.preventDefault();
-              e.stopPropagation();
-              toast.error("Insufficient privileges, contact Admin");
-            }
-          }}
         >
           <PiPlusCircleDuotone className="w-5 h-5" />
           Create Project

--- a/features/workspace/projects/UpdateProjectDialog.tsx
+++ b/features/workspace/projects/UpdateProjectDialog.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { toast } from "sonner";
+import { useAuth } from "react-oidc-context";
 import { useEffect, useId, useState } from "react";
 import { useForm, SubmitHandler } from "react-hook-form";
 import { ImagePlusIcon, XIcon } from "lucide-react";
@@ -41,11 +43,6 @@ import {
 import { useGetAllDepartments } from "@/hooks/department/useGetAllDepartments";
 import { Department } from "@/types/department";
 import { uploadFiles } from "@/utils/uploadthing";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
 
 interface User {
   _id: string;
@@ -80,6 +77,8 @@ export default function UpdateProjectDialog({
   const [uploadingImage, setUploadingImage] = useState(false);
 
   const { mutate: updateProject, isPending } = useUpdateProject();
+  const auth = useAuth();
+  const isAdmin = auth.user?.profile?.userType === "admin";
 
   type FormValues = {
     project_name: string;
@@ -157,21 +156,21 @@ export default function UpdateProjectDialog({
   return (
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogTrigger>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <Button
-              variant="secondary"
-              size="sm"
-              className="flex items-center gap-2"
-            >
-              <PiPencilCircleDuotone className="w-4 h-4" />
-              Update
-            </Button>
-          </TooltipTrigger>
-          <TooltipContent>
-            <p>Update Project</p>
-          </TooltipContent>
-        </Tooltip>
+        <Button
+          variant="secondary"
+          size="sm"
+          className="flex items-center gap-2"
+          onClick={(e) => {
+            if (!isAdmin) {
+              e.preventDefault();
+              e.stopPropagation();
+              toast.error("Insufficient privileges, contact Admin");
+            }
+          }}
+        >
+          <PiPencilCircleDuotone className="w-4 h-4" />
+          Update
+        </Button>
       </DialogTrigger>
       <DialogContent className="flex flex-col gap-0 overflow-y-visible p-0 sm:max-w-xl [&>button:last-child]:top-3.5">
         <DialogHeader className="contents space-y-0 text-left">

--- a/features/workspace/projects/UpdateProjectDialog.tsx
+++ b/features/workspace/projects/UpdateProjectDialog.tsx
@@ -154,19 +154,21 @@ export default function UpdateProjectDialog({
   };
 
   return (
-    <Dialog open={open} onOpenChange={setOpen}>
+    <Dialog
+      open={open}
+      onOpenChange={(newOpen) => {
+        if (newOpen && !isAdmin) {
+          toast.error("Insufficient privileges, contact Admin");
+          return;
+        }
+        setOpen(newOpen);
+      }}
+    >
       <DialogTrigger>
         <Button
           variant="secondary"
           size="sm"
           className="flex items-center gap-2"
-          onClick={(e) => {
-            if (!isAdmin) {
-              e.preventDefault();
-              e.stopPropagation();
-              toast.error("Insufficient privileges, contact Admin");
-            }
-          }}
         >
           <PiPencilCircleDuotone className="w-4 h-4" />
           Update

--- a/features/workspace/projects/UpdateProjectDialog.tsx
+++ b/features/workspace/projects/UpdateProjectDialog.tsx
@@ -154,21 +154,20 @@ export default function UpdateProjectDialog({
   };
 
   return (
-    <Dialog
-      open={open}
-      onOpenChange={(newOpen) => {
-        if (newOpen && !isAdmin) {
-          toast.error("Insufficient privileges, contact Admin");
-          return;
-        }
-        setOpen(newOpen);
-      }}
-    >
+    <Dialog open={open} onOpenChange={setOpen}>
       <DialogTrigger>
         <Button
           variant="secondary"
           size="sm"
           className="flex items-center gap-2"
+          onClick={(e) => {
+            if (!isAdmin) {
+              e.preventDefault();
+              e.stopPropagation();
+              toast.error("Insufficient privileges, contact Admin");
+              return;
+            }
+          }}
         >
           <PiPencilCircleDuotone className="w-4 h-4" />
           Update

--- a/features/workspace/settings/InviteMembersDialog.tsx
+++ b/features/workspace/settings/InviteMembersDialog.tsx
@@ -82,19 +82,23 @@ export function InviteMembersDialog() {
     });
   }
 
+  const [open, setOpen] = useState(false);
+
   return (
-    <Dialog>
+    <Dialog
+      open={open}
+      onOpenChange={(newOpen) => {
+        if (newOpen && !isAdmin) {
+          toast.error("Insufficient privileges, contact Admin");
+          return;
+        }
+        setOpen(newOpen);
+      }}
+    >
       <DialogTrigger asChild>
         <Button
           size="sm"
           className="gap-2"
-          onClick={(e) => {
-            if (!isAdmin) {
-              e.preventDefault();
-              e.stopPropagation();
-              toast.error("Insufficient privileges, contact Admin");
-            }
-          }}
         >
           <PiUserPlusDuotone className="w-4 h-4" />
           Invite Members

--- a/features/workspace/settings/InviteMembersDialog.tsx
+++ b/features/workspace/settings/InviteMembersDialog.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useForm, useFieldArray, Controller } from "react-hook-form";
+import { useAuth } from "react-oidc-context";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -41,6 +42,9 @@ type InviteMembersFormValues = {
 };
 
 export function InviteMembersDialog() {
+  const auth = useAuth();
+  const isAdmin = auth.user?.profile?.userType === "admin";
+
   const { mutate: inviteMembersMutation, isPending } =
     useInviteWorkspaceMembers();
 
@@ -81,7 +85,17 @@ export function InviteMembersDialog() {
   return (
     <Dialog>
       <DialogTrigger asChild>
-        <Button size="sm" className="gap-2">
+        <Button
+          size="sm"
+          className="gap-2"
+          onClick={(e) => {
+            if (!isAdmin) {
+              e.preventDefault();
+              e.stopPropagation();
+              toast.error("Insufficient privileges, contact Admin");
+            }
+          }}
+        >
           <PiUserPlusDuotone className="w-4 h-4" />
           Invite Members
         </Button>

--- a/features/workspace/settings/InviteMembersDialog.tsx
+++ b/features/workspace/settings/InviteMembersDialog.tsx
@@ -82,23 +82,20 @@ export function InviteMembersDialog() {
     });
   }
 
-  const [open, setOpen] = useState(false);
-
   return (
-    <Dialog
-      open={open}
-      onOpenChange={(newOpen) => {
-        if (newOpen && !isAdmin) {
-          toast.error("Insufficient privileges, contact Admin");
-          return;
-        }
-        setOpen(newOpen);
-      }}
-    >
+    <Dialog>
       <DialogTrigger asChild>
         <Button
           size="sm"
           className="gap-2"
+          onClick={(e) => {
+            if (!isAdmin) {
+              e.preventDefault();
+              e.stopPropagation();
+              toast.error("Insufficient privileges, contact Admin");
+              return;
+            }
+          }}
         >
           <PiUserPlusDuotone className="w-4 h-4" />
           Invite Members


### PR DESCRIPTION
Restrict admin-only operations (create/edit/archive/restore/invite) to show toast error for non-admin users.

Changes:
- Add admin privilege checks to departments, projects, archive, and settings
- Show 'Insufficient privileges, contact Admin' toast on unauthorized access
- Add product name display in header