### PR TITLE
feat: Add loading spinners to label tag and schematics dialogs

### DIFF
--- a/features/workspace/products/product/graphics-other-components/AddSchematicsDialog.tsx
+++ b/features/workspace/products/product/graphics-other-components/AddSchematicsDialog.tsx
@@ -30,6 +30,7 @@ import {
   PiXCircleDuotone,
   PiPictureInPictureDuotone,
 } from "react-icons/pi";
+import { Spinner } from "@/components/ui/spinner";
 
 type FormData = {
   componentName: string;
@@ -227,10 +228,14 @@ export default function AddSchematicsDialog({
             type="button"
             size="sm"
             onClick={handleSubmit(onSubmit)}
-            disabled={isPending}
+            disabled={isPending || uploadingImage}
             variant="default"
           >
-            <PiPlusCircleDuotone />
+            {isPending || uploadingImage ? (
+              <Spinner />
+            ) : (
+              <PiPlusCircleDuotone />
+            )}
             {isPending
               ? "Adding..."
               : uploadingImage

--- a/features/workspace/products/product/label-tags/DialogAddLabelTag.tsx
+++ b/features/workspace/products/product/label-tags/DialogAddLabelTag.tsx
@@ -30,6 +30,7 @@ import {
   PiTagDuotone,
   PiPictureInPictureDuotone,
 } from "react-icons/pi";
+import { Spinner } from "@/components/ui/spinner";
 
 type FormData = {
   name: string;
@@ -228,7 +229,11 @@ export default function DialogAddLabelTag({
             disabled={uploadingImage || isPending}
             aria-busy={uploadingImage || isPending}
           >
-            <PiPlusCircleDuotone />
+            {uploadingImage || isPending ? (
+              <Spinner />
+            ) : (
+              <PiPlusCircleDuotone />
+            )}
             {uploadingImage
               ? "Uploading..."
               : isPending

--- a/features/workspace/products/product/label-tags/DialogDeleteLabelTag.tsx
+++ b/features/workspace/products/product/label-tags/DialogDeleteLabelTag.tsx
@@ -12,6 +12,7 @@ import {
   AlertDialogTrigger,
 } from "@/components/ui/alert-dialog";
 import { PiTrashDuotone, PiXCircleDuotone } from "react-icons/pi";
+import { Spinner } from "@/components/ui/spinner";
 import { useUpdateProductTabData } from "@/hooks/product/useUpdateProductTabData";
 
 interface LabelTagItem {
@@ -114,7 +115,7 @@ export default function DialogDeleteLabelTag({
             variant="destructive"
             size="sm"
           >
-            <PiTrashDuotone />
+            {isPending ? <Spinner /> : <PiTrashDuotone />}
             {isPending ? "Deleting..." : "Delete Label"}
           </Button>
         </AlertDialogFooter>

--- a/features/workspace/products/product/label-tags/DialogEditLabelTag.tsx
+++ b/features/workspace/products/product/label-tags/DialogEditLabelTag.tsx
@@ -30,6 +30,7 @@ import {
   PiFloppyDiskDuotone,
   PiPictureInPictureDuotone,
 } from "react-icons/pi";
+import { Spinner } from "@/components/ui/spinner";
 
 type FormData = {
   name: string;
@@ -238,7 +239,11 @@ export default function DialogEditLabelTag({
             disabled={uploadingImage || isPending}
             aria-busy={uploadingImage || isPending}
           >
-            <PiFloppyDiskDuotone />
+            {uploadingImage || isPending ? (
+              <Spinner />
+            ) : (
+              <PiFloppyDiskDuotone />
+            )}
             {uploadingImage
               ? "Uploading..."
               : isPending


### PR DESCRIPTION
Add loading spinners to dialogs that were missing them. Replaced the action icons (PlusCircle, Trash, FloppyDisk) with a Spinner component during pending states.

Affected dialogs:
- AddSchematicsDialog
- DialogAddLabelTag
- DialogDeleteLabelTag
- DialogEditLabelTag

🤖 Generated with [Claude Code](https://claude.com/claude-code)