### PR TITLE
Feature/admin only accesses

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,7 +117,7 @@ export function useUpdateWorkspace() {
 
 ## Backend Repository
 
-Located at `/Users/amit/Developer/Startup/uprevit-backend`:
+Located at `../uprevit-backend`:
 
 - Uses AWS SAM for local testing: `npm run start:local`
 - API endpoints return structured responses with `ResponseWrapper`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,131 @@
+# AGENTS.md
+
+This guide provides instructions and conventions for agents operating in the uprevit-ui repository.
+
+## Project Overview
+
+Uprevit is a medical device labeling documentation application with a hierarchical structure:
+
+- **Workspaces** → Organizations
+- **Departments** → Grouped within workspaces
+- **Projects** → Grouped within departments
+- **Products** → Core entity, created within projects
+
+Frontend: Next.js 16 with TypeScript, Tailwind CSS, shadcn/ui
+Backend: AWS Lambda (SAM), API Gateway, Cognito, MongoDB, TypeScript
+
+## Build, Lint, and Test Commands
+
+```bash
+# Development server (runs on port 8080)
+bun run dev
+
+# Build for production
+bun run build
+
+# Lint codebase
+bun run lint
+```
+
+## Project Structure
+
+- **`app/`**: Next.js app router, layouts, pages, and API routes
+- **`components/`**: Reusable UI components (`common/` and `ui/` subdirectories)
+- **`features/`**: Feature-specific components organized by domain
+- **`hooks/`**: Custom React hooks for data fetching and state management
+- **`lib/`**: Shared utilities, providers, and configuration
+- **`types/`**: TypeScript interfaces and types
+- **`utils/`**: Utility functions (e.g., `isAdmin.ts`, `cn.ts`)
+
+## Code Style Guidelines
+
+### TypeScript
+
+- Strict mode enabled in tsconfig.json
+- Use explicit interfaces for API types (see `types/` directory)
+- Avoid `any` and always think, ask or look for to add proper types
+- Use optional properties with `?` for nullable fields
+
+### Naming Conventions
+
+- **Components**: PascalCase for React components, camelCase for file names
+- **Hooks**: Prefix with `use`, camelCase (e.g., `useGetUser`, `useUpdateWorkspace`)
+- **Utilities**: camelCase (e.g., `cn`, `isAdminProfile`)
+- **Types/Interfaces**: PascalCase with descriptive names
+- **Constants**: SCREAMING_SNAKE_CASE for global constants
+
+### React Patterns
+
+- Use "use client" directive for all the components
+- Use named exports for components and hooks
+- Destructure props with explicit typing
+- Handle loading/error states explicitly in components
+- Use react-hook-form for forms with proper schema validation
+
+### Error Handling
+
+- Use `toast.error()` for user-facing error messages
+- Throw descriptive errors in async functions
+- Handle API errors with try/catch in hooks and components
+- Example hook error handling:
+
+```typescript
+onError: (error) => {
+  console.error(error.message || "Failed to update workspace");
+  toast.error("Failed to update workspace");
+};
+```
+
+### UI Components
+
+- Use shadcn/ui components (configured in components.json, style: "new-york")
+- Prefix custom components with the function (e.g., `ArchiveProductDialog`)
+- Use Tailwind CSS with `cn()` utility for conditional classes
+- Icons from react-icons (prefer Pi prefix for Phosphor icons)
+
+### Authentication
+
+- Use `react-oidc-context` for auth (useAuth hook)
+- Check admin status via `cognito:groups` in user profile whenever needed
+- Use `isAdminProfile()` utility from `@/utils/isAdmin`
+- Always handle unauthenticated states
+
+### Backend Communication
+
+- API routes under `/api/` directory
+- Use React Query (TanStack Query v5) for data fetching/mutation
+- Pass access token in Authorization header (Bearer token)
+- Always include AbortSignal for request cancellation
+- Example hook pattern:
+
+```typescript
+export function useUpdateWorkspace() {
+  const auth = useAuth();
+  return useMutation({
+    mutationFn: async (data: Workspace) => {
+      const token = auth.user?.access_token;
+      if (!token) throw new Error("Not authenticated");
+      // API call with signal and token
+    },
+    onSuccess: () => {
+      toast.success("Success message");
+      queryClient.invalidateQueries({ queryKey: ["workspace"] });
+    },
+  });
+}
+```
+
+## Backend Repository
+
+Located at `/Users/amit/Developer/Startup/uprevit-backend`:
+
+- Uses AWS SAM for local testing: `npm run start:local`
+- API endpoints return structured responses with `ResponseWrapper`
+- Backend enforces admin role via `authenticateWithRole(event, 'admin')`
+- Admin status checked via `cognito:groups` in JWT token
+
+## Key Utilities
+
+- **`@/lib/utils`**: Contains `cn()` for Tailwind class merging
+- **`@/utils/isAdmin`**: Contains `isAdminProfile()` for admin role checks
+- **`@/components/ui`**: shadcn/ui component library

--- a/app/(app)/settings/page.tsx
+++ b/app/(app)/settings/page.tsx
@@ -27,10 +27,12 @@ function SettingsPage() {
   const tab = useSearchParams().get("tab");
   const auth = useAuth();
   const isAdmin = isAdminProfile(auth.user?.profile);
-  const [activeTab, setActiveTab] = useState(tab || "profile");
+  const adminTabs = ["admins", "workspace"];
+  const initialTab =
+    tab && (!adminTabs.includes(tab) || isAdmin) ? tab : "profile";
+  const [activeTab, setActiveTab] = useState(initialTab);
 
   const handleTabChange = (value: string) => {
-    const adminTabs = ["admins", "workspace"];
     if (adminTabs.includes(value) && !isAdmin) {
       toast.error("Insufficient privileges, contact Admin");
       return;

--- a/app/(app)/settings/page.tsx
+++ b/app/(app)/settings/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState } from "react";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import SecurityTab from "@/features/workspace/settings/SecurityTab";
 import ProfileTab from "@/features/workspace/settings/ProfileTab";
@@ -18,9 +19,24 @@ import {
 } from "react-icons/pi";
 import { useSearchParams } from "next/navigation";
 import { ThemeToggle } from "@/components/common/ThemeToggle";
+import { useAuth } from "react-oidc-context";
+import { isAdminProfile } from "@/utils/isAdmin";
+import { toast } from "sonner";
 
 function SettingsPage() {
   const tab = useSearchParams().get("tab");
+  const auth = useAuth();
+  const isAdmin = isAdminProfile(auth.user?.profile);
+  const [activeTab, setActiveTab] = useState(tab || "profile");
+
+  const handleTabChange = (value: string) => {
+    const adminTabs = ["admins", "workspace"];
+    if (adminTabs.includes(value) && !isAdmin) {
+      toast.error("Insufficient privileges, contact Admin");
+      return;
+    }
+    setActiveTab(value);
+  };
 
   return (
     <div className="flex flex-col gap-2 p-2">
@@ -41,7 +57,11 @@ function SettingsPage() {
 
       {/* Settings Tabs */}
       <div className="border border-input bg-background rounded-xl p-4">
-        <Tabs defaultValue={tab || "profile"} className="w-full">
+        <Tabs
+          value={activeTab}
+          onValueChange={handleTabChange}
+          className="w-full"
+        >
           <TabsList>
             <TabsTrigger value="profile">
               <PiUserDuotone className="mr-2 h-4 w-4" />

--- a/app/onboarding/create-workspace/page.tsx
+++ b/app/onboarding/create-workspace/page.tsx
@@ -21,6 +21,7 @@ import {
 } from "@/hooks/onboarding/useOnboardAdminCreateWorkspace";
 import { Workspace } from "@/types/workspace";
 import { useAuth } from "react-oidc-context";
+import { isAdminProfile } from "@/utils/isAdmin";
 import { toast } from "sonner";
 
 type WorkspaceFormValues = Pick<
@@ -58,6 +59,12 @@ export default function OnboardingCreateWorkspacePage() {
     try {
       if (!auth.user?.profile)
         throw new Error("You are not authorized to perform this action");
+
+      const isAdmin = isAdminProfile(auth.user?.profile);
+      if (!isAdmin) {
+        toast.error("Insufficient privileges, contact Admin");
+        return;
+      }
 
       const { name, email, sub } = auth.user.profile;
 

--- a/features/workspace/archive/DialogArchiveEntity.tsx
+++ b/features/workspace/archive/DialogArchiveEntity.tsx
@@ -2,6 +2,7 @@
 
 import { toast } from "sonner";
 import { useAuth } from "react-oidc-context";
+import { isAdminProfile } from "@/utils/isAdmin";
 import { useId, useMemo, useState } from "react";
 import { PiWarningCircleDuotone } from "react-icons/pi";
 
@@ -41,7 +42,7 @@ export default function DialogArchiveEntity({
   const [open, setOpen] = useState(false);
 
   const auth = useAuth();
-  const isAdmin = auth.user?.profile?.userType === "admin";
+  const isAdmin = isAdminProfile(auth.user?.profile);
 
   // Prepare mutations
   const departmentArchive = useArchiveDepartment();

--- a/features/workspace/archive/departments/ArchivedDepartmentsTable.tsx
+++ b/features/workspace/archive/departments/ArchivedDepartmentsTable.tsx
@@ -2,6 +2,7 @@
 
 import { toast } from "sonner";
 import { useAuth } from "react-oidc-context";
+import { isAdminProfile } from "@/utils/isAdmin";
 import {
   Column,
   ColumnDef,
@@ -129,7 +130,7 @@ export function ArchivedDepartmentsTable({
   const [columnVisibility, setColumnVisibility] = useState<VisibilityState>({});
 
   const auth = useAuth();
-  const isAdmin = auth.user?.profile?.userType === "admin";
+  const isAdmin = isAdminProfile(auth.user?.profile);
 
   const handleRestore = (item: DepartmentArchiveRow) => {
     if (!isAdmin) {

--- a/features/workspace/archive/products/ArchivedProducts.tsx
+++ b/features/workspace/archive/products/ArchivedProducts.tsx
@@ -9,6 +9,9 @@ import {
 import { RestoreEntityDialog } from "@/features/workspace/archive/RestoreEntityDialog";
 import { useGetArchivedProducts } from "@/hooks/archive/useGetArchivedProducts";
 import { useUpdateProduct } from "@/hooks/product/useUpdateProduct";
+import { useAuth } from "react-oidc-context";
+import { isAdminProfile } from "@/utils/isAdmin";
+import { toast } from "sonner";
 
 export type ArchivedProductsProps = {
   onRowClick?: (row: ProductArchiveRow) => void;
@@ -17,12 +20,18 @@ export type ArchivedProductsProps = {
 export function ArchivedProducts({ onRowClick }: ArchivedProductsProps) {
   const { data: archivedProducts } = useGetArchivedProducts();
   const { mutate: updateProductStatus, isPending } = useUpdateProduct();
+  const auth = useAuth();
+  const isAdmin = isAdminProfile(auth.user?.profile);
 
   const [restoreDialogOpen, setRestoreDialogOpen] = useState(false);
   const [selectedItemToRestore, setSelectedItemToRestore] =
     useState<ProductArchiveRow | null>(null);
 
   const handleRestoreClick = (row: ProductArchiveRow) => {
+    if (!isAdmin) {
+      toast.error("Insufficient privileges, contact Admin");
+      return;
+    }
     setSelectedItemToRestore(row);
     setRestoreDialogOpen(true);
   };

--- a/features/workspace/archive/projects/ArchivedProjectsTable.tsx
+++ b/features/workspace/archive/projects/ArchivedProjectsTable.tsx
@@ -2,6 +2,7 @@
 
 import { toast } from "sonner";
 import { useAuth } from "react-oidc-context";
+import { isAdminProfile } from "@/utils/isAdmin";
 import {
   Column,
   ColumnDef,
@@ -125,7 +126,7 @@ export function ArchivedProjectsTable({
   const [columnVisibility, setColumnVisibility] = useState<VisibilityState>({});
 
   const auth = useAuth();
-  const isAdmin = auth.user?.profile?.userType === "admin";
+  const isAdmin = isAdminProfile(auth.user?.profile);
 
   const handleRestore = (item: ProjectArchiveRow) => {
     if (!isAdmin) {

--- a/features/workspace/departments/AddUsersInDepartmentDropdown.tsx
+++ b/features/workspace/departments/AddUsersInDepartmentDropdown.tsx
@@ -2,6 +2,7 @@
 
 import { toast } from "sonner";
 import { useAuth } from "react-oidc-context";
+import { isAdminProfile } from "@/utils/isAdmin";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -33,7 +34,7 @@ export default function AddUsersInDepartmentDropdown({
   users = [],
 }: AddUsersInDepartmentDropdownProps) {
   const auth = useAuth();
-  const isAdmin = auth.user?.profile?.userType === "admin";
+  const isAdmin = isAdminProfile(auth.user?.profile);
 
   const handleUserClick = (user: User) => {
     if (!isAdmin) {

--- a/features/workspace/departments/CreateDepartmentDialog.tsx
+++ b/features/workspace/departments/CreateDepartmentDialog.tsx
@@ -5,6 +5,7 @@ import { useId, useState } from "react";
 import { useForm } from "react-hook-form";
 import { PiPlusSquareDuotone, PiXDuotone } from "react-icons/pi";
 import { useAuth } from "react-oidc-context";
+import { isAdminProfile } from "@/utils/isAdmin";
 import { useFileUpload } from "@/hooks/general/use-file-upload";
 import { Button } from "@/components/ui/button";
 import {
@@ -60,7 +61,7 @@ export default function CreateDepartmentDialog() {
   const auth = useAuth();
   const userId = auth?.user?.profile?.userId;
   const workspaceId = auth?.user?.profile?.workspaceId;
-  const isAdmin = auth.user?.profile?.userType === "admin";
+  const isAdmin = isAdminProfile(auth.user?.profile);
   const users = usersData?.data;
 
   const {

--- a/features/workspace/departments/UpdateDepartmentDialog.tsx
+++ b/features/workspace/departments/UpdateDepartmentDialog.tsx
@@ -2,6 +2,7 @@
 
 import { toast } from "sonner";
 import { useAuth } from "react-oidc-context";
+import { isAdminProfile } from "@/utils/isAdmin";
 import { useId, useState, useEffect } from "react";
 import { useForm, SubmitHandler } from "react-hook-form";
 import { PiPlusSquareDuotone, PiXDuotone } from "react-icons/pi";
@@ -78,7 +79,7 @@ export default function UpdateDepartmentDialog({
 
   const { mutate: updateDepartment, isPending } = useUpdateDepartment();
   const auth = useAuth();
-  const isAdmin = auth.user?.profile?.userType === "admin";
+  const isAdmin = isAdminProfile(auth.user?.profile);
 
   const {
     register,

--- a/features/workspace/products/DialogArchiveProduct.tsx
+++ b/features/workspace/products/DialogArchiveProduct.tsx
@@ -19,6 +19,9 @@ import {
   PiXCircleDuotone,
 } from "react-icons/pi";
 import { Spinner } from "@/components/ui/spinner";
+import { useAuth } from "react-oidc-context";
+import { isAdminProfile } from "@/utils/isAdmin";
+import { toast } from "sonner";
 
 type ArchiveProductProps = Pick<Product, "_id">;
 
@@ -35,9 +38,15 @@ export default function DialogArchiveProduct({
 }) {
   const [internalOpen, setInternalOpen] = useState(false);
   const { mutate: archiveProduct, isPending } = useUpdateProduct();
+  const auth = useAuth();
+  const isAdmin = isAdminProfile(auth.user?.profile);
 
   async function handleArchiveProduct(e: React.MouseEvent) {
     e.preventDefault();
+    if (!isAdmin) {
+      toast.error("Insufficient privileges, contact Admin");
+      return;
+    }
     if (!product?._id) return;
 
     try {
@@ -135,7 +144,17 @@ export default function DialogArchiveProduct({
     <Dialog open={internalOpen} onOpenChange={setInternalOpen}>
       <DialogTrigger asChild>
         {children || (
-          <div className="focus:bg-accent hover:bg-accent focus:text-accent-foreground relative flex cursor-pointer items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none">
+          <div
+            className="focus:bg-accent hover:bg-accent focus:text-accent-foreground relative flex cursor-pointer items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none"
+            onClick={(e) => {
+              if (!isAdmin) {
+                e.preventDefault();
+                e.stopPropagation();
+                toast.error("Insufficient privileges, contact Admin");
+                return;
+              }
+            }}
+          >
             <PiArchiveDuotone className="h-4 w-4 text-muted-foreground" />
             <span>Archive</span>
           </div>

--- a/features/workspace/projects/AddUsersInProjectDropdown.tsx
+++ b/features/workspace/projects/AddUsersInProjectDropdown.tsx
@@ -2,6 +2,7 @@
 
 import { toast } from "sonner";
 import { useAuth } from "react-oidc-context";
+import { isAdminProfile } from "@/utils/isAdmin";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -32,7 +33,7 @@ export default function AddUsersInProjectDropdown({
   users = [],
 }: AddUsersInProjectDropdownProps) {
   const auth = useAuth();
-  const isAdmin = auth.user?.profile?.userType === "admin";
+  const isAdmin = isAdminProfile(auth.user?.profile);
 
   const handleUserClick = (user: User) => {
     if (!isAdmin) {

--- a/features/workspace/projects/ProjectCreateDialog.tsx
+++ b/features/workspace/projects/ProjectCreateDialog.tsx
@@ -34,13 +34,13 @@ import Image from "next/image";
 import { useId, useState } from "react";
 import { useForm } from "react-hook-form";
 import {
-  PiBuildingsDuotone,
   PiKanbanDuotone,
   PiPlusCircleDuotone,
   PiXCircleDuotone,
 } from "react-icons/pi";
 import { Spinner } from "@/components/ui/spinner";
 import { useAuth } from "react-oidc-context";
+import { isAdminProfile } from "@/utils/isAdmin";
 import AddUsersInProjectDropdown from "./AddUsersInProjectDropdown";
 
 interface User {
@@ -79,7 +79,7 @@ export default function ProjectCreateDialog({
   const auth = useAuth();
   const userId = auth?.user?.profile?.userId;
   const workspaceId = auth?.user?.profile?.workspaceId;
-  const isAdmin = auth.user?.profile?.userType === "admin";
+  const isAdmin = isAdminProfile(auth.user?.profile);
 
   const departments = departmentsData?.result?.departments || [];
   const users = usersData?.data;

--- a/features/workspace/projects/UpdateProjectDialog.tsx
+++ b/features/workspace/projects/UpdateProjectDialog.tsx
@@ -2,6 +2,7 @@
 
 import { toast } from "sonner";
 import { useAuth } from "react-oidc-context";
+import { isAdminProfile } from "@/utils/isAdmin";
 import { useEffect, useId, useState } from "react";
 import { useForm, SubmitHandler } from "react-hook-form";
 import { PiPlusSquareDuotone, PiXDuotone } from "react-icons/pi";
@@ -78,7 +79,7 @@ export default function UpdateProjectDialog({
 
   const { mutate: updateProject, isPending } = useUpdateProject();
   const auth = useAuth();
-  const isAdmin = auth.user?.profile?.userType === "admin";
+  const isAdmin = isAdminProfile(auth.user?.profile);
 
   type FormValues = {
     project_name: string;

--- a/features/workspace/settings/DialogUpdateWorkspace.tsx
+++ b/features/workspace/settings/DialogUpdateWorkspace.tsx
@@ -24,9 +24,11 @@ import {
   PiCheckCircleDuotone,
   PiCameraDuotone,
   PiTrashDuotone,
-  PiBuildingsDuotone,
 } from "react-icons/pi";
 import { Spinner } from "@/components/ui/spinner";
+import { useAuth } from "react-oidc-context";
+import { isAdminProfile } from "@/utils/isAdmin";
+import { toast } from "sonner";
 
 interface DialogUpdateWorkspaceProps {
   workspaceData: Workspace;
@@ -40,6 +42,8 @@ export function DialogUpdateWorkspace({
   const { mutate: updateWorkspaceMutation, isPending } = useUpdateWorkspace();
   const [uploadingLogo, setUploadingLogo] = useState(false);
   const [logoPreview, setLogoPreview] = useState<string>("");
+  const auth = useAuth();
+  const isAdmin = isAdminProfile(auth.user?.profile);
 
   const {
     register,
@@ -58,6 +62,10 @@ export function DialogUpdateWorkspace({
   });
 
   const onSubmit: SubmitHandler<Workspace> = async (formData) => {
+    if (!isAdmin) {
+      toast.error("Insufficient privileges, contact Admin");
+      return;
+    }
     try {
       updateWorkspaceMutation(
         { ...formData, _id: workspaceData._id },
@@ -69,7 +77,7 @@ export function DialogUpdateWorkspace({
             setOpen(false);
             console.error("Failed to update workspace:", error);
           },
-        }
+        },
       );
     } catch (error) {
       console.error("Failed to update workspace:", error);
@@ -77,7 +85,7 @@ export function DialogUpdateWorkspace({
   };
 
   const handleLogoChange = async (
-    event: React.ChangeEvent<HTMLInputElement>
+    event: React.ChangeEvent<HTMLInputElement>,
   ) => {
     const file = event.target.files?.[0];
     if (!file) return;
@@ -116,7 +124,19 @@ export function DialogUpdateWorkspace({
   return (
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogTrigger asChild>
-        <Button variant="outline" size="sm" className="gap-2">
+        <Button
+          variant="outline"
+          size="sm"
+          className="gap-2"
+          onClick={(e) => {
+            if (!isAdmin) {
+              e.preventDefault();
+              e.stopPropagation();
+              toast.error("Insufficient privileges, contact Admin");
+              return;
+            }
+          }}
+        >
           <PiPencilSimpleDuotone className="w-4 h-4" />
           Edit Workspace
         </Button>

--- a/features/workspace/settings/DialogUpdateWorkspace.tsx
+++ b/features/workspace/settings/DialogUpdateWorkspace.tsx
@@ -121,21 +121,21 @@ export function DialogUpdateWorkspace({
 
   const currentLogo = logoPreview || watch("logo") || workspaceData?.logo;
 
+  const handleOpenChange = (nextOpen: boolean) => {
+    if (nextOpen && !isAdmin) {
+      toast.error("Insufficient privileges, contact Admin");
+      return;
+    }
+    setOpen(nextOpen);
+  };
+
   return (
-    <Dialog open={open} onOpenChange={setOpen}>
+    <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogTrigger asChild>
         <Button
           variant="outline"
           size="sm"
           className="gap-2"
-          onClick={(e) => {
-            if (!isAdmin) {
-              e.preventDefault();
-              e.stopPropagation();
-              toast.error("Insufficient privileges, contact Admin");
-              return;
-            }
-          }}
         >
           <PiPencilSimpleDuotone className="w-4 h-4" />
           Edit Workspace

--- a/features/workspace/settings/InviteMembersDialog.tsx
+++ b/features/workspace/settings/InviteMembersDialog.tsx
@@ -2,11 +2,11 @@
 
 import { useForm, useFieldArray, Controller } from "react-hook-form";
 import { useAuth } from "react-oidc-context";
+import { isAdminProfile } from "@/utils/isAdmin";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
   DialogContent,
-  DialogDescription,
   DialogFooter,
   DialogHeader,
   DialogTitle,
@@ -43,7 +43,7 @@ type InviteMembersFormValues = {
 
 export function InviteMembersDialog() {
   const auth = useAuth();
-  const isAdmin = auth.user?.profile?.userType === "admin";
+  const isAdmin = isAdminProfile(auth.user?.profile);
 
   const { mutate: inviteMembersMutation, isPending } =
     useInviteWorkspaceMembers();

--- a/utils/isAdmin.ts
+++ b/utils/isAdmin.ts
@@ -1,0 +1,20 @@
+export type AuthProfile = Record<string, unknown> | null | undefined;
+
+function includesAdmin(groups: unknown) {
+  if (Array.isArray(groups)) {
+    return groups.includes("admin");
+  }
+
+  if (typeof groups === "string") {
+    return groups
+      .split(",")
+      .map((group) => group.trim())
+      .includes("admin");
+  }
+
+  return false;
+}
+
+export function isAdminProfile(profile: AuthProfile) {
+  return includesAdmin(profile?.["cognito:groups"]);
+}


### PR DESCRIPTION
- Created utils/isAdmin.ts utility that checks cognito:groups for admin status
- Added toast-only guards for admin-only actions (no UI hiding):
  - Product archive/restore
  - Workspace settings (edit, tabs)
  - Onboarding workspace creation
  - Department/Project CRUD operations
- Updated all existing admin checks to use the new utility