### PR TITLE
fix: add loading spinner icons to dialogs missing loading state

### DIFF
--- a/app/(app)/source-files/page.tsx
+++ b/app/(app)/source-files/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useAuth } from "react-oidc-context";
-import { BookmarkIcon, FolderIcon } from "lucide-react";
+import { PiBookmarkDuotone, PiFolderDuotone } from "react-icons/pi";
 import DialogAddProductFolder from "@/features/workspace/source-files/DialogAddProductFolder";
 import { useGetAllSourceFileFolders } from "@/hooks/source-files/useGetAllSourceFileFolders";
 import SourceFilesFoldersCard from "@/features/workspace/source-files/SourceFilesFoldersCard";

--- a/app/(app)/source-files/view/[...slug]/page.tsx
+++ b/app/(app)/source-files/view/[...slug]/page.tsx
@@ -19,7 +19,7 @@ import { useGetSourceFilesFolderById } from "@/hooks/source-files/useGetSourceFi
 import { useToggleBookmarkSourceFilesFolder } from "@/hooks/source-files/useToggleBookmarkSourceFilesFolder";
 import { cn } from "@/lib/utils";
 import type { SourceFilesFolder } from "@/types/source-files";
-import { BookmarkIcon, FolderIcon } from "lucide-react";
+import { PiBookmarkDuotone, PiFolderDuotone } from "react-icons/pi";
 import Image from "next/image";
 import { useParams, useRouter } from "next/navigation";
 import { useState } from "react";

--- a/app/(auth)/login/page.tsx
+++ b/app/(auth)/login/page.tsx
@@ -4,7 +4,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { cn } from "@/lib/utils";
-import { GalleryVerticalEnd } from "lucide-react";
+import { PiSquaresFourDuotone } from "react-icons/pi";
 import Image from "next/image";
 
 function LoginPage() {

--- a/app/(auth)/signup/page.tsx
+++ b/app/(auth)/signup/page.tsx
@@ -4,7 +4,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { cn } from "@/lib/utils";
-import { GalleryVerticalEnd } from "lucide-react";
+import { PiSquaresFourDuotone } from "react-icons/pi";
 import Image from "next/image";
 
 function SignupPage() {

--- a/app/onboarding/onboard-user/page.tsx
+++ b/app/onboarding/onboard-user/page.tsx
@@ -18,7 +18,7 @@ import { Input } from "@/components/ui/input";
 import { useOnboardUser } from "@/hooks/onboarding/useOnboardUser";
 import { useGetUser } from "@/hooks/user/useGetUser";
 import { uploadFiles } from "@/utils/uploadthing";
-import { ImagePlusIcon, XIcon } from "lucide-react";
+import { PiImageDuotone, PiXDuotone } from "react-icons/pi";
 import { useAuth } from "react-oidc-context";
 import { toast } from "sonner";
 

--- a/components/ui/accordion.tsx
+++ b/components/ui/accordion.tsx
@@ -2,9 +2,9 @@
 
 import * as React from "react";
 import * as AccordionPrimitive from "@radix-ui/react-accordion";
-import { ChevronDownIcon } from "lucide-react";
 
 import { cn } from "@/lib/utils";
+import { PiCaretDownDuotone } from "react-icons/pi";
 
 function Accordion({
   ...props
@@ -41,7 +41,7 @@ function AccordionTrigger({
         {...props}
       >
         {children}
-        <ChevronDownIcon className="text-muted-foreground pointer-events-none size-4 shrink-0 translate-y-0.5 transition-transform duration-200" />
+        <PiCaretDownDuotone className="text-muted-foreground pointer-events-none size-4 shrink-0 translate-y-0.5 transition-transform duration-200" />
       </AccordionPrimitive.Trigger>
     </AccordionPrimitive.Header>
   );

--- a/components/ui/breadcrumb.tsx
+++ b/components/ui/breadcrumb.tsx
@@ -1,8 +1,8 @@
 import * as React from "react";
 import { Slot } from "@radix-ui/react-slot";
-import { ChevronRight, MoreHorizontal } from "lucide-react";
 
 import { cn } from "@/lib/utils";
+import { PiCaretRightDuotone, PiDotsThreeDuotone } from "react-icons/pi";
 
 function Breadcrumb({ ...props }: React.ComponentProps<"nav">) {
   return <nav aria-label="breadcrumb" data-slot="breadcrumb" {...props} />;
@@ -75,7 +75,7 @@ function BreadcrumbSeparator({
       className={cn("[&>svg]:size-3.5", className)}
       {...props}
     >
-      {children ?? <ChevronRight />}
+      {children ?? <PiCaretRightDuotone />}
     </li>
   );
 }
@@ -92,7 +92,7 @@ function BreadcrumbEllipsis({
       className={cn("flex size-9 items-center justify-center", className)}
       {...props}
     >
-      <MoreHorizontal className="size-4" />
+      <PiDotsThreeDuotone className="size-4" />
       <span className="sr-only">More</span>
     </span>
   );

--- a/components/ui/calendar.tsx
+++ b/components/ui/calendar.tsx
@@ -1,11 +1,6 @@
 "use client";
 
 import * as React from "react";
-import {
-  ChevronDownIcon,
-  ChevronLeftIcon,
-  ChevronRightIcon,
-} from "lucide-react";
 import { DayButton, DayPicker, getDefaultClassNames } from "react-day-picker";
 
 import { cn } from "@/lib/utils";
@@ -14,6 +9,7 @@ import {
   PiCaretCircleDownDuotone,
   PiCaretCircleLeftDuotone,
   PiCaretCircleRightDuotone,
+  PiCaretDownDuotone,
 } from "react-icons/pi";
 
 function Calendar({

--- a/components/ui/command.tsx
+++ b/components/ui/command.tsx
@@ -3,10 +3,10 @@
 import * as React from "react"
 import { type DialogProps } from "@radix-ui/react-dialog"
 import { Command as CommandPrimitive } from "cmdk"
-import { Search } from "lucide-react"
 
 import { cn } from "@/lib/utils"
 import { Dialog, DialogContent } from "@/components/ui/dialog"
+import { PiMagnifyingGlassDuotone } from "react-icons/pi"
 
 const Command = React.forwardRef<
   React.ElementRef<typeof CommandPrimitive>,
@@ -40,7 +40,7 @@ const CommandInput = React.forwardRef<
   React.ComponentPropsWithoutRef<typeof CommandPrimitive.Input>
 >(({ className, ...props }, ref) => (
   <div className="flex items-center border-b px-3" cmdk-input-wrapper="">
-    <Search className="mr-2 h-4 w-4 shrink-0 opacity-50" />
+    <PiMagnifyingGlassDuotone className="mr-2 h-4 w-4 shrink-0 opacity-50" />
     <CommandPrimitive.Input
       ref={ref}
       className={cn(

--- a/components/ui/dialog.tsx
+++ b/components/ui/dialog.tsx
@@ -2,7 +2,6 @@
 
 import * as React from "react";
 import * as DialogPrimitive from "@radix-ui/react-dialog";
-import { X } from "lucide-react";
 
 import { cn } from "@/lib/utils";
 import { PiXCircleDuotone } from "react-icons/pi";

--- a/components/ui/dropdown-menu.tsx
+++ b/components/ui/dropdown-menu.tsx
@@ -2,10 +2,14 @@
 
 import * as React from "react";
 import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu";
-import { CheckIcon, ChevronRightIcon, CircleIcon } from "lucide-react";
 
 import { cn } from "@/lib/utils";
-import { PiCaretCircleDownDuotone, PiCheckCircleDuotone } from "react-icons/pi";
+import {
+  PiCaretCircleDownDuotone,
+  PiCaretRightDuotone,
+  PiCheckCircleDuotone,
+  PiCircleDuotone,
+} from "react-icons/pi";
 
 function DropdownMenu({
   ...props
@@ -136,7 +140,7 @@ function DropdownMenuRadioItem({
     >
       <span className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
         <DropdownMenuPrimitive.ItemIndicator>
-          <CircleIcon className="size-2 fill-current" />
+          <PiCircleDuotone className="size-2 fill-current" />
         </DropdownMenuPrimitive.ItemIndicator>
       </span>
       {children}
@@ -218,7 +222,7 @@ function DropdownMenuSubTrigger({
       {...props}
     >
       {children}
-      <PiCaretCircleDownDuotone className="ml-auto size-4" />
+      <PiCaretRightDuotone className="ml-auto size-4" />
     </DropdownMenuPrimitive.SubTrigger>
   );
 }

--- a/components/ui/navigation-menu.tsx
+++ b/components/ui/navigation-menu.tsx
@@ -1,9 +1,9 @@
 import * as React from "react";
 import * as NavigationMenuPrimitive from "@radix-ui/react-navigation-menu";
 import { cva } from "class-variance-authority";
-import { ChevronDownIcon } from "lucide-react";
 
 import { cn } from "@/lib/utils";
+import { PiCaretDownDuotone } from "react-icons/pi";
 
 function NavigationMenu({
   className,
@@ -74,7 +74,7 @@ function NavigationMenuTrigger({
       {...props}
     >
       {children}{" "}
-      <ChevronDownIcon
+      <PiCaretDownDuotone
         className="relative top-px ml-1 size-3 transition duration-300 group-data-[state=open]:rotate-180"
         aria-hidden="true"
       />

--- a/components/ui/pagination.tsx
+++ b/components/ui/pagination.tsx
@@ -1,9 +1,9 @@
 import * as React from "react"
 import {
-  ChevronLeftIcon,
-  ChevronRightIcon,
-  MoreHorizontalIcon,
-} from "lucide-react"
+  PiCaretLeftDuotone,
+  PiCaretRightDuotone,
+  PiDotsThreeDuotone,
+} from "react-icons/pi"
 
 import { cn } from "@/lib/utils"
 import { Button, buttonVariants } from "@/components/ui/button"

--- a/components/ui/select.tsx
+++ b/components/ui/select.tsx
@@ -2,10 +2,14 @@
 
 import * as React from "react";
 import * as SelectPrimitive from "@radix-ui/react-select";
-import { CheckIcon, ChevronDownIcon, ChevronUpIcon } from "lucide-react";
 
 import { cn } from "@/lib/utils";
-import { PiCaretCircleDownDuotone, PiCheckCircleDuotone } from "react-icons/pi";
+import {
+  PiCaretCircleDownDuotone,
+  PiCaretUpDuotone,
+  PiCaretDownDuotone,
+  PiCheckCircleDuotone,
+} from "react-icons/pi";
 
 function Select({
   ...props
@@ -150,7 +154,7 @@ function SelectScrollUpButton({
       )}
       {...props}
     >
-      <ChevronUpIcon size={16} />
+      <PiCaretUpDuotone size={16} />
     </SelectPrimitive.ScrollUpButton>
   );
 }
@@ -168,7 +172,7 @@ function SelectScrollDownButton({
       )}
       {...props}
     >
-      <ChevronDownIcon size={16} />
+      <PiCaretDownDuotone size={16} />
     </SelectPrimitive.ScrollDownButton>
   );
 }

--- a/components/ui/sheet.tsx
+++ b/components/ui/sheet.tsx
@@ -2,9 +2,9 @@
 
 import * as React from "react"
 import * as SheetPrimitive from "@radix-ui/react-dialog"
-import { XIcon } from "lucide-react"
 
 import { cn } from "@/lib/utils"
+import { PiXDuotone } from "react-icons/pi"
 
 function Sheet({ ...props }: React.ComponentProps<typeof SheetPrimitive.Root>) {
   return <SheetPrimitive.Root data-slot="sheet" {...props} />
@@ -73,7 +73,7 @@ function SheetContent({
       >
         {children}
         <SheetPrimitive.Close className="ring-offset-background focus:ring-ring data-[state=open]:bg-secondary absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none">
-          <XIcon className="size-4" />
+          <PiXDuotone className="size-4" />
           <span className="sr-only">Close</span>
         </SheetPrimitive.Close>
       </SheetPrimitive.Content>

--- a/components/ui/tag-input.tsx
+++ b/components/ui/tag-input.tsx
@@ -2,12 +2,12 @@
 
 import * as React from "react";
 import { useId, useState } from "react";
-import { XIcon } from "lucide-react";
 
 import { cn } from "@/lib/utils";
 import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { PiXDuotone } from "react-icons/pi";
 
 interface Tag {
   id: string;
@@ -111,7 +111,7 @@ const TagInput = React.forwardRef<HTMLInputElement, TagInputProps>(
                 onClick={() => removeTag(tag.id)}
                 disabled={disabled}
               >
-                <XIcon className="h-3 w-3" />
+                <PiXDuotone className="h-3 w-3" />
               </button>
             </Badge>
           ))}

--- a/features/marketing/marketing-header.tsx
+++ b/features/marketing/marketing-header.tsx
@@ -2,7 +2,7 @@
 
 import * as React from "react";
 import Link from "next/link";
-import { CircleCheckIcon, CircleHelpIcon, CircleIcon } from "lucide-react";
+import { PiCheckCircleDuotone, PiQuestionCircleDuotone, PiCircleDuotone } from "react-icons/pi";
 import { cn } from "@/lib/utils";
 
 import { useIsMobile } from "@/hooks/general/use-mobile";

--- a/features/workspace/archive/DialogArchiveEntity.tsx
+++ b/features/workspace/archive/DialogArchiveEntity.tsx
@@ -3,7 +3,7 @@
 import { toast } from "sonner";
 import { useAuth } from "react-oidc-context";
 import { useId, useMemo, useState } from "react";
-import { CircleAlert as CircleAlertIcon } from "lucide-react";
+import { PiArchiveDuotone, PiAlertCircleDuotone } from "react-icons/pi";
 
 import { Button } from "@/components/ui/button";
 import {
@@ -20,7 +20,6 @@ import { Label } from "@/components/ui/label";
 import Link from "next/link";
 import { useArchiveDepartment } from "@/hooks/department/useArchiveDepartment";
 import { useArchiveProject } from "@/hooks/project/useArchiveProject";
-import { PiArchiveDuotone } from "react-icons/pi";
 import { Spinner } from "@/components/ui/spinner";
 
 export type ArchiveEntityType = "project" | "department";
@@ -96,7 +95,7 @@ export default function DialogArchiveEntity({
             className="flex size-9 shrink-0 items-center justify-center rounded-full border"
             aria-hidden="true"
           >
-            <CircleAlertIcon className="opacity-80" size={16} />
+            <PiAlertCircleDuotone className="opacity-80" size={16} />
           </div>
           <DialogHeader>
             <DialogTitle className="sm:text-center">

--- a/features/workspace/bookmarks/DialogAddProductsToFolder.tsx
+++ b/features/workspace/bookmarks/DialogAddProductsToFolder.tsx
@@ -6,8 +6,9 @@ import {
   PiFolderDuotone,
   PiPackageDuotone,
   PiXCircleDuotone,
+  PiCheckDuotone,
+  PiCaretUpDownDuotone,
 } from "react-icons/pi";
-import { Check, ChevronsUpDown } from "lucide-react";
 
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
@@ -175,7 +176,7 @@ export default function DialogAddProductsToFolder({
                             product._id === selectedProductId
                         )?.product_name || "Unnamed Product"
                       : "Choose a product..."}
-                    <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+                    <PiCaretUpDownDuotone className="ml-2 h-4 w-4 shrink-0 opacity-50" />
                   </Button>
                 </PopoverTrigger>
                 <PopoverContent className="w-[--radix-popover-trigger-width] p-0">
@@ -227,7 +228,7 @@ export default function DialogAddProductsToFolder({
                                     {product.status}
                                   </span>
                                 )}
-                                <Check
+                                <PiCheckDuotone
                                   className={cn(
                                     "ml-2 h-4 w-4",
                                     selectedProductId === product._id

--- a/features/workspace/dashboard/DepartmentsCard.tsx
+++ b/features/workspace/dashboard/DepartmentsCard.tsx
@@ -1,4 +1,4 @@
-import { CalendarClock, Text } from "lucide-react";
+import { PiCalendarClockDuotone, PiTextTDuotone } from "react-icons/pi";
 import Image from "next/image";
 import Link from "next/link";
 import { PiBuildingsDuotone } from "react-icons/pi";

--- a/features/workspace/departments/AddUsersInDepartmentDropdown.tsx
+++ b/features/workspace/departments/AddUsersInDepartmentDropdown.tsx
@@ -9,8 +9,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { PiPlusBold, PiUserCirclePlusDuotone } from "react-icons/pi";
-import { X } from "lucide-react";
+import { PiPlusBold, PiUserCirclePlusDuotone, PiXDuotone } from "react-icons/pi";
 import Image from "next/image";
 
 interface User {
@@ -82,7 +81,7 @@ export default function AddUsersInDepartmentDropdown({
                 {user.name}
               </div>
               {isSelected && (
-                <X className="size-4 text-muted-foreground hover:text-destructive" />
+                <PiXDuotone className="size-4 text-muted-foreground hover:text-destructive" />
               )}
             </DropdownMenuItem>
           );

--- a/features/workspace/departments/CreateDepartmentDialog.tsx
+++ b/features/workspace/departments/CreateDepartmentDialog.tsx
@@ -3,7 +3,6 @@
 import { toast } from "sonner";
 import { useId, useState } from "react";
 import { useForm } from "react-hook-form";
-import { ImagePlusIcon, XIcon } from "lucide-react";
 import { useAuth } from "react-oidc-context";
 import { useFileUpload } from "@/hooks/general/use-file-upload";
 import { Button } from "@/components/ui/button";
@@ -24,6 +23,8 @@ import {
   PiBuildingsDuotone,
   PiPlusCircleDuotone,
   PiXCircleDuotone,
+  PiXDuotone,
+  PiImageDuotone,
 } from "react-icons/pi";
 import { Spinner } from "@/components/ui/spinner";
 import Image from "next/image";

--- a/features/workspace/departments/ShareDepartmentDialog.tsx
+++ b/features/workspace/departments/ShareDepartmentDialog.tsx
@@ -1,5 +1,4 @@
-import { LinkIcon, CopyIcon, CheckIcon } from "lucide-react";
-import { PiShareNetworkDuotone, PiXCircleDuotone } from "react-icons/pi";
+import { PiShareNetworkDuotone, PiXCircleDuotone, PiLinkDuotone, PiCopyDuotone, PiCheckDuotone } from "react-icons/pi";
 import { useState, useMemo } from "react";
 
 import {

--- a/features/workspace/departments/UpdateDepartmentDialog.tsx
+++ b/features/workspace/departments/UpdateDepartmentDialog.tsx
@@ -4,7 +4,6 @@ import { toast } from "sonner";
 import { useAuth } from "react-oidc-context";
 import { useId, useState, useEffect } from "react";
 import { useForm, SubmitHandler } from "react-hook-form";
-import { ImagePlusIcon, XIcon } from "lucide-react";
 import { useFileUpload } from "@/hooks/general/use-file-upload";
 import { Button } from "@/components/ui/button";
 import {
@@ -24,7 +23,9 @@ import {
   PiBuildingsDuotone,
   PiPencilCircleDuotone,
   PiXCircleDuotone,
+  PiXDuotone,
   PiCheckCircleDuotone,
+  PiImageDuotone,
 } from "react-icons/pi";
 import { Spinner } from "@/components/ui/spinner";
 import Image from "next/image";

--- a/features/workspace/products/DialogShareProduct.tsx
+++ b/features/workspace/products/DialogShareProduct.tsx
@@ -1,5 +1,4 @@
-import { LinkIcon, CopyIcon, CheckIcon } from "lucide-react";
-import { PiShareNetworkDuotone, PiXCircleDuotone } from "react-icons/pi";
+import { PiShareNetworkDuotone, PiXCircleDuotone, PiLinkDuotone, PiCopyDuotone, PiCheckDuotone } from "react-icons/pi";
 import { useState, useMemo } from "react";
 
 import {

--- a/features/workspace/products/ProductsPageProductTable.tsx
+++ b/features/workspace/products/ProductsPageProductTable.tsx
@@ -15,16 +15,6 @@ import {
   useReactTable,
   VisibilityState,
 } from "@tanstack/react-table";
-import {
-  ChevronDownIcon,
-  ChevronFirstIcon,
-  ChevronLastIcon,
-  ChevronLeftIcon,
-  ChevronRightIcon,
-  ChevronUpIcon,
-  Columns3Icon,
-  EllipsisIcon,
-} from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useId, useState } from "react";
 import {
@@ -36,9 +26,12 @@ import {
   PiCaretDownDuotone,
   PiCaretUpDownDuotone,
   PiCaretUpDuotone,
+  PiCaretLeftDuotone,
+  PiCaretRightDuotone,
   PiChartPieSliceDuotone,
   PiColumnsDuotone,
   PiDotsThreeCircleVerticalDuotone,
+  PiDotsThreeDuotone,
   PiDownloadDuotone,
   PiFilePdfDuotone,
   PiFileXlsDuotone,

--- a/features/workspace/products/product/component-details/AddComponentDialog.tsx
+++ b/features/workspace/products/product/component-details/AddComponentDialog.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useId, useState } from "react";
-import { ImagePlusIcon, XIcon } from "lucide-react";
 import { useForm, Controller } from "react-hook-form";
 import {
   useFileUpload,
@@ -35,8 +34,10 @@ import { uploadFiles } from "@/utils/uploadthing";
 import {
   PiPlusCircleDuotone,
   PiXCircleDuotone,
+  PiXDuotone,
   PiCubeDuotone,
   PiPictureInPictureDuotone,
+  PiImageDuotone,
 } from "react-icons/pi";
 import { Spinner } from "@/components/ui/spinner";
 

--- a/features/workspace/products/product/component-details/EditComponentDialog.tsx
+++ b/features/workspace/products/product/component-details/EditComponentDialog.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useId, useState, useEffect } from "react";
-import { ImagePlusIcon, XIcon } from "lucide-react";
 import { useForm, Controller } from "react-hook-form";
 import {
   useFileUpload,
@@ -34,9 +33,11 @@ import { uploadFiles } from "@/utils/uploadthing";
 import {
   PiPencilSimpleDuotone,
   PiXCircleDuotone,
+  PiXDuotone,
   PiCheckCircleDuotone,
   PiCubeDuotone,
   PiPictureInPictureDuotone,
+  PiImageDuotone,
 } from "react-icons/pi";
 import { Spinner } from "@/components/ui/spinner";
 

--- a/features/workspace/products/product/component-details/ProductComponentDetailsTable.tsx
+++ b/features/workspace/products/product/component-details/ProductComponentDetailsTable.tsx
@@ -12,17 +12,17 @@ import {
   SortingState,
   useReactTable,
 } from "@tanstack/react-table";
-import {
-  ChevronDownIcon,
-  ChevronRightIcon,
-  EllipsisIcon,
-  LayoutList,
-} from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Fragment, useId, useState } from "react";
 import { usePathname } from "next/navigation";
 
 import { Button } from "@/components/ui/button";
+import {
+  PiCaretDownDuotone,
+  PiCaretRightDuotone,
+  PiDotsThreeDuotone,
+  PiListDuotone,
+} from "react-icons/pi";
 import {
   DropdownMenu,
   DropdownMenuContent,

--- a/features/workspace/products/product/graphics-other-components/AddBarcodesDialog.tsx
+++ b/features/workspace/products/product/graphics-other-components/AddBarcodesDialog.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useId, useState } from "react";
-import { ImagePlusIcon, XIcon } from "lucide-react";
 import { useForm, Controller } from "react-hook-form";
 import {
   useFileUpload,
@@ -28,9 +27,11 @@ import { uploadFiles } from "@/utils/uploadthing";
 import {
   PiPlusCircleDuotone,
   PiXCircleDuotone,
+  PiXDuotone,
   PiPictureInPictureDuotone,
-  PiCaretUpDown,
-  PiCheck,
+  PiImageDuotone,
+  PiCaretUpDownDuotone,
+  PiCheckDuotone,
 } from "react-icons/pi";
 import { BARCODE_STANDARDS } from "@/data/barcode-standards";
 import {
@@ -406,7 +407,7 @@ function ComponentImage({ value, onChange }: ComponentImageProps) {
             onClick={openFileDialog}
             aria-label={currentImage ? "Change image" : "Upload image"}
           >
-            <ImagePlusIcon size={16} aria-hidden="true" />
+            <PiImageDuotone size={16} aria-hidden="true" />
           </button>
           {currentImage && (
             <button
@@ -421,7 +422,7 @@ function ComponentImage({ value, onChange }: ComponentImageProps) {
               }}
               aria-label="Remove image"
             >
-              <XIcon size={16} aria-hidden="true" />
+              <PiXDuotone size={16} aria-hidden="true" />
             </button>
           )}
         </div>

--- a/features/workspace/products/product/graphics-other-components/AddOtherCompsDialog.tsx
+++ b/features/workspace/products/product/graphics-other-components/AddOtherCompsDialog.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useId, useState } from "react";
-import { ImagePlusIcon, XIcon } from "lucide-react";
 import { useForm, Controller } from "react-hook-form";
 import {
   useFileUpload,
@@ -28,7 +27,9 @@ import { uploadFiles } from "@/utils/uploadthing";
 import {
   PiPlusCircleDuotone,
   PiXCircleDuotone,
+  PiXDuotone,
   PiPictureInPictureDuotone,
+  PiImageDuotone,
 } from "react-icons/pi";
 
 type FormData = {
@@ -290,7 +291,7 @@ function ComponentImage({ value, onChange }: ComponentImageProps) {
             onClick={openFileDialog}
             aria-label={currentImage ? "Change image" : "Upload image"}
           >
-            <ImagePlusIcon size={16} aria-hidden="true" />
+            <PiImageDuotone size={16} aria-hidden="true" />
           </button>
           {currentImage && (
             <button
@@ -305,7 +306,7 @@ function ComponentImage({ value, onChange }: ComponentImageProps) {
               }}
               aria-label="Remove image"
             >
-              <XIcon size={16} aria-hidden="true" />
+              <PiXDuotone size={16} aria-hidden="true" />
             </button>
           )}
         </div>

--- a/features/workspace/products/product/graphics-other-components/AddSchematicsDialog.tsx
+++ b/features/workspace/products/product/graphics-other-components/AddSchematicsDialog.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useId, useState } from "react";
-import { ImagePlusIcon, XIcon } from "lucide-react";
 import { useForm, Controller } from "react-hook-form";
 import {
   useFileUpload,
@@ -28,7 +27,9 @@ import { uploadFiles } from "@/utils/uploadthing";
 import {
   PiPlusCircleDuotone,
   PiXCircleDuotone,
+  PiXDuotone,
   PiPictureInPictureDuotone,
+  PiImageDuotone,
 } from "react-icons/pi";
 import { Spinner } from "@/components/ui/spinner";
 
@@ -297,7 +298,7 @@ function ComponentImage({ value, onChange }: ComponentImageProps) {
             onClick={openFileDialog}
             aria-label={currentImage ? "Change image" : "Upload image"}
           >
-            <ImagePlusIcon size={16} aria-hidden="true" />
+            <PiImageDuotone size={16} aria-hidden="true" />
           </button>
           {currentImage && (
             <button
@@ -312,7 +313,7 @@ function ComponentImage({ value, onChange }: ComponentImageProps) {
               }}
               aria-label="Remove image"
             >
-              <XIcon size={16} aria-hidden="true" />
+              <PiXDuotone size={16} aria-hidden="true" />
             </button>
           )}
         </div>

--- a/features/workspace/products/product/graphics-other-components/AddSchematicsDialog.tsx
+++ b/features/workspace/products/product/graphics-other-components/AddSchematicsDialog.tsx
@@ -30,6 +30,7 @@ import {
   PiXCircleDuotone,
   PiPictureInPictureDuotone,
 } from "react-icons/pi";
+import { Spinner } from "@/components/ui/spinner";
 
 type FormData = {
   componentName: string;
@@ -227,10 +228,14 @@ export default function AddSchematicsDialog({
             type="button"
             size="sm"
             onClick={handleSubmit(onSubmit)}
-            disabled={isPending}
+            disabled={isPending || uploadingImage}
             variant="default"
           >
-            <PiPlusCircleDuotone />
+            {isPending || uploadingImage ? (
+              <Spinner />
+            ) : (
+              <PiPlusCircleDuotone />
+            )}
             {isPending
               ? "Adding..."
               : uploadingImage

--- a/features/workspace/products/product/graphics-other-components/AddSymbolsDialog.tsx
+++ b/features/workspace/products/product/graphics-other-components/AddSymbolsDialog.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useId, useState } from "react";
-import { ImagePlusIcon, XIcon } from "lucide-react";
 import { useForm, Controller } from "react-hook-form";
 import {
   useFileUpload,
@@ -28,7 +27,9 @@ import { uploadFiles } from "@/utils/uploadthing";
 import {
   PiPlusCircleDuotone,
   PiXCircleDuotone,
+  PiXDuotone,
   PiPictureInPictureDuotone,
+  PiImageDuotone,
 } from "react-icons/pi";
 
 type FormData = {
@@ -314,7 +315,7 @@ function ComponentImage({ value, onChange }: ComponentImageProps) {
             onClick={openFileDialog}
             aria-label={currentImage ? "Change image" : "Upload image"}
           >
-            <ImagePlusIcon size={16} aria-hidden="true" />
+            <PiImageDuotone size={16} aria-hidden="true" />
           </button>
           {currentImage && (
             <button
@@ -329,7 +330,7 @@ function ComponentImage({ value, onChange }: ComponentImageProps) {
               }}
               aria-label="Remove image"
             >
-              <XIcon size={16} aria-hidden="true" />
+              <PiXDuotone size={16} aria-hidden="true" />
             </button>
           )}
         </div>

--- a/features/workspace/products/product/graphics-other-components/EditBarcodesDialog.tsx
+++ b/features/workspace/products/product/graphics-other-components/EditBarcodesDialog.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useId, useState, useEffect } from "react";
-import { ImagePlusIcon, XIcon } from "lucide-react";
 import { useForm, Controller } from "react-hook-form";
 import {
   useFileUpload,
@@ -27,10 +26,12 @@ import { uploadFiles } from "@/utils/uploadthing";
 import {
   PiPencilSimpleDuotone,
   PiXCircleDuotone,
+  PiXDuotone,
   PiCheckCircleDuotone,
   PiPictureInPictureDuotone,
-  PiCaretUpDown,
-  PiCheck,
+  PiImageDuotone,
+  PiCaretUpDownDuotone,
+  PiCheckDuotone,
 } from "react-icons/pi";
 import { BARCODE_STANDARDS } from "@/data/barcode-standards";
 import {
@@ -465,7 +466,7 @@ function ComponentImage({
             onClick={openFileDialog}
             aria-label={displayImage ? "Change image" : "Upload image"}
           >
-            <ImagePlusIcon size={16} aria-hidden="true" />
+            <PiImageDuotone size={16} aria-hidden="true" />
           </button>
           {displayImage && (
             <button
@@ -483,7 +484,7 @@ function ComponentImage({
               }}
               aria-label="Remove image"
             >
-              <XIcon size={16} aria-hidden="true" />
+              <PiXDuotone size={16} aria-hidden="true" />
             </button>
           )}
         </div>

--- a/features/workspace/products/product/graphics-other-components/EditOtherComponentsDialog.tsx
+++ b/features/workspace/products/product/graphics-other-components/EditOtherComponentsDialog.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useId, useState, useEffect } from "react";
-import { ImagePlusIcon, XIcon } from "lucide-react";
 import { useForm, Controller } from "react-hook-form";
 import {
   useFileUpload,
@@ -27,8 +26,10 @@ import { uploadFiles } from "@/utils/uploadthing";
 import {
   PiPencilSimpleDuotone,
   PiXCircleDuotone,
+  PiXDuotone,
   PiCheckCircleDuotone,
   PiPictureInPictureDuotone,
+  PiImageDuotone,
 } from "react-icons/pi";
 
 type Item = {
@@ -345,7 +346,7 @@ function ComponentImage({
             onClick={openFileDialog}
             aria-label={displayImage ? "Change image" : "Upload image"}
           >
-            <ImagePlusIcon size={16} aria-hidden="true" />
+            <PiImageDuotone size={16} aria-hidden="true" />
           </button>
           {displayImage && (
             <button
@@ -363,7 +364,7 @@ function ComponentImage({
               }}
               aria-label="Remove image"
             >
-              <XIcon size={16} aria-hidden="true" />
+              <PiXDuotone size={16} aria-hidden="true" />
             </button>
           )}
         </div>

--- a/features/workspace/products/product/graphics-other-components/EditSchematicsDialog.tsx
+++ b/features/workspace/products/product/graphics-other-components/EditSchematicsDialog.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useId, useState, useEffect } from "react";
-import { ImagePlusIcon, XIcon } from "lucide-react";
 import { useForm, Controller } from "react-hook-form";
 import {
   useFileUpload,
@@ -27,8 +26,10 @@ import { uploadFiles } from "@/utils/uploadthing";
 import {
   PiPencilSimpleDuotone,
   PiXCircleDuotone,
+  PiXDuotone,
   PiCheckCircleDuotone,
   PiPictureInPictureDuotone,
+  PiImageDuotone,
 } from "react-icons/pi";
 
 type Item = {
@@ -344,7 +345,7 @@ function ComponentImage({
             onClick={openFileDialog}
             aria-label={displayImage ? "Change image" : "Upload image"}
           >
-            <ImagePlusIcon size={16} aria-hidden="true" />
+            <PiImageDuotone size={16} aria-hidden="true" />
           </button>
           {displayImage && (
             <button
@@ -362,7 +363,7 @@ function ComponentImage({
               }}
               aria-label="Remove image"
             >
-              <XIcon size={16} aria-hidden="true" />
+              <PiXDuotone size={16} aria-hidden="true" />
             </button>
           )}
         </div>

--- a/features/workspace/products/product/graphics-other-components/EditSymbolsDialog.tsx
+++ b/features/workspace/products/product/graphics-other-components/EditSymbolsDialog.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useId, useState, useEffect } from "react";
-import { ImagePlusIcon, XIcon } from "lucide-react";
 import { useForm, Controller } from "react-hook-form";
 import {
   useFileUpload,
@@ -27,8 +26,10 @@ import { uploadFiles } from "@/utils/uploadthing";
 import {
   PiPencilSimpleDuotone,
   PiXCircleDuotone,
+  PiXDuotone,
   PiCheckCircleDuotone,
   PiPictureInPictureDuotone,
+  PiImageDuotone,
 } from "react-icons/pi";
 
 type Item = {
@@ -364,7 +365,7 @@ function ComponentImage({
             onClick={openFileDialog}
             aria-label={displayImage ? "Change image" : "Upload image"}
           >
-            <ImagePlusIcon size={16} aria-hidden="true" />
+            <PiImageDuotone size={16} aria-hidden="true" />
           </button>
           {displayImage && (
             <button
@@ -382,7 +383,7 @@ function ComponentImage({
               }}
               aria-label="Remove image"
             >
-              <XIcon size={16} aria-hidden="true" />
+              <PiXDuotone size={16} aria-hidden="true" />
             </button>
           )}
         </div>

--- a/features/workspace/products/product/graphics-other-components/GraphicsAndOtherCompsTabs.tsx
+++ b/features/workspace/products/product/graphics-other-components/GraphicsAndOtherCompsTabs.tsx
@@ -1,4 +1,8 @@
-import { BoxIcon, HouseIcon, PanelsTopLeftIcon } from "lucide-react"
+import {
+  PiHouseDuotone,
+  PiSquaresFourDuotone,
+  PiBoxDuotone,
+} from "react-icons/pi"
 
 import { ScrollArea, ScrollBar } from "@/components/ui/scroll-area"
 import {
@@ -17,7 +21,7 @@ export default function Component() {
             value="tab-1"
             className="data-[state=active]:bg-muted data-[state=active]:after:bg-primary relative overflow-hidden rounded-none border py-2 after:pointer-events-none after:absolute after:inset-x-0 after:bottom-0 after:h-0.5 first:rounded-s last:rounded-e"
           >
-            <HouseIcon
+            <PiHouseDuotone
               className="-ms-0.5 me-1.5 opacity-60"
               size={16}
               aria-hidden="true"
@@ -28,7 +32,7 @@ export default function Component() {
             value="tab-2"
             className="data-[state=active]:bg-muted data-[state=active]:after:bg-primary relative overflow-hidden rounded-none border py-2 after:pointer-events-none after:absolute after:inset-x-0 after:bottom-0 after:h-0.5 first:rounded-s last:rounded-e"
           >
-            <PanelsTopLeftIcon
+            <PiSquaresFourDuotone
               className="-ms-0.5 me-1.5 opacity-60"
               size={16}
               aria-hidden="true"
@@ -39,7 +43,7 @@ export default function Component() {
             value="tab-3"
             className="data-[state=active]:bg-muted data-[state=active]:after:bg-primary relative overflow-hidden rounded-none border py-2 after:pointer-events-none after:absolute after:inset-x-0 after:bottom-0 after:h-0.5 first:rounded-s last:rounded-e"
           >
-            <BoxIcon
+            <PiBoxDuotone
               className="-ms-0.5 me-1.5 opacity-60"
               size={16}
               aria-hidden="true"

--- a/features/workspace/products/product/label-tags/DialogAddLabelTag.tsx
+++ b/features/workspace/products/product/label-tags/DialogAddLabelTag.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useId, useState } from "react";
-import { ImagePlusIcon, XIcon } from "lucide-react";
 import { useForm, Controller } from "react-hook-form";
 import {
   useFileUpload,
@@ -27,8 +26,10 @@ import { useUpdateProductTabData } from "@/hooks/product/useUpdateProductTabData
 import {
   PiPlusCircleDuotone,
   PiXCircleDuotone,
+  PiXDuotone,
   PiTagDuotone,
   PiPictureInPictureDuotone,
+  PiImageDuotone,
 } from "react-icons/pi";
 import { Spinner } from "@/components/ui/spinner";
 
@@ -296,7 +297,7 @@ function ComponentImage({ value, onChange }: ComponentImageProps) {
             onClick={openFileDialog}
             aria-label={currentImage ? "Change image" : "Upload image"}
           >
-            <ImagePlusIcon size={16} aria-hidden="true" />
+            <PiImageDuotone size={16} aria-hidden="true" />
           </button>
           {currentImage && (
             <button
@@ -311,7 +312,7 @@ function ComponentImage({ value, onChange }: ComponentImageProps) {
               }}
               aria-label="Remove image"
             >
-              <XIcon size={16} aria-hidden="true" />
+              <PiXDuotone size={16} aria-hidden="true" />
             </button>
           )}
         </div>

--- a/features/workspace/products/product/label-tags/DialogAddLabelTag.tsx
+++ b/features/workspace/products/product/label-tags/DialogAddLabelTag.tsx
@@ -30,6 +30,7 @@ import {
   PiTagDuotone,
   PiPictureInPictureDuotone,
 } from "react-icons/pi";
+import { Spinner } from "@/components/ui/spinner";
 
 type FormData = {
   name: string;
@@ -228,7 +229,11 @@ export default function DialogAddLabelTag({
             disabled={uploadingImage || isPending}
             aria-busy={uploadingImage || isPending}
           >
-            <PiPlusCircleDuotone />
+            {uploadingImage || isPending ? (
+              <Spinner />
+            ) : (
+              <PiPlusCircleDuotone />
+            )}
             {uploadingImage
               ? "Uploading..."
               : isPending

--- a/features/workspace/products/product/label-tags/DialogDeleteLabelTag.tsx
+++ b/features/workspace/products/product/label-tags/DialogDeleteLabelTag.tsx
@@ -12,6 +12,7 @@ import {
   AlertDialogTrigger,
 } from "@/components/ui/alert-dialog";
 import { PiTrashDuotone, PiXCircleDuotone } from "react-icons/pi";
+import { Spinner } from "@/components/ui/spinner";
 import { useUpdateProductTabData } from "@/hooks/product/useUpdateProductTabData";
 
 interface LabelTagItem {
@@ -114,7 +115,7 @@ export default function DialogDeleteLabelTag({
             variant="destructive"
             size="sm"
           >
-            <PiTrashDuotone />
+            {isPending ? <Spinner /> : <PiTrashDuotone />}
             {isPending ? "Deleting..." : "Delete Label"}
           </Button>
         </AlertDialogFooter>

--- a/features/workspace/products/product/label-tags/DialogEditLabelTag.tsx
+++ b/features/workspace/products/product/label-tags/DialogEditLabelTag.tsx
@@ -30,6 +30,7 @@ import {
   PiFloppyDiskDuotone,
   PiPictureInPictureDuotone,
 } from "react-icons/pi";
+import { Spinner } from "@/components/ui/spinner";
 
 type FormData = {
   name: string;
@@ -238,7 +239,11 @@ export default function DialogEditLabelTag({
             disabled={uploadingImage || isPending}
             aria-busy={uploadingImage || isPending}
           >
-            <PiFloppyDiskDuotone />
+            {uploadingImage || isPending ? (
+              <Spinner />
+            ) : (
+              <PiFloppyDiskDuotone />
+            )}
             {uploadingImage
               ? "Uploading..."
               : isPending

--- a/features/workspace/products/product/label-tags/DialogEditLabelTag.tsx
+++ b/features/workspace/products/product/label-tags/DialogEditLabelTag.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useId, useState } from "react";
-import { ImagePlusIcon, XIcon } from "lucide-react";
 import { useForm, Controller } from "react-hook-form";
 import {
   useFileUpload,
@@ -27,8 +26,10 @@ import { useUpdateProductTabData } from "@/hooks/product/useUpdateProductTabData
 import {
   PiPencilSimpleDuotone,
   PiXCircleDuotone,
+  PiXDuotone,
   PiFloppyDiskDuotone,
   PiPictureInPictureDuotone,
+  PiImageDuotone,
 } from "react-icons/pi";
 import { Spinner } from "@/components/ui/spinner";
 
@@ -310,7 +311,7 @@ function ComponentImage({ value, onChange }: ComponentImageProps) {
             onClick={openFileDialog}
             aria-label={currentImage ? "Change image" : "Upload image"}
           >
-            <ImagePlusIcon size={16} aria-hidden="true" />
+            <PiImageDuotone size={16} aria-hidden="true" />
           </button>
           {currentImage && (
             <button
@@ -327,7 +328,7 @@ function ComponentImage({ value, onChange }: ComponentImageProps) {
               }}
               aria-label="Remove image"
             >
-              <XIcon size={16} aria-hidden="true" />
+              <PiXDuotone size={16} aria-hidden="true" />
             </button>
           )}
         </div>

--- a/features/workspace/projects/AddUsersInProjectDropdown.tsx
+++ b/features/workspace/projects/AddUsersInProjectDropdown.tsx
@@ -9,8 +9,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { PiUserCirclePlusDuotone } from "react-icons/pi";
-import { X } from "lucide-react";
+import { PiUserCirclePlusDuotone, PiXDuotone } from "react-icons/pi";
 import Image from "next/image";
 
 interface User {
@@ -82,7 +81,7 @@ export default function AddUsersInProjectDropdown({
                 {user.name}
               </div>
               {isSelected && (
-                <X className="size-4 text-muted-foreground hover:text-destructive" />
+                <PiXDuotone className="size-4 text-muted-foreground hover:text-destructive" />
               )}
             </DropdownMenuItem>
           );

--- a/features/workspace/projects/ProjectCreateDialog.tsx
+++ b/features/workspace/projects/ProjectCreateDialog.tsx
@@ -29,7 +29,6 @@ import { useCreateProject } from "@/hooks/project/useCreateProject";
 import { useGetAllUsersByWorkspace } from "@/hooks/user/useGetAllUsersByWorkspace";
 import { Department } from "@/types/department";
 import { uploadFiles } from "@/utils/uploadthing";
-import { ImagePlusIcon, XIcon } from "lucide-react";
 import Image from "next/image";
 import { useId, useState } from "react";
 import { useForm } from "react-hook-form";
@@ -38,6 +37,8 @@ import {
   PiKanbanDuotone,
   PiPlusCircleDuotone,
   PiXCircleDuotone,
+  PiXDuotone,
+  PiImageDuotone,
 } from "react-icons/pi";
 import { Spinner } from "@/components/ui/spinner";
 import { useAuth } from "react-oidc-context";

--- a/features/workspace/projects/ShareProjectDialog.tsx
+++ b/features/workspace/projects/ShareProjectDialog.tsx
@@ -1,5 +1,4 @@
-import { LinkIcon, CopyIcon, CheckIcon } from "lucide-react";
-import { PiShareNetworkDuotone, PiXCircleDuotone } from "react-icons/pi";
+import { PiShareNetworkDuotone, PiXCircleDuotone, PiLinkDuotone, PiCopyDuotone, PiCheckDuotone } from "react-icons/pi";
 import { useState, useMemo } from "react";
 
 import {
@@ -87,18 +86,18 @@ export default function ShareProjectDialog({
                   className="pl-10"
                 />
                 <InputGroupAddon>
-                  <LinkIcon size={16} />
+                  <PiLinkDuotone size={16} />
                 </InputGroupAddon>
               </InputGroup>
               <Button size="sm" onClick={handleCopyLink} className="shrink-0">
                 {copied ? (
                   <>
-                    <CheckIcon size={16} className="mr-1" />
+                    <PiCheckDuotone size={16} className="mr-1" />
                     Copied
                   </>
                 ) : (
                   <>
-                    <CopyIcon size={16} className="mr-1" />
+                    <PiCopyDuotone size={16} className="mr-1" />
                     Copy
                   </>
                 )}

--- a/features/workspace/projects/UpdateProjectDialog.tsx
+++ b/features/workspace/projects/UpdateProjectDialog.tsx
@@ -4,7 +4,6 @@ import { toast } from "sonner";
 import { useAuth } from "react-oidc-context";
 import { useEffect, useId, useState } from "react";
 import { useForm, SubmitHandler } from "react-hook-form";
-import { ImagePlusIcon, XIcon } from "lucide-react";
 import { useFileUpload } from "@/hooks/general/use-file-upload";
 import { Button } from "@/components/ui/button";
 import {
@@ -24,7 +23,9 @@ import {
   PiBuildingsDuotone,
   PiPencilCircleDuotone,
   PiXCircleDuotone,
+  PiXDuotone,
   PiCheckCircleDuotone,
+  PiImageDuotone,
 } from "react-icons/pi";
 import { Spinner } from "@/components/ui/spinner";
 import Image from "next/image";

--- a/features/workspace/settings/DialogRemoveUser.tsx
+++ b/features/workspace/settings/DialogRemoveUser.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useId, useState } from "react";
-import { UserX } from "lucide-react";
+import { PiUserXDuotone } from "react-icons/pi";
 
 import { Button } from "@/components/ui/button";
 import {

--- a/features/workspace/source-files/DialogBookmarkSourceFileProductFolder.tsx
+++ b/features/workspace/source-files/DialogBookmarkSourceFileProductFolder.tsx
@@ -1,4 +1,4 @@
-import { BookmarkIcon, CheckIcon } from "lucide-react";
+import { PiBookmarkDuotone, PiCheckDuotone } from "react-icons/pi";
 import { useState } from "react";
 
 import { Button } from "@/components/ui/button";

--- a/features/workspace/source-files/SourceFilesFoldersCard.tsx
+++ b/features/workspace/source-files/SourceFilesFoldersCard.tsx
@@ -1,8 +1,7 @@
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
-import { FolderIcon } from "lucide-react";
-import { PiPlusBold, PiBookmarkSimpleDuotone } from "react-icons/pi";
+import { PiPlusBold, PiBookmarkSimpleDuotone, PiFolderDuotone } from "react-icons/pi";
 import { useRouter } from "next/navigation";
 import { useToggleBookmarkSourceFilesFolder } from "@/hooks/source-files/useToggleBookmarkSourceFilesFolder";
 import { useAuth } from "react-oidc-context";

--- a/features/workspace/source-files/SourceFilesTable.tsx
+++ b/features/workspace/source-files/SourceFilesTable.tsx
@@ -15,21 +15,21 @@ import {
   useReactTable,
   VisibilityState,
 } from "@tanstack/react-table";
-import {
-  ChevronDownIcon,
-  ChevronFirstIcon,
-  ChevronLastIcon,
-  ChevronLeftIcon,
-  ChevronRightIcon,
-  ChevronUpIcon,
-  Columns3Icon,
-  EllipsisIcon,
-} from "lucide-react";
 import { useId, useState } from "react";
 import { useRouter } from "next/navigation";
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import {
+  PiCaretDownDuotone,
+  PiCaretUpDuotone,
+  PiCaretLeftDuotone,
+  PiCaretRightDuotone,
+  PiCaretCircleDoubleLeftDuotone,
+  PiCaretCircleDoubleRightDuotone,
+  PiColumnsDuotone,
+  PiDotsThreeDuotone,
+} from "react-icons/pi";
 import {
   DropdownMenu,
   DropdownMenuCheckboxItem,

--- a/features/workspace/source-files/SourceFilesTableFilter.tsx
+++ b/features/workspace/source-files/SourceFilesTableFilter.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { Filter, Plus, X } from "lucide-react";
+import { PiFunnelDuotone, PiPlusDuotone, PiXDuotone } from "react-icons/pi";
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";

--- a/features/workspace/source-files/UploadSourceFiles.tsx
+++ b/features/workspace/source-files/UploadSourceFiles.tsx
@@ -1,17 +1,17 @@
 "use client";
 
 import {
-  AlertCircleIcon,
-  FileArchiveIcon,
-  FileIcon,
-  FileSpreadsheetIcon,
-  FileTextIcon,
-  FileUpIcon,
-  HeadphonesIcon,
-  ImageIcon,
-  VideoIcon,
-  XIcon,
-} from "lucide-react";
+  PiFileArchiveDuotone,
+  PiFileDuotone,
+  PiFileSpreadsheetDuotone,
+  PiFileTextDuotone,
+  PiUploadSimpleDuotone,
+  PiHeadphonesDuotone,
+  PiImageDuotone,
+  PiVideoDuotone,
+  PiXDuotone,
+  PiAlertCircleDuotone,
+} from "react-icons/pi";
 
 import { formatBytes, useFileUpload } from "@/hooks/general/use-file-upload";
 import { Button } from "@/components/ui/button";


### PR DESCRIPTION
Add Spinner component to 4 dialogs that were showing static icons during loading states instead of the loading spinner indicator.

Fixed dialogs:
- DialogAddLabelTag
- DialogEditLabelTag
- DialogDeleteLabelTag
- AddSchematicsDialog