### PR TITLE
Refactor/Replace Lucide icons with Phosphor duotone icons

### DIFF
--- a/app/(app)/source-files/page.tsx
+++ b/app/(app)/source-files/page.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useAuth } from "react-oidc-context";
-import { BookmarkIcon, FolderIcon } from "lucide-react";
 import DialogAddProductFolder from "@/features/workspace/source-files/DialogAddProductFolder";
 import { useGetAllSourceFileFolders } from "@/hooks/source-files/useGetAllSourceFileFolders";
 import SourceFilesFoldersCard from "@/features/workspace/source-files/SourceFilesFoldersCard";
@@ -9,7 +8,7 @@ import { useGetBookmarkedSourceFilesFoldersByUserId } from "@/hooks/source-files
 import { SourceFilesFolder } from "@/types/source-files";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
-import { PiWarningCircleDuotone } from "react-icons/pi";
+import { PiBookmarkSimpleDuotone, PiFolderSimpleDuotone, PiWarningCircleDuotone } from "react-icons/pi";
 
 interface BookmarkedSourceFilesFolder extends SourceFilesFolder {
   isBookmarked?: boolean;
@@ -22,7 +21,7 @@ function FolderLoadingCard() {
       <Card className="shadow-none border-border w-full">
         <CardContent className="p-4 flex flex-row items-center gap-3">
           <div className="w-16 h-16 rounded-lg bg-muted border border-border flex items-center justify-center animate-pulse">
-            <FolderIcon className="w-10 h-10 text-muted-foreground/30" />
+            <PiFolderSimpleDuotone className="w-10 h-10 text-muted-foreground/30" />
           </div>
           <div className="min-w-0 flex-1 space-y-2">
             <div className="h-4 bg-muted rounded w-3/4 animate-pulse" />
@@ -188,7 +187,7 @@ function SourceFilesPage() {
             </div>
             {sourceFilesFolders.length === 0 ? (
               <div className="flex flex-col items-center justify-center h-[200px] gap-4 text-muted-foreground">
-                <BookmarkIcon className="w-16 h-16" />
+                <PiBookmarkSimpleDuotone className="w-16 h-16" />
                 <p className="text-lg">No folders created yet.</p>
                 <p className="text-sm">Create a new folder to get started.</p>
               </div>

--- a/app/(app)/source-files/view/[...slug]/page.tsx
+++ b/app/(app)/source-files/view/[...slug]/page.tsx
@@ -19,7 +19,7 @@ import { useGetSourceFilesFolderById } from "@/hooks/source-files/useGetSourceFi
 import { useToggleBookmarkSourceFilesFolder } from "@/hooks/source-files/useToggleBookmarkSourceFilesFolder";
 import { cn } from "@/lib/utils";
 import type { SourceFilesFolder } from "@/types/source-files";
-import { BookmarkIcon, FolderIcon } from "lucide-react";
+import { PiFolderSimpleDuotone } from "react-icons/pi";
 import Image from "next/image";
 import { useParams, useRouter } from "next/navigation";
 import { useState } from "react";
@@ -221,7 +221,7 @@ export default function ProductSourceFilesPage() {
         <div className="flex flex-wrap gap-2 items-center w-full justify-between p-4">
           <div className="flex items-center gap-2">
             <div className="w-8 h-8 rounded-lg bg-muted border border-border flex items-center justify-center">
-              <FolderIcon className="w-4 h-4 text-muted-foreground" />
+              <PiFolderSimpleDuotone className="w-4 h-4 text-muted-foreground" />
             </div>
             <h1 className="text-base font-semibold">{currentFolder?.name}</h1>
             <div
@@ -282,7 +282,7 @@ export default function ProductSourceFilesPage() {
             {folder?.length === 0 ? (
               <div className="w-full h-full flex items-center justify-center">
                 <div className="flex flex-col items-center gap-4 text-muted-foreground">
-                  <FolderIcon className="w-16 h-16" />
+                  <PiFolderSimpleDuotone className="w-16 h-16" />
                   <p className="text-lg">No source files uploaded yet</p>
                   <p className="text-sm">
                     Upload your first source file to get started
@@ -323,7 +323,7 @@ export default function ProductSourceFilesPage() {
                               <CardContent className="p-2 flex flex-row items-center justify-between gap-2">
                                 <div className="flex items-center gap-2">
                                   <div className="w-10 h-10 rounded-lg bg-muted border border-border flex items-center justify-center">
-                                    <FolderIcon className="w-6 h-6 text-muted-foreground" />
+                                    <PiFolderSimpleDuotone className="w-6 h-6 text-muted-foreground" />
                                   </div>
                                   <div className="min-w-0 flex-1">
                                     <p className="font-medium text-sm leading-tight line-clamp-2">

--- a/features/workspace/archive/DialogArchiveEntity.tsx
+++ b/features/workspace/archive/DialogArchiveEntity.tsx
@@ -3,7 +3,7 @@
 import { toast } from "sonner";
 import { useAuth } from "react-oidc-context";
 import { useId, useMemo, useState } from "react";
-import { CircleAlert as CircleAlertIcon } from "lucide-react";
+import { PiWarningCircleDuotone } from "react-icons/pi";
 
 import { Button } from "@/components/ui/button";
 import {
@@ -96,7 +96,7 @@ export default function DialogArchiveEntity({
             className="flex size-9 shrink-0 items-center justify-center rounded-full border"
             aria-hidden="true"
           >
-            <CircleAlertIcon className="opacity-80" size={16} />
+            <PiWarningCircleDuotone className="opacity-80" size={16} />
           </div>
           <DialogHeader>
             <DialogTitle className="sm:text-center">

--- a/features/workspace/bookmarks/DialogAddProductsToFolder.tsx
+++ b/features/workspace/bookmarks/DialogAddProductsToFolder.tsx
@@ -7,7 +7,7 @@ import {
   PiPackageDuotone,
   PiXCircleDuotone,
 } from "react-icons/pi";
-import { Check, ChevronsUpDown } from "lucide-react";
+import { PiCheckDuotone, PiCaretUpDownDuotone } from "react-icons/pi";
 
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
@@ -175,7 +175,7 @@ export default function DialogAddProductsToFolder({
                             product._id === selectedProductId
                         )?.product_name || "Unnamed Product"
                       : "Choose a product..."}
-                    <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+                    <PiCaretUpDownDuotone className="ml-2 h-4 w-4 shrink-0 opacity-50" />
                   </Button>
                 </PopoverTrigger>
                 <PopoverContent className="w-[--radix-popover-trigger-width] p-0">
@@ -227,7 +227,7 @@ export default function DialogAddProductsToFolder({
                                     {product.status}
                                   </span>
                                 )}
-                                <Check
+                                <PiCheckDuotone
                                   className={cn(
                                     "ml-2 h-4 w-4",
                                     selectedProductId === product._id

--- a/features/workspace/dashboard/DepartmentsCard.tsx
+++ b/features/workspace/dashboard/DepartmentsCard.tsx
@@ -1,4 +1,4 @@
-import { CalendarClock, Text } from "lucide-react";
+import { PiCalendarCheckDuotone, PiTextTDuotone } from "react-icons/pi";
 import Image from "next/image";
 import Link from "next/link";
 import { PiBuildingsDuotone } from "react-icons/pi";
@@ -37,7 +37,7 @@ function Departments({ departments }: { departments: DepartmentsProps[] }) {
                 </p>
                 <p className="flex items-start gap-1 text-xs text-muted-foreground">
                   <span>
-                    <Text className="mr-1 w-4 h-4" />
+                    <PiTextTDuotone className="mr-1 w-4 h-4" />
                   </span>
                   {department.department_description}
                 </p>
@@ -45,7 +45,7 @@ function Departments({ departments }: { departments: DepartmentsProps[] }) {
               <div className="flex flex-wrap items-center justify-between w-full gap-4">
                 <div className="flex items-center gap-1 text-muted-foreground">
                   <span>
-                    <CalendarClock className="mr-1 w-4 h-4" />
+                    <PiCalendarCheckDuotone className="mr-1 w-4 h-4" />
                   </span>
                   <p className="text-xs text-muted-foreground">
                     {department.date}

--- a/features/workspace/departments/AddUsersInDepartmentDropdown.tsx
+++ b/features/workspace/departments/AddUsersInDepartmentDropdown.tsx
@@ -10,7 +10,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { PiPlusBold, PiUserCirclePlusDuotone } from "react-icons/pi";
-import { X } from "lucide-react";
+import { PiXBold } from "react-icons/pi";
 import Image from "next/image";
 
 interface User {
@@ -82,7 +82,7 @@ export default function AddUsersInDepartmentDropdown({
                 {user.name}
               </div>
               {isSelected && (
-                <X className="size-4 text-muted-foreground hover:text-destructive" />
+                <PiXBold className="size-4 text-muted-foreground hover:text-destructive" />
               )}
             </DropdownMenuItem>
           );

--- a/features/workspace/departments/CreateDepartmentDialog.tsx
+++ b/features/workspace/departments/CreateDepartmentDialog.tsx
@@ -3,7 +3,7 @@
 import { toast } from "sonner";
 import { useId, useState } from "react";
 import { useForm } from "react-hook-form";
-import { ImagePlusIcon, XIcon } from "lucide-react";
+import { PiPlusSquareDuotone, PiXDuotone } from "react-icons/pi";
 import { useAuth } from "react-oidc-context";
 import { useFileUpload } from "@/hooks/general/use-file-upload";
 import { Button } from "@/components/ui/button";
@@ -374,7 +374,7 @@ function ProfileBg({
             onClick={openFileDialog}
             aria-label={currentImage ? "Change image" : "Upload image"}
           >
-            <ImagePlusIcon size={16} aria-hidden="true" />
+            <PiPlusSquareDuotone size={16} aria-hidden="true" />
           </button>
           {currentImage && (
             <button
@@ -383,7 +383,7 @@ function ProfileBg({
               onClick={() => removeFile(files[0]?.id)}
               aria-label="Remove image"
             >
-              <XIcon size={16} aria-hidden="true" />
+              <PiXDuotone size={16} aria-hidden="true" />
             </button>
           )}
         </div>

--- a/features/workspace/departments/ShareDepartmentDialog.tsx
+++ b/features/workspace/departments/ShareDepartmentDialog.tsx
@@ -1,4 +1,4 @@
-import { LinkIcon, CopyIcon, CheckIcon } from "lucide-react";
+import { PiLinkDuotone, PiCopyDuotone, PiCheckDuotone } from "react-icons/pi";
 import { PiShareNetworkDuotone, PiXCircleDuotone } from "react-icons/pi";
 import { useState, useMemo } from "react";
 
@@ -87,18 +87,18 @@ export default function ShareDepartmentDialog({
                   className="pl-10"
                 />
                 <InputGroupAddon>
-                  <LinkIcon size={16} />
+                  <PiLinkDuotone size={16} />
                 </InputGroupAddon>
               </InputGroup>
               <Button size="sm" onClick={handleCopyLink} className="shrink-0">
                 {copied ? (
                   <>
-                    <CheckIcon size={16} className="mr-1" />
+                    <PiCheckDuotone size={16} className="mr-1" />
                     Copied
                   </>
                 ) : (
                   <>
-                    <CopyIcon size={16} className="mr-1" />
+                    <PiCopyDuotone size={16} className="mr-1" />
                     Copy
                   </>
                 )}

--- a/features/workspace/departments/UpdateDepartmentDialog.tsx
+++ b/features/workspace/departments/UpdateDepartmentDialog.tsx
@@ -4,7 +4,7 @@ import { toast } from "sonner";
 import { useAuth } from "react-oidc-context";
 import { useId, useState, useEffect } from "react";
 import { useForm, SubmitHandler } from "react-hook-form";
-import { ImagePlusIcon, XIcon } from "lucide-react";
+import { PiPlusSquareDuotone, PiXDuotone } from "react-icons/pi";
 import { useFileUpload } from "@/hooks/general/use-file-upload";
 import { Button } from "@/components/ui/button";
 import {
@@ -429,7 +429,7 @@ function ProfileBg({
             onClick={openFileDialog}
             aria-label={currentImage ? "Change image" : "Upload image"}
           >
-            <ImagePlusIcon size={16} aria-hidden="true" />
+            <PiPlusSquareDuotone size={16} aria-hidden="true" />
           </button>
           {currentImage && (
             <button
@@ -438,7 +438,7 @@ function ProfileBg({
               onClick={() => removeFile(files[0]?.id)}
               aria-label="Remove image"
             >
-              <XIcon size={16} aria-hidden="true" />
+              <PiXDuotone size={16} aria-hidden="true" />
             </button>
           )}
         </div>

--- a/features/workspace/products/DialogShareProduct.tsx
+++ b/features/workspace/products/DialogShareProduct.tsx
@@ -1,4 +1,4 @@
-import { LinkIcon, CopyIcon, CheckIcon } from "lucide-react";
+import { PiLinkDuotone, PiCopyDuotone, PiCheckDuotone } from "react-icons/pi";
 import { PiShareNetworkDuotone, PiXCircleDuotone } from "react-icons/pi";
 import { useState, useMemo } from "react";
 
@@ -80,18 +80,18 @@ export default function DialogShareProduct({
                 className="pl-10"
               />
               <InputGroupAddon>
-                <LinkIcon size={16} />
+                <PiLinkDuotone size={16} />
               </InputGroupAddon>
             </InputGroup>
             <Button size="sm" onClick={handleCopyLink} className="shrink-0">
               {copied ? (
                 <>
-                  <CheckIcon size={16} className="mr-1" />
+                  <PiCheckDuotone size={16} className="mr-1" />
                   Copied
                 </>
               ) : (
                 <>
-                  <CopyIcon size={16} className="mr-1" />
+                  <PiCopyDuotone size={16} className="mr-1" />
                   Copy
                 </>
               )}

--- a/features/workspace/products/ProductsPageProductTable.tsx
+++ b/features/workspace/products/ProductsPageProductTable.tsx
@@ -16,24 +16,14 @@ import {
   VisibilityState,
 } from "@tanstack/react-table";
 import {
-  ChevronDownIcon,
-  ChevronFirstIcon,
-  ChevronLastIcon,
-  ChevronLeftIcon,
-  ChevronRightIcon,
-  ChevronUpIcon,
-  Columns3Icon,
-  EllipsisIcon,
-} from "lucide-react";
-import { useRouter } from "next/navigation";
-import { useId, useState } from "react";
-import {
   PiBuildingsDuotone,
   PiCaretCircleDoubleLeftDuotone,
   PiCaretCircleDoubleRightDuotone,
   PiCaretCircleLeftDuotone,
   PiCaretCircleRightDuotone,
   PiCaretDownDuotone,
+  PiCaretLeftDuotone,
+  PiCaretRightDuotone,
   PiCaretUpDownDuotone,
   PiCaretUpDuotone,
   PiChartPieSliceDuotone,
@@ -49,6 +39,8 @@ import {
   PiKanbanDuotone,
   PiPackageDuotone,
 } from "react-icons/pi";
+import { useRouter } from "next/navigation";
+import { useId, useState } from "react";
 import { Progress } from "@/components/ui/progress";
 
 import { Badge } from "@/components/ui/badge";

--- a/features/workspace/products/product/component-details/AddComponentDialog.tsx
+++ b/features/workspace/products/product/component-details/AddComponentDialog.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useId, useState } from "react";
-import { ImagePlusIcon, XIcon } from "lucide-react";
+import { PiPlusSquareDuotone, PiXDuotone } from "react-icons/pi";
 import { useForm, Controller } from "react-hook-form";
 import {
   useFileUpload,
@@ -351,7 +351,7 @@ function ComponentImage({ value, onChange }: ComponentImageProps) {
             onClick={openFileDialog}
             aria-label={currentImage ? "Change image" : "Upload image"}
           >
-            <ImagePlusIcon size={16} aria-hidden="true" />
+            <PiPlusSquareDuotone size={16} aria-hidden="true" />
           </button>
           {currentImage && (
             <button
@@ -366,7 +366,7 @@ function ComponentImage({ value, onChange }: ComponentImageProps) {
               }}
               aria-label="Remove image"
             >
-              <XIcon size={16} aria-hidden="true" />
+              <PiXDuotone size={16} aria-hidden="true" />
             </button>
           )}
         </div>

--- a/features/workspace/products/product/component-details/EditComponentDialog.tsx
+++ b/features/workspace/products/product/component-details/EditComponentDialog.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useId, useState, useEffect } from "react";
-import { ImagePlusIcon, XIcon } from "lucide-react";
+import { PiPlusSquareDuotone, PiXDuotone } from "react-icons/pi";
 import { useForm, Controller } from "react-hook-form";
 import {
   useFileUpload,
@@ -372,7 +372,7 @@ function ComponentImage({
             onClick={openFileDialog}
             aria-label={displayImage ? "Change image" : "Upload image"}
           >
-            <ImagePlusIcon size={16} aria-hidden="true" />
+            <PiPlusSquareDuotone size={16} aria-hidden="true" />
           </button>
           {displayImage && (
             <button
@@ -387,7 +387,7 @@ function ComponentImage({
               }}
               aria-label="Remove image"
             >
-              <XIcon size={16} aria-hidden="true" />
+              <PiXDuotone size={16} aria-hidden="true" />
             </button>
           )}
         </div>

--- a/features/workspace/products/product/component-details/ProductComponentDetailsTable.tsx
+++ b/features/workspace/products/product/component-details/ProductComponentDetailsTable.tsx
@@ -13,11 +13,25 @@ import {
   useReactTable,
 } from "@tanstack/react-table";
 import {
-  ChevronDownIcon,
-  ChevronRightIcon,
-  EllipsisIcon,
-  LayoutList,
-} from "lucide-react";
+  PiCaretCircleDoubleLeftDuotone,
+  PiCaretCircleDoubleRightDuotone,
+  PiCaretCircleDownDuotone,
+  PiCaretCircleLeftDuotone,
+  PiCaretCircleRightDuotone,
+  PiCaretDownDuotone,
+  PiCaretUpDownDuotone,
+  PiCaretUpDuotone,
+  PiCirclesFourDuotone,
+  PiDotsThreeCircleDuotone,
+  PiHashDuotone,
+  PiImageDuotone,
+  PiLayoutDuotone,
+  PiPencilSimpleDuotone,
+  PiRulerDuotone,
+  PiTagDuotone,
+  PiTextAlignLeftDuotone,
+  PiTrashDuotone,
+} from "react-icons/pi";
 import { Badge } from "@/components/ui/badge";
 import { Fragment, useId, useState } from "react";
 import { usePathname } from "next/navigation";
@@ -53,25 +67,6 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import Image from "next/image";
-import {
-  PiPencilSimpleDuotone,
-  PiTrashDuotone,
-  PiHashDuotone,
-  PiImageDuotone,
-  PiTagDuotone,
-  PiTextAlignLeftDuotone,
-  PiRulerDuotone,
-  PiCirclesFourDuotone,
-  PiCaretDownDuotone,
-  PiCaretUpDuotone,
-  PiCaretUpDownDuotone,
-  PiCaretCircleDoubleLeftDuotone,
-  PiCaretCircleLeftDuotone,
-  PiCaretCircleRightDuotone,
-  PiCaretCircleDoubleRightDuotone,
-  PiCaretCircleDownDuotone,
-  PiDotsThreeCircleDuotone,
-} from "react-icons/pi";
 import EditComponentDialog from "./EditComponentDialog";
 import DeleteComponentDialog from "./DeleteComponentDialog";
 

--- a/features/workspace/products/product/graphics-other-components/AddBarcodesDialog.tsx
+++ b/features/workspace/products/product/graphics-other-components/AddBarcodesDialog.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useId, useState } from "react";
-import { ImagePlusIcon, XIcon } from "lucide-react";
+import { PiPlusSquareDuotone, PiXDuotone } from "react-icons/pi";
 import { useForm, Controller } from "react-hook-form";
 import {
   useFileUpload,
@@ -406,7 +406,7 @@ function ComponentImage({ value, onChange }: ComponentImageProps) {
             onClick={openFileDialog}
             aria-label={currentImage ? "Change image" : "Upload image"}
           >
-            <ImagePlusIcon size={16} aria-hidden="true" />
+            <PiPlusSquareDuotone size={16} aria-hidden="true" />
           </button>
           {currentImage && (
             <button
@@ -421,7 +421,7 @@ function ComponentImage({ value, onChange }: ComponentImageProps) {
               }}
               aria-label="Remove image"
             >
-              <XIcon size={16} aria-hidden="true" />
+              <PiXDuotone size={16} aria-hidden="true" />
             </button>
           )}
         </div>

--- a/features/workspace/products/product/graphics-other-components/AddOtherCompsDialog.tsx
+++ b/features/workspace/products/product/graphics-other-components/AddOtherCompsDialog.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useId, useState } from "react";
-import { ImagePlusIcon, XIcon } from "lucide-react";
+import { PiPlusSquareDuotone, PiXDuotone } from "react-icons/pi";
 import { useForm, Controller } from "react-hook-form";
 import {
   useFileUpload,
@@ -290,7 +290,7 @@ function ComponentImage({ value, onChange }: ComponentImageProps) {
             onClick={openFileDialog}
             aria-label={currentImage ? "Change image" : "Upload image"}
           >
-            <ImagePlusIcon size={16} aria-hidden="true" />
+            <PiPlusSquareDuotone size={16} aria-hidden="true" />
           </button>
           {currentImage && (
             <button
@@ -305,7 +305,7 @@ function ComponentImage({ value, onChange }: ComponentImageProps) {
               }}
               aria-label="Remove image"
             >
-              <XIcon size={16} aria-hidden="true" />
+              <PiXDuotone size={16} aria-hidden="true" />
             </button>
           )}
         </div>

--- a/features/workspace/products/product/graphics-other-components/AddSchematicsDialog.tsx
+++ b/features/workspace/products/product/graphics-other-components/AddSchematicsDialog.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useId, useState } from "react";
-import { ImagePlusIcon, XIcon } from "lucide-react";
+import { PiPlusSquareDuotone, PiXDuotone } from "react-icons/pi";
 import { useForm, Controller } from "react-hook-form";
 import {
   useFileUpload,
@@ -297,7 +297,7 @@ function ComponentImage({ value, onChange }: ComponentImageProps) {
             onClick={openFileDialog}
             aria-label={currentImage ? "Change image" : "Upload image"}
           >
-            <ImagePlusIcon size={16} aria-hidden="true" />
+            <PiPlusSquareDuotone size={16} aria-hidden="true" />
           </button>
           {currentImage && (
             <button
@@ -312,7 +312,7 @@ function ComponentImage({ value, onChange }: ComponentImageProps) {
               }}
               aria-label="Remove image"
             >
-              <XIcon size={16} aria-hidden="true" />
+              <PiXDuotone size={16} aria-hidden="true" />
             </button>
           )}
         </div>

--- a/features/workspace/products/product/graphics-other-components/AddSymbolsDialog.tsx
+++ b/features/workspace/products/product/graphics-other-components/AddSymbolsDialog.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useId, useState } from "react";
-import { ImagePlusIcon, XIcon } from "lucide-react";
+import { PiPlusSquareDuotone, PiXDuotone } from "react-icons/pi";
 import { useForm, Controller } from "react-hook-form";
 import {
   useFileUpload,
@@ -314,7 +314,7 @@ function ComponentImage({ value, onChange }: ComponentImageProps) {
             onClick={openFileDialog}
             aria-label={currentImage ? "Change image" : "Upload image"}
           >
-            <ImagePlusIcon size={16} aria-hidden="true" />
+            <PiPlusSquareDuotone size={16} aria-hidden="true" />
           </button>
           {currentImage && (
             <button
@@ -329,7 +329,7 @@ function ComponentImage({ value, onChange }: ComponentImageProps) {
               }}
               aria-label="Remove image"
             >
-              <XIcon size={16} aria-hidden="true" />
+              <PiXDuotone size={16} aria-hidden="true" />
             </button>
           )}
         </div>

--- a/features/workspace/products/product/graphics-other-components/EditBarcodesDialog.tsx
+++ b/features/workspace/products/product/graphics-other-components/EditBarcodesDialog.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useId, useState, useEffect } from "react";
-import { ImagePlusIcon, XIcon } from "lucide-react";
+import { PiPlusSquareDuotone, PiXDuotone } from "react-icons/pi";
 import { useForm, Controller } from "react-hook-form";
 import {
   useFileUpload,
@@ -465,7 +465,7 @@ function ComponentImage({
             onClick={openFileDialog}
             aria-label={displayImage ? "Change image" : "Upload image"}
           >
-            <ImagePlusIcon size={16} aria-hidden="true" />
+            <PiPlusSquareDuotone size={16} aria-hidden="true" />
           </button>
           {displayImage && (
             <button
@@ -483,7 +483,7 @@ function ComponentImage({
               }}
               aria-label="Remove image"
             >
-              <XIcon size={16} aria-hidden="true" />
+              <PiXDuotone size={16} aria-hidden="true" />
             </button>
           )}
         </div>

--- a/features/workspace/products/product/graphics-other-components/EditOtherComponentsDialog.tsx
+++ b/features/workspace/products/product/graphics-other-components/EditOtherComponentsDialog.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useId, useState, useEffect } from "react";
-import { ImagePlusIcon, XIcon } from "lucide-react";
+import { PiPlusSquareDuotone, PiXDuotone } from "react-icons/pi";
 import { useForm, Controller } from "react-hook-form";
 import {
   useFileUpload,
@@ -345,7 +345,7 @@ function ComponentImage({
             onClick={openFileDialog}
             aria-label={displayImage ? "Change image" : "Upload image"}
           >
-            <ImagePlusIcon size={16} aria-hidden="true" />
+            <PiPlusSquareDuotone size={16} aria-hidden="true" />
           </button>
           {displayImage && (
             <button
@@ -363,7 +363,7 @@ function ComponentImage({
               }}
               aria-label="Remove image"
             >
-              <XIcon size={16} aria-hidden="true" />
+              <PiXDuotone size={16} aria-hidden="true" />
             </button>
           )}
         </div>

--- a/features/workspace/products/product/graphics-other-components/EditSchematicsDialog.tsx
+++ b/features/workspace/products/product/graphics-other-components/EditSchematicsDialog.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useId, useState, useEffect } from "react";
-import { ImagePlusIcon, XIcon } from "lucide-react";
+import { PiPlusSquareDuotone, PiXDuotone } from "react-icons/pi";
 import { useForm, Controller } from "react-hook-form";
 import {
   useFileUpload,
@@ -344,7 +344,7 @@ function ComponentImage({
             onClick={openFileDialog}
             aria-label={displayImage ? "Change image" : "Upload image"}
           >
-            <ImagePlusIcon size={16} aria-hidden="true" />
+            <PiPlusSquareDuotone size={16} aria-hidden="true" />
           </button>
           {displayImage && (
             <button
@@ -362,7 +362,7 @@ function ComponentImage({
               }}
               aria-label="Remove image"
             >
-              <XIcon size={16} aria-hidden="true" />
+              <PiXDuotone size={16} aria-hidden="true" />
             </button>
           )}
         </div>

--- a/features/workspace/products/product/graphics-other-components/EditSymbolsDialog.tsx
+++ b/features/workspace/products/product/graphics-other-components/EditSymbolsDialog.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useId, useState, useEffect } from "react";
-import { ImagePlusIcon, XIcon } from "lucide-react";
+import { PiPlusSquareDuotone, PiXDuotone } from "react-icons/pi";
 import { useForm, Controller } from "react-hook-form";
 import {
   useFileUpload,
@@ -364,7 +364,7 @@ function ComponentImage({
             onClick={openFileDialog}
             aria-label={displayImage ? "Change image" : "Upload image"}
           >
-            <ImagePlusIcon size={16} aria-hidden="true" />
+            <PiPlusSquareDuotone size={16} aria-hidden="true" />
           </button>
           {displayImage && (
             <button
@@ -382,7 +382,7 @@ function ComponentImage({
               }}
               aria-label="Remove image"
             >
-              <XIcon size={16} aria-hidden="true" />
+              <PiXDuotone size={16} aria-hidden="true" />
             </button>
           )}
         </div>

--- a/features/workspace/products/product/graphics-other-components/GraphicsAndOtherCompsTabs.tsx
+++ b/features/workspace/products/product/graphics-other-components/GraphicsAndOtherCompsTabs.tsx
@@ -1,4 +1,4 @@
-import { BoxIcon, HouseIcon, PanelsTopLeftIcon } from "lucide-react"
+import { PiHouseDuotone, PiSquaresFourDuotone, PiPackageDuotone } from "react-icons/pi";
 
 import { ScrollArea, ScrollBar } from "@/components/ui/scroll-area"
 import {
@@ -17,7 +17,7 @@ export default function Component() {
             value="tab-1"
             className="data-[state=active]:bg-muted data-[state=active]:after:bg-primary relative overflow-hidden rounded-none border py-2 after:pointer-events-none after:absolute after:inset-x-0 after:bottom-0 after:h-0.5 first:rounded-s last:rounded-e"
           >
-            <HouseIcon
+            <PiHouseDuotone
               className="-ms-0.5 me-1.5 opacity-60"
               size={16}
               aria-hidden="true"
@@ -28,7 +28,7 @@ export default function Component() {
             value="tab-2"
             className="data-[state=active]:bg-muted data-[state=active]:after:bg-primary relative overflow-hidden rounded-none border py-2 after:pointer-events-none after:absolute after:inset-x-0 after:bottom-0 after:h-0.5 first:rounded-s last:rounded-e"
           >
-            <PanelsTopLeftIcon
+            <PiSquaresFourDuotone
               className="-ms-0.5 me-1.5 opacity-60"
               size={16}
               aria-hidden="true"
@@ -39,7 +39,7 @@ export default function Component() {
             value="tab-3"
             className="data-[state=active]:bg-muted data-[state=active]:after:bg-primary relative overflow-hidden rounded-none border py-2 after:pointer-events-none after:absolute after:inset-x-0 after:bottom-0 after:h-0.5 first:rounded-s last:rounded-e"
           >
-            <BoxIcon
+            <PiPackageDuotone
               className="-ms-0.5 me-1.5 opacity-60"
               size={16}
               aria-hidden="true"

--- a/features/workspace/products/product/label-tags/DialogAddLabelTag.tsx
+++ b/features/workspace/products/product/label-tags/DialogAddLabelTag.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useId, useState } from "react";
-import { ImagePlusIcon, XIcon } from "lucide-react";
+import { PiPlusSquareDuotone, PiXDuotone } from "react-icons/pi";
 import { useForm, Controller } from "react-hook-form";
 import {
   useFileUpload,
@@ -296,7 +296,7 @@ function ComponentImage({ value, onChange }: ComponentImageProps) {
             onClick={openFileDialog}
             aria-label={currentImage ? "Change image" : "Upload image"}
           >
-            <ImagePlusIcon size={16} aria-hidden="true" />
+            <PiPlusSquareDuotone size={16} aria-hidden="true" />
           </button>
           {currentImage && (
             <button
@@ -311,7 +311,7 @@ function ComponentImage({ value, onChange }: ComponentImageProps) {
               }}
               aria-label="Remove image"
             >
-              <XIcon size={16} aria-hidden="true" />
+              <PiXDuotone size={16} aria-hidden="true" />
             </button>
           )}
         </div>

--- a/features/workspace/products/product/label-tags/DialogEditLabelTag.tsx
+++ b/features/workspace/products/product/label-tags/DialogEditLabelTag.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useId, useState } from "react";
-import { ImagePlusIcon, XIcon } from "lucide-react";
+import { PiPlusSquareDuotone, PiXDuotone } from "react-icons/pi";
 import { useForm, Controller } from "react-hook-form";
 import {
   useFileUpload,
@@ -310,7 +310,7 @@ function ComponentImage({ value, onChange }: ComponentImageProps) {
             onClick={openFileDialog}
             aria-label={currentImage ? "Change image" : "Upload image"}
           >
-            <ImagePlusIcon size={16} aria-hidden="true" />
+            <PiPlusSquareDuotone size={16} aria-hidden="true" />
           </button>
           {currentImage && (
             <button
@@ -327,7 +327,7 @@ function ComponentImage({ value, onChange }: ComponentImageProps) {
               }}
               aria-label="Remove image"
             >
-              <XIcon size={16} aria-hidden="true" />
+              <PiXDuotone size={16} aria-hidden="true" />
             </button>
           )}
         </div>

--- a/features/workspace/projects/AddUsersInProjectDropdown.tsx
+++ b/features/workspace/projects/AddUsersInProjectDropdown.tsx
@@ -9,8 +9,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { PiUserCirclePlusDuotone } from "react-icons/pi";
-import { X } from "lucide-react";
+import { PiUserCirclePlusDuotone, PiXDuotone } from "react-icons/pi";
 import Image from "next/image";
 
 interface User {
@@ -82,7 +81,7 @@ export default function AddUsersInProjectDropdown({
                 {user.name}
               </div>
               {isSelected && (
-                <X className="size-4 text-muted-foreground hover:text-destructive" />
+                <PiXDuotone className="size-4 text-muted-foreground hover:text-destructive" />
               )}
             </DropdownMenuItem>
           );

--- a/features/workspace/projects/ProjectCreateDialog.tsx
+++ b/features/workspace/projects/ProjectCreateDialog.tsx
@@ -29,7 +29,7 @@ import { useCreateProject } from "@/hooks/project/useCreateProject";
 import { useGetAllUsersByWorkspace } from "@/hooks/user/useGetAllUsersByWorkspace";
 import { Department } from "@/types/department";
 import { uploadFiles } from "@/utils/uploadthing";
-import { ImagePlusIcon, XIcon } from "lucide-react";
+import { PiPlusSquareDuotone, PiXDuotone } from "react-icons/pi";
 import Image from "next/image";
 import { useId, useState } from "react";
 import { useForm } from "react-hook-form";
@@ -441,7 +441,7 @@ function ProfileBg({
             onClick={openFileDialog}
             aria-label={currentImage ? "Change image" : "Upload image"}
           >
-            <ImagePlusIcon size={16} aria-hidden="true" />
+            <PiPlusSquareDuotone size={16} aria-hidden="true" />
           </button>
           {currentImage && (
             <button
@@ -450,7 +450,7 @@ function ProfileBg({
               onClick={() => removeFile(files[0]?.id)}
               aria-label="Remove image"
             >
-              <XIcon size={16} aria-hidden="true" />
+              <PiXDuotone size={16} aria-hidden="true" />
             </button>
           )}
         </div>

--- a/features/workspace/projects/ShareProjectDialog.tsx
+++ b/features/workspace/projects/ShareProjectDialog.tsx
@@ -1,5 +1,4 @@
-import { LinkIcon, CopyIcon, CheckIcon } from "lucide-react";
-import { PiShareNetworkDuotone, PiXCircleDuotone } from "react-icons/pi";
+import { PiLinkDuotone, PiCopyDuotone, PiCheckDuotone, PiShareNetworkDuotone, PiXCircleDuotone } from "react-icons/pi";
 import { useState, useMemo } from "react";
 
 import {
@@ -87,18 +86,18 @@ export default function ShareProjectDialog({
                   className="pl-10"
                 />
                 <InputGroupAddon>
-                  <LinkIcon size={16} />
+                  <PiLinkDuotone size={16} />
                 </InputGroupAddon>
               </InputGroup>
               <Button size="sm" onClick={handleCopyLink} className="shrink-0">
                 {copied ? (
                   <>
-                    <CheckIcon size={16} className="mr-1" />
+                    <PiCheckDuotone size={16} className="mr-1" />
                     Copied
                   </>
                 ) : (
                   <>
-                    <CopyIcon size={16} className="mr-1" />
+                    <PiCopyDuotone size={16} className="mr-1" />
                     Copy
                   </>
                 )}

--- a/features/workspace/projects/UpdateProjectDialog.tsx
+++ b/features/workspace/projects/UpdateProjectDialog.tsx
@@ -4,7 +4,7 @@ import { toast } from "sonner";
 import { useAuth } from "react-oidc-context";
 import { useEffect, useId, useState } from "react";
 import { useForm, SubmitHandler } from "react-hook-form";
-import { ImagePlusIcon, XIcon } from "lucide-react";
+import { PiPlusSquareDuotone, PiXDuotone } from "react-icons/pi";
 import { useFileUpload } from "@/hooks/general/use-file-upload";
 import { Button } from "@/components/ui/button";
 import {
@@ -482,7 +482,7 @@ function ProfileBg({
             onClick={openFileDialog}
             aria-label={currentImage ? "Change image" : "Upload image"}
           >
-            <ImagePlusIcon size={16} aria-hidden="true" />
+            <PiPlusSquareDuotone size={16} aria-hidden="true" />
           </button>
           {currentImage && (
             <button
@@ -491,7 +491,7 @@ function ProfileBg({
               onClick={() => removeFile(files[0]?.id)}
               aria-label="Remove image"
             >
-              <XIcon size={16} aria-hidden="true" />
+              <PiXDuotone size={16} aria-hidden="true" />
             </button>
           )}
         </div>

--- a/features/workspace/settings/DialogRemoveUser.tsx
+++ b/features/workspace/settings/DialogRemoveUser.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useId, useState } from "react";
-import { UserX } from "lucide-react";
+import { PiUserMinusDuotone } from "react-icons/pi";
 
 import { Button } from "@/components/ui/button";
 import {
@@ -49,7 +49,7 @@ export default function DialogRemoveUser({
             className="flex size-9 shrink-0 items-center justify-center rounded-full border"
             aria-hidden="true"
           >
-            <UserX className="opacity-80" size={16} />
+            <PiUserMinusDuotone className="opacity-80" size={16} />
           </div>
           <DialogHeader>
             <DialogTitle className="sm:text-center">Remove User</DialogTitle>

--- a/features/workspace/source-files/DialogBookmarkSourceFileProductFolder.tsx
+++ b/features/workspace/source-files/DialogBookmarkSourceFileProductFolder.tsx
@@ -1,4 +1,4 @@
-import { BookmarkIcon, CheckIcon } from "lucide-react";
+import { PiBookmarkSimpleDuotone, PiCheckDuotone } from "react-icons/pi";
 import { useState } from "react";
 
 import { Button } from "@/components/ui/button";
@@ -84,7 +84,7 @@ export default function DialogBookmarkSourceFileProductFolder({
     <DialogContent className="max-w-2xl w-full max-h-[85vh] overflow-hidden flex flex-col">
       <DialogHeader>
         <DialogTitle className="flex items-center gap-2">
-          <BookmarkIcon size={20} />
+          <PiBookmarkSimpleDuotone size={20} />
           Bookmark Product Folders
         </DialogTitle>
         <DialogDescription>
@@ -155,7 +155,7 @@ export default function DialogBookmarkSourceFileProductFolder({
                           </div>
                         </div>
                         {isSelected && (
-                          <CheckIcon
+                          <PiCheckDuotone
                             size={16}
                             className="text-primary flex-shrink-0 ml-2"
                           />
@@ -216,7 +216,7 @@ export default function DialogBookmarkSourceFileProductFolder({
       <DialogTrigger asChild>
         {children || (
           <Button variant="outline" className="flex items-center gap-2">
-            <BookmarkIcon size={16} />
+            <PiBookmarkSimpleDuotone size={16} />
             Bookmark Products
           </Button>
         )}

--- a/features/workspace/source-files/SourceFilesFoldersCard.tsx
+++ b/features/workspace/source-files/SourceFilesFoldersCard.tsx
@@ -1,8 +1,7 @@
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
-import { FolderIcon } from "lucide-react";
-import { PiPlusBold, PiBookmarkSimpleDuotone } from "react-icons/pi";
+import { PiFolderSimpleDuotone, PiPlusBold, PiBookmarkSimpleDuotone } from "react-icons/pi";
 import { useRouter } from "next/navigation";
 import { useToggleBookmarkSourceFilesFolder } from "@/hooks/source-files/useToggleBookmarkSourceFilesFolder";
 import { useAuth } from "react-oidc-context";
@@ -43,7 +42,7 @@ function SourceFilesFoldersCard({ folders }: SourceFilesFoldersCardProps) {
                 <CardContent className="p-2 flex flex-row items-center justify-between gap-2">
                   <div className="flex items-center gap-2">
                     <div className="w-10 h-10 rounded-lg bg-muted border border-border flex items-center justify-center">
-                      <FolderIcon className="w-6 h-6 text-muted-foreground" />
+                      <PiFolderSimpleDuotone className="w-6 h-6 text-muted-foreground" />
                     </div>
                     <div className="min-w-0 flex-1">
                       <p className="font-medium text-sm leading-tight line-clamp-2">

--- a/features/workspace/source-files/SourceFilesTable.tsx
+++ b/features/workspace/source-files/SourceFilesTable.tsx
@@ -16,15 +16,15 @@ import {
   VisibilityState,
 } from "@tanstack/react-table";
 import {
-  ChevronDownIcon,
-  ChevronFirstIcon,
-  ChevronLastIcon,
-  ChevronLeftIcon,
-  ChevronRightIcon,
-  ChevronUpIcon,
-  Columns3Icon,
-  EllipsisIcon,
-} from "lucide-react";
+  PiCaretDownDuotone,
+  PiCaretDoubleLeftDuotone,
+  PiCaretDoubleRightDuotone,
+  PiCaretLeftDuotone,
+  PiCaretRightDuotone,
+  PiCaretUpDuotone,
+  PiColumnsDuotone,
+  PiDotsThreeDuotone,
+} from "react-icons/pi";
 import { useId, useState } from "react";
 import { useRouter } from "next/navigation";
 
@@ -290,7 +290,7 @@ export default function SourceFilesTable({
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
               <Button variant="outline" size="sm" className="text-xs">
-                <Columns3Icon
+                <PiColumnsDuotone
                   className="-ms-1 text-muted-foreground"
                   size={14}
                   aria-hidden="true"
@@ -361,14 +361,14 @@ export default function SourceFilesTable({
                           )}
                           {{
                             asc: (
-                              <ChevronUpIcon
+                              <PiCaretUpDuotone
                                 className="shrink-0 opacity-60"
                                 size={16}
                                 aria-hidden="true"
                               />
                             ),
                             desc: (
-                              <ChevronDownIcon
+                              <PiCaretDownDuotone
                                 className="shrink-0 opacity-60"
                                 size={16}
                                 aria-hidden="true"
@@ -492,7 +492,7 @@ export default function SourceFilesTable({
                   disabled={!table.getCanPreviousPage()}
                   aria-label="Go to first page"
                 >
-                  <ChevronFirstIcon size={16} aria-hidden="true" />
+                  <PiCaretDoubleLeftDuotone size={16} aria-hidden="true" />
                 </Button>
               </PaginationItem>
               {/* Previous page button */}
@@ -505,7 +505,7 @@ export default function SourceFilesTable({
                   disabled={!table.getCanPreviousPage()}
                   aria-label="Go to previous page"
                 >
-                  <ChevronLeftIcon size={16} aria-hidden="true" />
+                  <PiCaretLeftDuotone size={16} aria-hidden="true" />
                 </Button>
               </PaginationItem>
               {/* Next page button */}
@@ -518,7 +518,7 @@ export default function SourceFilesTable({
                   disabled={!table.getCanNextPage()}
                   aria-label="Go to next page"
                 >
-                  <ChevronRightIcon size={16} aria-hidden="true" />
+                  <PiCaretRightDuotone size={16} aria-hidden="true" />
                 </Button>
               </PaginationItem>
               {/* Last page button */}
@@ -531,7 +531,7 @@ export default function SourceFilesTable({
                   disabled={!table.getCanNextPage()}
                   aria-label="Go to last page"
                 >
-                  <ChevronLastIcon size={16} aria-hidden="true" />
+                  <PiCaretDoubleRightDuotone size={16} aria-hidden="true" />
                 </Button>
               </PaginationItem>
             </PaginationContent>
@@ -555,7 +555,7 @@ function RowActions() {
             aria-label="Edit item"
             onClick={(e) => e.stopPropagation()}
           >
-            <EllipsisIcon size={16} aria-hidden="true" />
+            <PiDotsThreeDuotone size={16} aria-hidden="true" />
           </Button>
         </div>
       </DropdownMenuTrigger>

--- a/features/workspace/source-files/SourceFilesTableFilter.tsx
+++ b/features/workspace/source-files/SourceFilesTableFilter.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { Filter, Plus, X } from "lucide-react";
+import { PiFunnelDuotone, PiPlusDuotone, PiXDuotone } from "react-icons/pi";
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -178,7 +178,7 @@ export default function SourceFilesTableFilter({
           size="sm"
           className="text-xs"
         >
-          <Filter
+          <PiFunnelDuotone
             className={cn(
               "h-2 w-2 mr-1",
               table.getState().columnFilters.length > 0
@@ -288,7 +288,7 @@ export default function SourceFilesTableFilter({
                     onClick={() => handleRemoveFilter(filter.id)}
                     className="p-0"
                   >
-                    <X className="h-4 w-4" />
+                    <PiXDuotone className="h-4 w-4" />
                     <span className="sr-only">Remove filter</span>
                   </Button>
                 </div>
@@ -306,7 +306,7 @@ export default function SourceFilesTableFilter({
             className="text-xs"
             onClick={handleAddFilter}
           >
-            <Plus className="h-4 w-4" />
+            <PiPlusDuotone className="h-4 w-4" />
             Add filter
           </Button>
           <Button

--- a/features/workspace/source-files/UploadSourceFiles.tsx
+++ b/features/workspace/source-files/UploadSourceFiles.tsx
@@ -1,17 +1,17 @@
 "use client";
 
 import {
-  AlertCircleIcon,
-  FileArchiveIcon,
-  FileIcon,
-  FileSpreadsheetIcon,
-  FileTextIcon,
-  FileUpIcon,
-  HeadphonesIcon,
-  ImageIcon,
-  VideoIcon,
-  XIcon,
-} from "lucide-react";
+  PiFileArchiveDuotone,
+  PiFileDuotone,
+  PiFileTextDuotone,
+  PiHeadphonesDuotone,
+  PiImageDuotone,
+  PiTableDuotone,
+  PiUploadSimpleDuotone,
+  PiVideoDuotone,
+  PiWarningCircleDuotone,
+  PiXDuotone,
+} from "react-icons/pi";
 
 import { formatBytes, useFileUpload } from "@/hooks/general/use-file-upload";
 import { Button } from "@/components/ui/button";
@@ -53,28 +53,28 @@ const getFileIcon = (file: { file: File | { type: string; name: string } }) => {
     fileName.endsWith(".doc") ||
     fileName.endsWith(".docx")
   ) {
-    return <FileTextIcon className="size-4 opacity-60" />;
+    return <PiFileTextDuotone className="size-4 opacity-60" />;
   } else if (
     fileType.includes("zip") ||
     fileType.includes("archive") ||
     fileName.endsWith(".zip") ||
     fileName.endsWith(".rar")
   ) {
-    return <FileArchiveIcon className="size-4 opacity-60" />;
+    return <PiFileArchiveDuotone className="size-4 opacity-60" />;
   } else if (
     fileType.includes("excel") ||
     fileName.endsWith(".xls") ||
     fileName.endsWith(".xlsx")
   ) {
-    return <FileSpreadsheetIcon className="size-4 opacity-60" />;
+    return <PiTableDuotone className="size-4 opacity-60" />;
   } else if (fileType.includes("video/")) {
-    return <VideoIcon className="size-4 opacity-60" />;
+    return <PiVideoDuotone className="size-4 opacity-60" />;
   } else if (fileType.includes("audio/")) {
-    return <HeadphonesIcon className="size-4 opacity-60" />;
+    return <PiHeadphonesDuotone className="size-4 opacity-60" />;
   } else if (fileType.startsWith("image/")) {
-    return <ImageIcon className="size-4 opacity-60" />;
+    return <PiImageDuotone className="size-4 opacity-60" />;
   }
-  return <FileIcon className="size-4 opacity-60" />;
+  return <PiFileDuotone className="size-4 opacity-60" />;
 };
 
 type UploadSourceFilesProps = {
@@ -146,7 +146,7 @@ export default function Component({
             className="bg-background mb-2 flex size-11 shrink-0 items-center justify-center rounded-full border"
             aria-hidden="true"
           >
-            <FileUpIcon className="size-4 opacity-60" />
+            <PiUploadSimpleDuotone className="size-4 opacity-60" />
           </div>
           <p className="mb-1.5 text-sm font-medium">Upload files</p>
           <p className="text-muted-foreground mb-2 text-xs">
@@ -167,7 +167,7 @@ export default function Component({
           className="text-destructive flex items-center gap-1 text-xs"
           role="alert"
         >
-          <AlertCircleIcon className="size-3 shrink-0" />
+          <PiWarningCircleDuotone className="size-3 shrink-0" />
           <span>{errors[0]}</span>
         </div>
       )}
@@ -209,7 +209,7 @@ export default function Component({
                 onClick={() => removeFile(file.id)}
                 aria-label="Remove file"
               >
-                <XIcon className="size-4" aria-hidden="true" />
+                <PiXDuotone className="size-4" aria-hidden="true" />
               </Button>
             </div>
           ))}


### PR DESCRIPTION
Replace all Lucide icons with Phosphor duotone icons from react-icons/pi across the codebase. Updated 32+ files including dashboard, source-files, projects, products, departments, settings, bookmarks, and archive components.