### PR TITLE
feat: add resources section with marketing pages

### DIFF
--- a/app/resources/blogs/page.tsx
+++ b/app/resources/blogs/page.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import MarketingHeader from "@/features/marketing/marketing-header";
+import BlogsSection from "@/features/resources/blogs/BlogsSection";
+import FooterSection from "@/features/marketing/landing-page/FooterSection";
+
+export default function BlogsPage() {
+  return (
+    <div className="flex flex-col items-center justify-center min-h-screen relative bg-accent/50">
+      <MarketingHeader />
+      <div className="w-full pt-32">
+        <BlogsSection />
+      </div>
+      <div className="w-full">
+        <FooterSection />
+      </div>
+    </div>
+  );
+}

--- a/app/resources/page.tsx
+++ b/app/resources/page.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import MarketingHeader from "@/features/marketing/marketing-header";
+import ResourcesHub from "@/features/resources/ResourcesHub";
+import FooterSection from "@/features/marketing/landing-page/FooterSection";
+
+export default function ResourcesPage() {
+  return (
+    <div className="flex flex-col items-center justify-center min-h-screen relative bg-accent/50">
+      <MarketingHeader />
+      <div className="w-full pt-32">
+        <ResourcesHub />
+      </div>
+      <div className="w-full">
+        <FooterSection />
+      </div>
+    </div>
+  );
+}

--- a/app/resources/standards-symbols/page.tsx
+++ b/app/resources/standards-symbols/page.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import MarketingHeader from "@/features/marketing/marketing-header";
+import StandardsSymbolsSection from "@/features/resources/standards/StandardsSymbolsSection";
+import FooterSection from "@/features/marketing/landing-page/FooterSection";
+
+export default function StandardsSymbolsPage() {
+  return (
+    <div className="flex flex-col items-center justify-center min-h-screen relative bg-accent/50">
+      <MarketingHeader />
+      <div className="w-full pt-32">
+        <StandardsSymbolsSection />
+      </div>
+      <div className="w-full">
+        <FooterSection />
+      </div>
+    </div>
+  );
+}

--- a/app/resources/templates/page.tsx
+++ b/app/resources/templates/page.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import MarketingHeader from "@/features/marketing/marketing-header";
+import TemplatesSection from "@/features/resources/templates/TemplatesSection";
+import FooterSection from "@/features/marketing/landing-page/FooterSection";
+
+export default function TemplatesPage() {
+  return (
+    <div className="flex flex-col items-center justify-center min-h-screen relative bg-accent/50">
+      <MarketingHeader />
+      <div className="w-full pt-32">
+        <TemplatesSection />
+      </div>
+      <div className="w-full">
+        <FooterSection />
+      </div>
+    </div>
+  );
+}

--- a/app/resources/toolkits/page.tsx
+++ b/app/resources/toolkits/page.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import MarketingHeader from "@/features/marketing/marketing-header";
+import ToolkitsPlaceholder from "@/features/resources/toolkits/ToolkitsPlaceholder";
+import FooterSection from "@/features/marketing/landing-page/FooterSection";
+
+export default function ToolkitsPage() {
+  return (
+    <div className="flex flex-col items-center justify-center min-h-screen relative bg-accent/50">
+      <MarketingHeader />
+      <div className="w-full pt-32">
+        <ToolkitsPlaceholder />
+      </div>
+      <div className="w-full">
+        <FooterSection />
+      </div>
+    </div>
+  );
+}

--- a/features/marketing/marketing-header.tsx
+++ b/features/marketing/marketing-header.tsx
@@ -3,6 +3,12 @@
 import * as React from "react";
 import Link from "next/link";
 import { CircleCheckIcon, CircleHelpIcon, CircleIcon } from "lucide-react";
+import {
+  PiFileTextDuotone,
+  PiSquaresFourDuotone,
+  PiNewspaperDuotone,
+  PiWrenchDuotone,
+} from "react-icons/pi";
 import { cn } from "@/lib/utils";
 
 import { useIsMobile } from "@/hooks/general/use-mobile";
@@ -20,41 +26,30 @@ import { useRouter } from "next/navigation";
 import { useAuth } from "react-oidc-context";
 import Image from "next/image";
 
-const components: { title: string; href: string; description: string }[] = [
+const resourceLinks = [
   {
-    title: "Alert Dialog",
-    href: "/docs/primitives/alert-dialog",
-    description:
-      "A modal dialog that interrupts the user with important content and expects a response.",
+    title: "Templates",
+    href: "/resources/templates",
+    description: "Compliance checklists and templates.",
+    icon: PiFileTextDuotone,
   },
   {
-    title: "Hover Card",
-    href: "/docs/primitives/hover-card",
-    description:
-      "For sighted users to preview content available behind a link.",
+    title: "Standards & Symbols",
+    href: "/resources/standards-symbols",
+    description: "ISO documents and symbol library.",
+    icon: PiSquaresFourDuotone,
   },
   {
-    title: "Progress",
-    href: "/docs/primitives/progress",
-    description:
-      "Displays an indicator showing the completion progress of a task, typically displayed as a progress bar.",
+    title: "Blogs & News",
+    href: "/resources/blogs",
+    description: "Regulatory updates and insights.",
+    icon: PiNewspaperDuotone,
   },
   {
-    title: "Scroll-area",
-    href: "/docs/primitives/scroll-area",
-    description: "Visually or semantically separates content.",
-  },
-  {
-    title: "Tabs",
-    href: "/docs/primitives/tabs",
-    description:
-      "A set of layered sections of content—known as tab panels—that are displayed one at a time.",
-  },
-  {
-    title: "Tooltip",
-    href: "/docs/primitives/tooltip",
-    description:
-      "A popup that displays information related to an element when the element receives keyboard focus or the mouse hovers over it.",
+    title: "Free Tools",
+    href: "/resources/toolkits",
+    description: "Coming soon.",
+    icon: PiWrenchDuotone,
   },
 ];
 
@@ -119,37 +114,33 @@ export default function MarketingHeader() {
             <NavigationMenuList className="flex-wrap">
               <NavigationMenuItem>
                 <NavigationMenuTrigger>Resources</NavigationMenuTrigger>
-                <NavigationMenuContent>
-                  <ul className="grid gap-2 md:w-[400px] lg:w-[500px] lg:grid-cols-[.75fr_1fr]">
-                    <li className="row-span-3">
+                <NavigationMenuContent className="">
+                  <ul className="grid gap-2 md:w-[400px] lg:w-[600px] lg:grid-cols-[.75fr_1fr]">
+                    <li className="row-span-4">
                       <NavigationMenuLink asChild>
-                        <a
+                        <Link
                           className="from-muted/50 to-muted flex h-full w-full flex-col justify-end rounded-md bg-linear-to-b p-4 no-underline outline-hidden transition-all duration-200 select-none focus:shadow-md md:p-6"
-                          href="/"
+                          href="/resources"
                         >
                           <div className="mb-2 text-lg font-medium sm:mt-4">
-                            shadcn/ui
+                            Resources Hub
                           </div>
                           <p className="text-muted-foreground text-sm leading-tight">
-                            Beautifully designed components built with Tailwind
-                            CSS.
+                            Compliance resources, templates, and tools.
                           </p>
-                        </a>
+                        </Link>
                       </NavigationMenuLink>
                     </li>
-                    <ListItem href="/docs" title="Introduction">
-                      Re-usable components built using Radix UI and Tailwind
-                      CSS.
-                    </ListItem>
-                    <ListItem href="/docs/installation" title="Installation">
-                      How to install dependencies and structure your app.
-                    </ListItem>
-                    <ListItem
-                      href="/docs/primitives/typography"
-                      title="Typography"
-                    >
-                      Styles for headings, paragraphs, lists...etc
-                    </ListItem>
+                    {resourceLinks.map((link) => (
+                      <ListItem
+                        key={link.title}
+                        href={link.href}
+                        title={link.title}
+                        icon={link.icon}
+                      >
+                        {link.description}
+                      </ListItem>
+                    ))}
                   </ul>
                 </NavigationMenuContent>
               </NavigationMenuItem>
@@ -157,15 +148,18 @@ export default function MarketingHeader() {
                 <NavigationMenuTrigger>Pricing</NavigationMenuTrigger>
                 <NavigationMenuContent>
                   <ul className="grid gap-2 sm:w-[400px] md:w-[500px] md:grid-cols-2 lg:w-[600px]">
-                    {components.map((component) => (
-                      <ListItem
-                        key={component.title}
-                        title={component.title}
-                        href={component.href}
-                      >
-                        {component.description}
-                      </ListItem>
-                    ))}
+                    <ListItem href="/pricing" title="Pricing Plans">
+                      Flexible pricing options for teams of all sizes.
+                    </ListItem>
+                    <ListItem href="/pricing#enterprise" title="Enterprise">
+                      Custom solutions for large organizations.
+                    </ListItem>
+                    <ListItem href="/pricing#faq" title="FAQ">
+                      Answers to common pricing questions.
+                    </ListItem>
+                    <ListItem href="/contact" title="Contact Sales">
+                      Get in touch for personalized pricing quotes.
+                    </ListItem>
                   </ul>
                 </NavigationMenuContent>
               </NavigationMenuItem>
@@ -207,16 +201,27 @@ function ListItem({
   title,
   children,
   href,
+  icon: Icon,
   ...props
-}: React.ComponentPropsWithoutRef<"li"> & { href: string }) {
+}: React.ComponentPropsWithoutRef<"li"> & {
+  href: string;
+  icon?: React.ElementType;
+}) {
   return (
     <li {...props}>
       <NavigationMenuLink asChild>
-        <Link href={href}>
-          <div className="text-sm leading-none font-medium">{title}</div>
-          <p className="text-muted-foreground line-clamp-2 text-sm leading-snug">
-            {children}
-          </p>
+        <Link href={href} className="flex flex-row items-center gap-3">
+          {Icon && (
+            <div className="flex-shrink-0 flex items-center justify-center size-10 rounded-lg bg-accent mt-0.5">
+              <Icon className="size-5 text-foreground" />
+            </div>
+          )}
+          <div className="flex flex-col">
+            <div className="text-sm leading-none font-medium">{title}</div>
+            <p className="text-muted-foreground line-clamp-2 text-sm leading-snug">
+              {children}
+            </p>
+          </div>
         </Link>
       </NavigationMenuLink>
     </li>

--- a/features/resources/ResourcesHub.tsx
+++ b/features/resources/ResourcesHub.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
+import { useTheme } from "next-themes";
+import { useEffect, useState } from "react";
+import { PiFilesDuotone, PiBookOpenDuotone, PiNewspaperDuotone, PiWrenchDuotone } from "react-icons/pi";
+import Link from "next/link";
+
+const resources = [
+  {
+    id: "templates",
+    title: "Templates",
+    description: "Access battle-tested checklists and templates designed by regulatory experts. Stop building documents from scratch.",
+    icon: PiFilesDuotone,
+    href: "/resources/templates",
+  },
+  {
+    id: "standards-symbols",
+    title: "Standards & Symbols",
+    description: "Complete ISO standards library and standardized medical device symbols for universal compliance understanding.",
+    icon: PiBookOpenDuotone,
+    href: "/resources/standards-symbols",
+  },
+  {
+    id: "blogs",
+    title: "Blogs",
+    description: "Expert analysis of regulatory shifts and industry insights to help you stay ahead of compliance changes.",
+    icon: PiNewspaperDuotone,
+    href: "/resources/blogs",
+  },
+  {
+    id: "toolkits",
+    title: "Toolkits",
+    description: "Free compliance tools to streamline your labeling workflow. Coming soon!",
+    icon: PiWrenchDuotone,
+    href: "/resources/toolkits",
+  },
+];
+
+export default function ResourcesHub() {
+  const { resolvedTheme } = useTheme();
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  const badgeVariant = mounted && resolvedTheme === "dark" ? "outline" : "white";
+
+  return (
+    <div className="w-full mt-20 mb-20 pointer-events-auto">
+      <div className="max-w-6xl mx-auto mb-8 px-4">
+        <Badge variant={badgeVariant} className="mb-8 z-60 dark:px-2 dark:py-0.5">
+          <span className="font-medium">Resources</span>
+        </Badge>
+        <div className="w-full flex flex-col md:flex-row items-start gap-4">
+          <h2 className="text-4xl md:text-5xl font-medium">
+            Everything You Need for Compliance
+          </h2>
+        </div>
+      </div>
+
+      <div className="max-w-6xl mx-auto px-4">
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+          {resources.map((resource) => (
+            <Card key={resource.id} className="hover:shadow-lg transition-shadow duration-300">
+              <CardHeader>
+                <div className="flex items-center gap-3">
+                  <div className="p-2 rounded-lg bg-primary/10">
+                    <resource.icon className="w-6 h-6 text-primary" />
+                  </div>
+                  <CardTitle className="text-xl">{resource.title}</CardTitle>
+                </div>
+              </CardHeader>
+              <CardContent>
+                <CardDescription className="text-base">
+                  {resource.description}
+                </CardDescription>
+              </CardContent>
+              <CardFooter>
+                <Link href={resource.href}>
+                  <Button variant="outline">Learn More</Button>
+                </Link>
+              </CardFooter>
+            </Card>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/features/resources/blogs/BlogsSection.tsx
+++ b/features/resources/blogs/BlogsSection.tsx
@@ -1,0 +1,151 @@
+"use client";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { useTheme } from "next-themes";
+import { useEffect, useState } from "react";
+import { PiNewspaperDuotone, PiArrowRightDuotone, PiCalendarDuotone } from "react-icons/pi";
+
+const blogPosts = [
+  {
+    title: "Understanding FDA's New Labeling Requirements",
+    excerpt: "A comprehensive guide to the latest FDA labeling guidelines and how they impact your medical device documentation.",
+    date: "2024-12-15",
+    category: "Regulatory Update",
+  },
+  {
+    title: "EU MDR Compliance: A Step-by-Step Approach",
+    excerpt: "Navigate the complexities of European Medical Device Regulation with this practical implementation guide.",
+    date: "2024-12-01",
+    category: "Compliance Guide",
+  },
+  {
+    title: "ISO 15223-1:2021 Key Changes Explained",
+    excerpt: "Understanding the important updates to the international standard for medical device symbols.",
+    date: "2024-11-20",
+    category: "Standards",
+  },
+];
+
+const newsUpdates = [
+  {
+    title: "FDA Announces Updated UDI Compliance Deadlines",
+    excerpt: "New timeline for Unique Device Identifier requirements gives manufacturers additional flexibility.",
+    date: "2024-12-10",
+    source: "FDA",
+  },
+  {
+    title: "EU MDR Implementation Extended for Certain Devices",
+    excerpt: "European Commission grants transition period for specific medical device categories.",
+    date: "2024-12-05",
+    source: "EU Commission",
+  },
+  {
+    title: "New ISO Standard for Digital Labeling Published",
+    excerpt: "International Organization for Standardization releases guidance for electronic labeling.",
+    date: "2024-11-28",
+    source: "ISO",
+  },
+];
+
+export default function BlogsSection() {
+  const { resolvedTheme } = useTheme();
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  const badgeVariant = mounted && resolvedTheme === "dark" ? "outline" : "white";
+
+  return (
+    <div className="w-full mt-10 mb-20 pointer-events-auto">
+      {/* Part 1: Navigate Compliance with Clarity */}
+      <div className="max-w-6xl mx-auto mb-16 px-4">
+        <Badge variant={badgeVariant} className="mb-8 z-60 dark:px-2 dark:py-0.5">
+          <span className="font-medium">Blogs</span>
+        </Badge>
+        <div className="w-full flex flex-col md:flex-row items-start gap-4 mb-6">
+          <h2 className="text-4xl md:text-5xl font-medium">
+            Navigate Compliance with Clarity and Confidence
+          </h2>
+        </div>
+        <p className="text-lg text-muted-foreground max-w-3xl mb-8">
+          The medical device landscape is constantly evolving, making compliant labeling a continuous
+          challenge. Our blog and news section provides clear, expert analysis of the latest regulatory
+          shifts, giving you the critical knowledge to make informed decisions and stay ahead of
+          enforcement.
+        </p>
+
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+          {blogPosts.map((post, index) => (
+            <Card key={index} className="hover:shadow-lg transition-shadow duration-300">
+              <CardHeader>
+                <div className="flex items-center gap-2 mb-2">
+                  <Badge variant="outline">{post.category}</Badge>
+                </div>
+                <CardTitle className="text-lg leading-tight">{post.title}</CardTitle>
+                <CardDescription className="flex items-center gap-1 mt-2">
+                  <PiCalendarDuotone className="w-4 h-4" />
+                  {post.date}
+                </CardDescription>
+              </CardHeader>
+              <CardContent>
+                <CardDescription className="text-base mb-4">
+                  {post.excerpt}
+                </CardDescription>
+                <Button variant="link" className="px-0">
+                  Read More
+                  <PiArrowRightDuotone className="w-4 h-4 ml-1" />
+                </Button>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      </div>
+
+      {/* Part 2: Decoding Regulatory Change */}
+      <div className="max-w-6xl mx-auto px-4">
+        <div className="border-t pt-16">
+          <div className="w-full flex flex-col md:flex-row items-start gap-4 mb-6">
+            <h2 className="text-4xl md:text-5xl font-medium">
+              Decoding Regulatory Change
+            </h2>
+          </div>
+          <p className="text-lg text-muted-foreground max-w-3xl mb-8">
+            Compliance is complex, but understanding it shouldn&apos;t be. We break down the latest
+            regulatory announcements from bodies worldwide, transforming complicated rules into clear,
+            actionable steps for your labeling teams. Get the crucial intelligence you need to
+            future-proof your product documentation.
+          </p>
+
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+            {newsUpdates.map((news, index) => (
+              <Card key={index} className="hover:shadow-md transition-shadow">
+                <CardHeader>
+                  <div className="flex items-center justify-between mb-2">
+                    <Badge variant="secondary">{news.source}</Badge>
+                  </div>
+                  <CardTitle className="text-lg leading-tight">{news.title}</CardTitle>
+                  <CardDescription className="flex items-center gap-1 mt-2">
+                    <PiCalendarDuotone className="w-4 h-4" />
+                    {news.date}
+                  </CardDescription>
+                </CardHeader>
+                <CardContent>
+                  <CardDescription className="text-base mb-4">
+                    {news.excerpt}
+                  </CardDescription>
+                  <Button variant="outline" size="sm">
+                    Read Full Article
+                  </Button>
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/features/resources/standards/StandardsSymbolsSection.tsx
+++ b/features/resources/standards/StandardsSymbolsSection.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { useTheme } from "next-themes";
+import { useEffect, useState } from "react";
+import { PiImagesDuotone, PiFileTextDuotone, PiLinkDuotone } from "react-icons/pi";
+
+const symbols = [
+  {
+    title: "Global Compliance Iconography",
+    description: "Ensure universal understanding and regulatory adherence with our comprehensive library of standardized medical device symbols.",
+    usage: "LinkedIn Ref, Cue Cards & Usage",
+  },
+];
+
+const isoDocuments = [
+  {
+    title: "ISO 15223-1:2021",
+    description: "Symbols to be used with medical devices, labels, and labeling.",
+  },
+  {
+    title: "ISO 7000:2014",
+    description: "Graphical symbols for use on equipment - Registered symbols.",
+  },
+  {
+    title: "ISO 7001:2008",
+    description: "Public information symbols.",
+  },
+  {
+    title: "ISO 7010:2019",
+    description: "Graphical symbols - Safety colors and safety signs.",
+  },
+];
+
+export default function StandardsSymbolsSection() {
+  const { resolvedTheme } = useTheme();
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  const badgeVariant = mounted && resolvedTheme === "dark" ? "outline" : "white";
+
+  return (
+    <div className="w-full mt-10 mb-20 pointer-events-auto">
+      <div className="max-w-6xl mx-auto mb-8 px-4">
+        <Badge variant={badgeVariant} className="mb-8 z-60 dark:px-2 dark:py-0.5">
+          <span className="font-medium">Standards & Symbols</span>
+        </Badge>
+        <div className="w-full flex flex-col md:flex-row items-start gap-4">
+          <h2 className="text-4xl md:text-5xl font-medium">
+            Standards & Regulatory Symbols
+          </h2>
+        </div>
+      </div>
+
+      <div className="max-w-6xl mx-auto px-4">
+        <Tabs defaultValue="symbols" className="w-full">
+          <TabsList className="grid w-full grid-cols-2 max-w-md">
+            <TabsTrigger value="symbols">Symbol Library</TabsTrigger>
+            <TabsTrigger value="iso">ISO Documents</TabsTrigger>
+          </TabsList>
+
+          <TabsContent value="symbols" className="mt-6">
+            <div className="space-y-6">
+              {symbols.map((symbol, index) => (
+                <Card key={index}>
+                  <CardHeader>
+                    <CardTitle className="flex items-center gap-2">
+                      <PiImagesDuotone className="w-6 h-6 text-primary" />
+                      {symbol.title}
+                    </CardTitle>
+                    <CardDescription className="text-base">
+                      {symbol.description}
+                    </CardDescription>
+                  </CardHeader>
+                  <CardContent>
+                    <div className="flex items-center gap-2 p-4 bg-muted rounded-lg">
+                      <PiLinkDuotone className="w-5 h-5 text-muted-foreground" />
+                      <span className="text-sm font-medium">{symbol.usage}</span>
+                    </div>
+                    <div className="mt-4">
+                      <Button variant="outline">
+                        Browse Symbol Library
+                      </Button>
+                    </div>
+                  </CardContent>
+                </Card>
+              ))}
+            </div>
+          </TabsContent>
+
+          <TabsContent value="iso" className="mt-6">
+            <Card>
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2">
+                  <PiFileTextDuotone className="w-6 h-6 text-primary" />
+                  ISO Documents Repository
+                </CardTitle>
+                <CardDescription className="text-base">
+                  Access the complete, up-to-date library of critical ISO standards relevant to
+                  medical device labeling and compliance, all in one centralized location.
+                </CardDescription>
+              </CardHeader>
+              <CardContent>
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                  {isoDocuments.map((doc, index) => (
+                    <div
+                      key={index}
+                      className="p-4 border rounded-lg hover:bg-muted/50 transition-colors"
+                    >
+                      <h4 className="font-semibold">{doc.title}</h4>
+                      <p className="text-sm text-muted-foreground mt-1">
+                        {doc.description}
+                      </p>
+                      <Button variant="link" size="sm" className="mt-2 px-0">
+                        View Document
+                      </Button>
+                    </div>
+                  ))}
+                </div>
+              </CardContent>
+            </Card>
+          </TabsContent>
+        </Tabs>
+      </div>
+    </div>
+  );
+}

--- a/features/resources/templates/TemplatesSection.tsx
+++ b/features/resources/templates/TemplatesSection.tsx
@@ -1,0 +1,128 @@
+"use client";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion";
+import { useTheme } from "next-themes";
+import { useEffect, useState } from "react";
+import { PiDownloadDuotone, PiFileTextDuotone, PiCheckCircleDuotone } from "react-icons/pi";
+
+const templates = [
+  {
+    category: "Checklist & Templates",
+    items: [
+      {
+        title: "Gap Assessment Checklist - Basic",
+        description: "Identify compliance gaps in your labeling process with this comprehensive checklist.",
+        type: "checklist",
+      },
+      {
+        title: "Validation Template (CSV)",
+        description: "Structured template for validating label data and ensuring accuracy.",
+        type: "template",
+      },
+      {
+        title: "Project Timeline & Gantt Template",
+        description: "Plan and track your labeling projects with this visual timeline template.",
+        type: "template",
+      },
+      {
+        title: "Standard File Naming Nomenclatures",
+        description: "Consistent naming conventions for medical device documentation.",
+        type: "guide",
+      },
+    ],
+  },
+];
+
+const tags = ["All", "Checklist", "Template", "Guide", "Validation"];
+
+export default function TemplatesSection() {
+  const { resolvedTheme } = useTheme();
+  const [mounted, setMounted] = useState(false);
+  const [activeTag, setActiveTag] = useState("All");
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  const badgeVariant = mounted && resolvedTheme === "dark" ? "outline" : "white";
+
+  return (
+    <div className="w-full mt-10 mb-20 pointer-events-auto">
+      <div className="max-w-6xl mx-auto mb-8 px-4">
+        <Badge variant={badgeVariant} className="mb-8 z-60 dark:px-2 dark:py-0.5">
+          <span className="font-medium">Templates</span>
+        </Badge>
+        <div className="w-full flex flex-col md:flex-row items-start gap-4">
+          <h2 className="text-4xl md:text-5xl font-medium">
+            Practical Toolkits & Templates
+          </h2>
+        </div>
+        <p className="mt-4 text-lg text-muted-foreground max-w-3xl">
+          The Regulatory Toolkit: Build Compliance Faster. Gain immediate access to a library of
+          battle-tested templates and checklists, designed by regulatory experts. Stop building
+          documents from scratch; simply leverage these verified assets for your medical device
+          documentation.
+        </p>
+      </div>
+
+      {/* Tags */}
+      <div className="max-w-6xl mx-auto px-4 mb-8">
+        <div className="flex flex-wrap gap-2">
+          {tags.map((tag) => (
+            <Button
+              key={tag}
+              variant={activeTag === tag ? "default" : "outline"}
+              size="sm"
+              onClick={() => setActiveTag(tag)}
+              className="rounded-full"
+            >
+              {tag}
+            </Button>
+          ))}
+        </div>
+      </div>
+
+      {/* Templates Accordion */}
+      <div className="max-w-6xl mx-auto px-4">
+        <Accordion type="single" defaultValue="checklist-templates" className="w-full">
+          {templates.map((section, index) => (
+            <AccordionItem key={index} value={section.category.toLowerCase().replace(/\s+/g, "-")}>
+              <AccordionTrigger className="text-lg font-semibold">
+                <div className="flex items-center gap-2">
+                  <PiCheckCircleDuotone className="w-5 h-5" />
+                  {section.category}
+                </div>
+              </AccordionTrigger>
+              <AccordionContent>
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-4 pt-4">
+                  {section.items.map((item, itemIndex) => (
+                    <Card key={itemIndex} className="hover:shadow-md transition-shadow">
+                      <CardHeader className="pb-2">
+                        <CardTitle className="text-base flex items-start gap-2">
+                          <PiFileTextDuotone className="w-5 h-5 mt-0.5 text-primary" />
+                          {item.title}
+                        </CardTitle>
+                      </CardHeader>
+                      <CardContent>
+                        <CardDescription className="mb-4">
+                          {item.description}
+                        </CardDescription>
+                        <Button variant="outline" size="sm" className="w-full">
+                          <PiDownloadDuotone className="w-4 h-4 mr-2" />
+                          Download
+                        </Button>
+                      </CardContent>
+                    </Card>
+                  ))}
+                </div>
+              </AccordionContent>
+            </AccordionItem>
+          ))}
+        </Accordion>
+      </div>
+    </div>
+  );
+}

--- a/features/resources/toolkits/ToolkitsPlaceholder.tsx
+++ b/features/resources/toolkits/ToolkitsPlaceholder.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { useTheme } from "next-themes";
+import { useEffect, useState } from "react";
+import { PiWrenchDuotone, PiClockDuotone } from "react-icons/pi";
+
+const upcomingTools = [
+  {
+    title: "Label Generator",
+    description: "Create compliant medical device labels with automatic symbol inclusion and regulatory validation.",
+    status: "In Development",
+  },
+  {
+    title: "Compliance Checker",
+    description: "Automated validation of your labels against FDA, EU MDR, and other regulatory requirements.",
+    status: "Planned",
+  },
+  {
+    title: "Symbol Library Manager",
+    description: "Organize and manage your organization's symbol library with version control and approval workflows.",
+    status: "Planned",
+  },
+];
+
+export default function ToolkitsPlaceholder() {
+  const { resolvedTheme } = useTheme();
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  const badgeVariant = mounted && resolvedTheme === "dark" ? "outline" : "white";
+
+  return (
+    <div className="w-full mt-10 mb-20 pointer-events-auto">
+      <div className="max-w-6xl mx-auto mb-8 px-4">
+        <Badge variant={badgeVariant} className="mb-8 z-60 dark:px-2 dark:py-0.5">
+          <span className="font-medium">Toolkits</span>
+        </Badge>
+        <div className="w-full flex flex-col md:flex-row items-start gap-4">
+          <h2 className="text-4xl md:text-5xl font-medium">
+            Free Compliance Tools
+          </h2>
+        </div>
+        <p className="mt-4 text-lg text-muted-foreground max-w-3xl">
+          Powerful tools to streamline your labeling workflow. All tools are free to use and designed
+          specifically for medical device regulatory compliance.
+        </p>
+      </div>
+
+      <div className="max-w-6xl mx-auto px-4">
+        <Card className="bg-muted/50 border-dashed">
+          <CardContent className="flex flex-col items-center justify-center py-16">
+            <PiWrenchDuotone className="w-16 h-16 text-muted-foreground/50 mb-4" />
+            <h3 className="text-2xl font-semibold mb-2">Coming Soon</h3>
+            <p className="text-muted-foreground text-center max-w-md">
+              We&apos;re working on building powerful free tools to help you with your compliance needs.
+              Stay tuned for updates!
+            </p>
+          </CardContent>
+        </Card>
+
+        {/* Upcoming Tools Preview */}
+        <div className="mt-12">
+          <h3 className="text-2xl font-semibold mb-6">What&apos;s Coming</h3>
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+            {upcomingTools.map((tool, index) => (
+              <Card key={index}>
+                <CardHeader>
+                  <CardTitle className="flex items-center gap-2">
+                    <PiClockDuotone className="w-5 h-5 text-muted-foreground" />
+                    {tool.title}
+                  </CardTitle>
+                  <CardDescription className="text-sm text-muted-foreground">
+                    {tool.status}
+                  </CardDescription>
+                </CardHeader>
+                <CardContent>
+                  <CardDescription className="text-base">
+                    {tool.description}
+                  </CardDescription>
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
This PR adds a Resources section to the application with the following changes:

- Resources Hub page with overview of all available resources
- Templates page with downloadable compliance checklists and templates
- Standards & Symbols page with ISO document library and symbol gallery
- Blogs & News page with regulatory updates and industry articles
- Toolkits placeholder page for upcoming free compliance tools
- Updated marketing header navigation with new Resources menu and improved Pricing menu with icons

**Note: These are just draft pages, we will update the UI and linking in the next few days.**