### PR TITLE
feat: add count field to barcodes

### DIFF
--- a/app/(app)/products/[productId]/symbols-graphics/page.tsx
+++ b/app/(app)/products/[productId]/symbols-graphics/page.tsx
@@ -19,6 +19,7 @@ interface SymbolGraphicItem {
   text_present: boolean;
   label_presence: string[];
   entity: string;
+  count?: number;
   _isFromDiff?: boolean;
   _isRemovedFromDiff?: boolean;
   _originalIndex?: number;
@@ -201,6 +202,7 @@ export default function Page() {
     componentDescription: item.description,
     componentImage: item.image,
     presentOnLabels: item.label_presence,
+    count: item.count,
     _isFromDiff: item._isFromDiff,
     _isRemovedFromDiff: item._isRemovedFromDiff,
     _originalIndex: item._originalIndex,

--- a/features/workspace/products/product/graphics-other-components/AddBarcodesDialog.tsx
+++ b/features/workspace/products/product/graphics-other-components/AddBarcodesDialog.tsx
@@ -54,6 +54,7 @@ type FormData = {
   componentDescription: string;
   labelPresence: Tag[];
   image: FileWithPreview | null;
+  count: number;
 };
 
 export default function AddBarcodesDialog({
@@ -83,6 +84,7 @@ export default function AddBarcodesDialog({
       barcodeTypeInput: "",
       labelPresence: [],
       image: null,
+      count: 1,
     },
   });
 
@@ -124,6 +126,7 @@ export default function AddBarcodesDialog({
               : JSON.parse(labelPresence || "[]")
             ).map((tag: Tag) => tag.text),
             description: data.componentDescription,
+            count: data.count,
           },
         ],
       };
@@ -317,6 +320,24 @@ export default function AddBarcodesDialog({
                   Press Enter to add a label type. You can add multiple label
                   types.
                 </p>
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor={`${id}-count`}>Count</Label>
+                <Input
+                  id={`${id}-count`}
+                  type="number"
+                  min={1}
+                  {...register("count", {
+                    required: "Count is required",
+                    min: { value: 1, message: "Count must be at least 1" },
+                    valueAsNumber: true,
+                  })}
+                  defaultValue={1}
+                />
+                {errors.count && (
+                  <p className="text-xs text-red-500">{errors.count.message}</p>
+                )}
               </div>
             </div>
           </div>

--- a/features/workspace/products/product/graphics-other-components/EditBarcodesDialog.tsx
+++ b/features/workspace/products/product/graphics-other-components/EditBarcodesDialog.tsx
@@ -54,6 +54,7 @@ type Item = {
   componentImage: string;
   description: string;
   labelPresence: string[];
+  count?: number;
 };
 
 type FormData = {
@@ -62,6 +63,7 @@ type FormData = {
   componentDescription: string;
   labelPresence: Tag[];
   image: FileWithPreview | null;
+  count: number;
 };
 
 export default function EditBarcodesDialog({
@@ -107,6 +109,7 @@ export default function EditBarcodesDialog({
         text: label,
       })),
       image: null,
+      count: barcode.count ?? 1,
     },
   });
 
@@ -129,6 +132,7 @@ export default function EditBarcodesDialog({
         text: label,
       })),
       image: null,
+      count: barcode.count ?? 1,
     });
     setLabelPresence(
       barcode.labelPresence.map((label, index) => ({
@@ -180,6 +184,7 @@ export default function EditBarcodesDialog({
           entity: "Barcodes",
           description: data.componentDescription,
           label_presence: labelPresence.map((tag: Tag) => tag.text),
+          count: data.count,
         },
       };
 
@@ -370,6 +375,23 @@ export default function EditBarcodesDialog({
                   Press Enter to add a label type. You can add multiple label
                   types.
                 </p>
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor={`${id}-count`}>Count</Label>
+                <Input
+                  id={`${id}-count`}
+                  type="number"
+                  min={1}
+                  {...register("count", {
+                    required: "Count is required",
+                    min: { value: 1, message: "Count must be at least 1" },
+                    valueAsNumber: true,
+                  })}
+                />
+                {errors.count && (
+                  <p className="text-xs text-red-500">{errors.count.message}</p>
+                )}
               </div>
             </div>
           </div>

--- a/features/workspace/products/product/graphics-other-components/SchematicsSymbolsTabs.tsx
+++ b/features/workspace/products/product/graphics-other-components/SchematicsSymbolsTabs.tsx
@@ -41,6 +41,7 @@ interface BarcodesData {
   componentDescription: string;
   componentImage: string;
   presentOnLabels: string[];
+  count?: number;
 }
 
 interface OtherComponentData {

--- a/features/workspace/products/product/graphics-other-components/SymbolsGraphicsPageBarcodesTable.tsx
+++ b/features/workspace/products/product/graphics-other-components/SymbolsGraphicsPageBarcodesTable.tsx
@@ -55,6 +55,7 @@ import {
   PiCaretCircleDownDuotone,
   PiDotsThreeCircleDuotone,
   PiBarcodeDuotone,
+  PiHashDuotone,
 } from "react-icons/pi";
 import EditBarcodesDialog from "./EditBarcodesDialog";
 import DeleteSymbolsSchematicsDialog from "./DeleteSymbolsSchematicsDialog";
@@ -66,6 +67,7 @@ type Item = {
   componentImage: string;
   note?: string;
   presentOnLabels: string[];
+  count?: number;
   _isFromDiff?: boolean;
   _isRemovedFromDiff?: boolean;
   _originalIndex?: number;
@@ -338,6 +340,38 @@ const columns: ColumnDef<Item>[] = [
     },
   },
   {
+    accessorKey: "count",
+    enableSorting: true,
+    header: ({ column }) => (
+      <SortableHeader
+        column={column}
+        title="Count"
+        icon={PiHashDuotone}
+      />
+    ),
+    cell: ({ row, table }) => {
+      const meta = table.options.meta as any;
+      const count = row.getValue("count") as number;
+      const originalIndex = row.original._originalIndex ?? row.index;
+      const diff = meta?.isRedlineView
+        ? meta.getDiff?.(`symbols_graphics.data[${originalIndex}].count`)
+        : null;
+
+      const displayCount = count ?? 1; // Default to 1 if count is not set
+
+      return diff ? (
+        <RedlineCell
+          value={displayCount}
+          diff={diff}
+          formatFn={(v) => <span className="font-medium">{v}</span>}
+        />
+      ) : (
+        <span className="font-medium">{displayCount}</span>
+      );
+    },
+    size: 80,
+  },
+  {
     id: "actions",
     header: () => <span className="sr-only">Actions</span>,
     cell: ({ row, table }) => (
@@ -599,6 +633,7 @@ function RowActions({
     description: item.componentDescription,
     componentImage: item.componentImage,
     labelPresence: item.presentOnLabels,
+    count: item.count,
   };
 
   return (


### PR DESCRIPTION
Adds a count field to barcodes in the symbols and graphics section.

- Count input field in Add/Edit barcode dialogs
- Count column in barcodes table with sorting support
- Redline view support for tracking count changes