### PR TITLE
Feature/revamp resource pages UI

### DIFF
--- a/app/resources/blogs/page.tsx
+++ b/app/resources/blogs/page.tsx
@@ -11,7 +11,7 @@ export default function BlogsPage() {
       <MarketingHeader />
       <div className="relative w-full">
         <DottedVerticalLines />
-        <div className="relative z-10 w-full pt-32">
+        <div className="relative z-10 w-full pt-24">
           <BlogsSection />
         </div>
         <div className="relative z-35 w-full">

--- a/app/resources/blogs/page.tsx
+++ b/app/resources/blogs/page.tsx
@@ -1,18 +1,22 @@
 "use client";
 
 import MarketingHeader from "@/features/marketing/marketing-header";
-import BlogsSection from "@/features/resources/blogs/BlogsSection";
 import FooterSection from "@/features/marketing/landing-page/FooterSection";
+import { DottedVerticalLines } from "@/features/marketing/landing-page/DottedVerticalLines";
+import BlogsSection from "@/features/resources/blogs/BlogsSection";
 
 export default function BlogsPage() {
   return (
     <div className="flex flex-col items-center justify-center min-h-screen relative bg-accent/50">
       <MarketingHeader />
-      <div className="w-full pt-32">
-        <BlogsSection />
-      </div>
-      <div className="w-full">
-        <FooterSection />
+      <div className="relative w-full">
+        <DottedVerticalLines />
+        <div className="relative z-10 w-full pt-32">
+          <BlogsSection />
+        </div>
+        <div className="relative z-35 w-full">
+          <FooterSection />
+        </div>
       </div>
     </div>
   );

--- a/app/resources/page.tsx
+++ b/app/resources/page.tsx
@@ -1,18 +1,22 @@
 "use client";
 
 import MarketingHeader from "@/features/marketing/marketing-header";
-import ResourcesHub from "@/features/resources/ResourcesHub";
 import FooterSection from "@/features/marketing/landing-page/FooterSection";
+import { DottedVerticalLines } from "@/features/marketing/landing-page/DottedVerticalLines";
+import ResourcesHub from "@/features/resources/ResourcesHub";
 
 export default function ResourcesPage() {
   return (
     <div className="flex flex-col items-center justify-center min-h-screen relative bg-accent/50">
       <MarketingHeader />
-      <div className="w-full pt-32">
-        <ResourcesHub />
-      </div>
-      <div className="w-full">
-        <FooterSection />
+      <div className="relative w-full">
+        <DottedVerticalLines />
+        <div className="relative z-10 w-full pt-24">
+          <ResourcesHub />
+        </div>
+        <div className="relative z-35 w-full">
+          <FooterSection />
+        </div>
       </div>
     </div>
   );

--- a/app/resources/standards-symbols/page.tsx
+++ b/app/resources/standards-symbols/page.tsx
@@ -11,7 +11,7 @@ export default function StandardsSymbolsPage() {
       <MarketingHeader />
       <div className="relative w-full">
         <DottedVerticalLines />
-        <div className="relative z-10 w-full pt-32">
+        <div className="relative z-10 w-full pt-24">
           <StandardsSymbolsSection />
         </div>
         <div className="relative z-35 w-full">

--- a/app/resources/standards-symbols/page.tsx
+++ b/app/resources/standards-symbols/page.tsx
@@ -1,18 +1,22 @@
 "use client";
 
 import MarketingHeader from "@/features/marketing/marketing-header";
-import StandardsSymbolsSection from "@/features/resources/standards/StandardsSymbolsSection";
 import FooterSection from "@/features/marketing/landing-page/FooterSection";
+import { DottedVerticalLines } from "@/features/marketing/landing-page/DottedVerticalLines";
+import StandardsSymbolsSection from "@/features/resources/standards/StandardsSymbolsSection";
 
 export default function StandardsSymbolsPage() {
   return (
     <div className="flex flex-col items-center justify-center min-h-screen relative bg-accent/50">
       <MarketingHeader />
-      <div className="w-full pt-32">
-        <StandardsSymbolsSection />
-      </div>
-      <div className="w-full">
-        <FooterSection />
+      <div className="relative w-full">
+        <DottedVerticalLines />
+        <div className="relative z-10 w-full pt-32">
+          <StandardsSymbolsSection />
+        </div>
+        <div className="relative z-35 w-full">
+          <FooterSection />
+        </div>
       </div>
     </div>
   );

--- a/app/resources/templates/page.tsx
+++ b/app/resources/templates/page.tsx
@@ -11,7 +11,7 @@ export default function TemplatesPage() {
       <MarketingHeader />
       <div className="relative w-full">
         <DottedVerticalLines />
-        <div className="relative z-10 w-full pt-32">
+        <div className="relative z-10 w-full pt-24">
           <TemplatesSection />
         </div>
         <div className="relative z-35 w-full">

--- a/app/resources/templates/page.tsx
+++ b/app/resources/templates/page.tsx
@@ -1,18 +1,22 @@
 "use client";
 
 import MarketingHeader from "@/features/marketing/marketing-header";
-import TemplatesSection from "@/features/resources/templates/TemplatesSection";
 import FooterSection from "@/features/marketing/landing-page/FooterSection";
+import { DottedVerticalLines } from "@/features/marketing/landing-page/DottedVerticalLines";
+import TemplatesSection from "@/features/resources/templates/TemplatesSection";
 
 export default function TemplatesPage() {
   return (
     <div className="flex flex-col items-center justify-center min-h-screen relative bg-accent/50">
       <MarketingHeader />
-      <div className="w-full pt-32">
-        <TemplatesSection />
-      </div>
-      <div className="w-full">
-        <FooterSection />
+      <div className="relative w-full">
+        <DottedVerticalLines />
+        <div className="relative z-10 w-full pt-32">
+          <TemplatesSection />
+        </div>
+        <div className="relative z-35 w-full">
+          <FooterSection />
+        </div>
       </div>
     </div>
   );

--- a/app/resources/toolkits/page.tsx
+++ b/app/resources/toolkits/page.tsx
@@ -11,7 +11,7 @@ export default function ToolkitsPage() {
       <MarketingHeader />
       <div className="relative w-full">
         <DottedVerticalLines />
-        <div className="relative z-10 w-full pt-32">
+        <div className="relative z-10 w-full pt-24">
           <ToolkitsPlaceholder />
         </div>
         <div className="relative z-35 w-full">

--- a/app/resources/toolkits/page.tsx
+++ b/app/resources/toolkits/page.tsx
@@ -1,18 +1,22 @@
 "use client";
 
 import MarketingHeader from "@/features/marketing/marketing-header";
-import ToolkitsPlaceholder from "@/features/resources/toolkits/ToolkitsPlaceholder";
 import FooterSection from "@/features/marketing/landing-page/FooterSection";
+import { DottedVerticalLines } from "@/features/marketing/landing-page/DottedVerticalLines";
+import ToolkitsPlaceholder from "@/features/resources/toolkits/ToolkitsPlaceholder";
 
 export default function ToolkitsPage() {
   return (
     <div className="flex flex-col items-center justify-center min-h-screen relative bg-accent/50">
       <MarketingHeader />
-      <div className="w-full pt-32">
-        <ToolkitsPlaceholder />
-      </div>
-      <div className="w-full">
-        <FooterSection />
+      <div className="relative w-full">
+        <DottedVerticalLines />
+        <div className="relative z-10 w-full pt-32">
+          <ToolkitsPlaceholder />
+        </div>
+        <div className="relative z-35 w-full">
+          <FooterSection />
+        </div>
       </div>
     </div>
   );

--- a/features/marketing/landing-page/DottedVerticalLines.tsx
+++ b/features/marketing/landing-page/DottedVerticalLines.tsx
@@ -1,0 +1,10 @@
+"use client";
+
+export function DottedVerticalLines() {
+  return (
+    <div className="absolute inset-0 w-full max-w-6xl mx-auto pointer-events-none">
+      <div className="absolute top-0 left-0 w-px bottom-0 border-l border-dashed border-border/80 z-30" />
+      <div className="absolute top-0 right-0 w-px bottom-0 border-r border-dashed border-border/80 z-30" />
+    </div>
+  );
+}

--- a/features/marketing/landing-page/FooterSection.tsx
+++ b/features/marketing/landing-page/FooterSection.tsx
@@ -7,7 +7,7 @@ import { ThemeToggle } from "@/components/common/ThemeToggle";
 
 export default function FooterSection() {
   return (
-    <footer className="w-full bg-black text-white px-6 md:px-20 mt-20 pointer-events-auto">
+    <footer className="w-full bg-black text-background px-6 md:px-20 mt-20 pointer-events-auto z-45">
       <div className="relative max-w-6xl mx-auto py-16">
         <div className="grid grid-cols-1 md:grid-cols-12 gap-10 md:gap-8 mb-16">
           {/* Brand Column */}

--- a/features/marketing/marketing-header.tsx
+++ b/features/marketing/marketing-header.tsx
@@ -2,7 +2,6 @@
 
 import * as React from "react";
 import Link from "next/link";
-import { CircleCheckIcon, CircleHelpIcon, CircleIcon } from "lucide-react";
 import {
   PiFileTextDuotone,
   PiSquaresFourDuotone,
@@ -22,7 +21,7 @@ import {
   navigationMenuTriggerStyle,
 } from "@/components/ui/navigation-menu";
 import { Button } from "@/components/ui/button";
-import { useRouter } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
 import { useAuth } from "react-oidc-context";
 import Image from "next/image";
 
@@ -58,6 +57,9 @@ export default function MarketingHeader() {
   const auth = useAuth();
   const router = useRouter();
   const [isAtTop, setIsAtTop] = React.useState(true);
+  const pathname = usePathname();
+
+  const isResourcesAndChildPaths = pathname.startsWith("/resources");
 
   React.useEffect(() => {
     const handleScroll = () => {
@@ -79,7 +81,8 @@ export default function MarketingHeader() {
     <div
       className={cn(
         "fixed top-0 w-full h-18 mx-auto flex items-center justify-between z-60 transition-all delay-150 ease-in-out duration-300",
-        !isAtTop ? "bg-accent/80 border-b" : "bg-transparent"
+        !isAtTop ? "bg-accent/80 border-b" : "bg-transparent",
+        isResourcesAndChildPaths && "border-b border-dashed border-border/80",
       )}
       style={{
         backdropFilter: !isAtTop ? "blur(8px)" : "none",
@@ -145,30 +148,19 @@ export default function MarketingHeader() {
                 </NavigationMenuContent>
               </NavigationMenuItem>
               <NavigationMenuItem>
-                <NavigationMenuTrigger>Pricing</NavigationMenuTrigger>
-                <NavigationMenuContent>
-                  <ul className="grid gap-2 sm:w-[400px] md:w-[500px] md:grid-cols-2 lg:w-[600px]">
-                    <ListItem href="/pricing" title="Pricing Plans">
-                      Flexible pricing options for teams of all sizes.
-                    </ListItem>
-                    <ListItem href="/pricing#enterprise" title="Enterprise">
-                      Custom solutions for large organizations.
-                    </ListItem>
-                    <ListItem href="/pricing#faq" title="FAQ">
-                      Answers to common pricing questions.
-                    </ListItem>
-                    <ListItem href="/contact" title="Contact Sales">
-                      Get in touch for personalized pricing quotes.
-                    </ListItem>
-                  </ul>
-                </NavigationMenuContent>
+                <NavigationMenuLink
+                  asChild
+                  className={navigationMenuTriggerStyle()}
+                >
+                  <Link href="/pricing">Pricing</Link>
+                </NavigationMenuLink>
               </NavigationMenuItem>
               <NavigationMenuItem>
                 <NavigationMenuLink
                   asChild
                   className={navigationMenuTriggerStyle()}
                 >
-                  <Link href="/docs">Contact</Link>
+                  <Link href="/contact">Contact</Link>
                 </NavigationMenuLink>
               </NavigationMenuItem>
             </NavigationMenuList>
@@ -212,7 +204,7 @@ function ListItem({
       <NavigationMenuLink asChild>
         <Link href={href} className="flex flex-row items-center gap-3">
           {Icon && (
-            <div className="flex-shrink-0 flex items-center justify-center size-10 rounded-lg bg-accent mt-0.5">
+            <div className="shrink-0 flex items-center justify-center size-10 rounded-lg bg-accent mt-0.5">
               <Icon className="size-5 text-foreground" />
             </div>
           )}

--- a/features/marketing/marketing-header.tsx
+++ b/features/marketing/marketing-header.tsx
@@ -7,6 +7,7 @@ import {
   PiSquaresFourDuotone,
   PiNewspaperDuotone,
   PiWrenchDuotone,
+  PiStackDuotone,
 } from "react-icons/pi";
 import { cn } from "@/lib/utils";
 
@@ -125,7 +126,10 @@ export default function MarketingHeader() {
                           className="from-muted/50 to-muted flex h-full w-full flex-col justify-end rounded-md bg-linear-to-b p-4 no-underline outline-hidden transition-all duration-200 select-none focus:shadow-md md:p-6"
                           href="/resources"
                         >
-                          <div className="mb-2 text-lg font-medium sm:mt-4">
+                          <div className="mb-3 flex size-10 items-center justify-center rounded-lg border border-border bg-background/80">
+                            <PiStackDuotone className="size-5 text-foreground" />
+                          </div>
+                          <div className="mb-2 text-lg font-medium">
                             Resources Hub
                           </div>
                           <p className="text-muted-foreground text-sm leading-tight">

--- a/features/resources/ResourcesHub.tsx
+++ b/features/resources/ResourcesHub.tsx
@@ -9,6 +9,7 @@ import {
   PiBookOpenDuotone,
   PiFilesDuotone,
   PiNewspaperDuotone,
+  PiStackDuotone,
   PiWrenchDuotone,
 } from "react-icons/pi";
 
@@ -87,12 +88,14 @@ export default function ResourcesHub() {
   const badgeVariant = resolvedTheme === "dark" ? "outline" : "white";
 
   return (
-    <div className="w-full mt-16 mb-24 pointer-events-auto">
+    <div className="w-full mt-16 mb-24 pointer-events-auto relative">
+      <div className="absolute top-0 left-0 w-full h-0 border-b border-dashed border-border/80" />
       <div className="max-w-6xl mx-auto mb-10">
         <Badge
           variant={badgeVariant}
           className="mb-8 z-60 dark:px-2 dark:py-0.5"
         >
+          <PiStackDuotone className="text-foreground/60" />
           <span className="font-medium">Resources</span>
         </Badge>
         <div className="w-full flex flex-col lg:flex-row items-start gap-8">

--- a/features/resources/ResourcesHub.tsx
+++ b/features/resources/ResourcesHub.tsx
@@ -2,91 +2,207 @@
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
+import { DecorativeCornerCircleCustom } from "@/components/ui/DecorativeCornerCircle";
 import { useTheme } from "next-themes";
-import { useEffect, useState } from "react";
-import { PiFilesDuotone, PiBookOpenDuotone, PiNewspaperDuotone, PiWrenchDuotone } from "react-icons/pi";
 import Link from "next/link";
+import {
+  PiBookOpenDuotone,
+  PiFilesDuotone,
+  PiNewspaperDuotone,
+  PiWrenchDuotone,
+} from "react-icons/pi";
 
 const resources = [
   {
     id: "templates",
     title: "Templates",
-    description: "Access battle-tested checklists and templates designed by regulatory experts. Stop building documents from scratch.",
+    description:
+      "Battle-tested checklists and templates built by regulatory experts to keep documentation audit-ready.",
     icon: PiFilesDuotone,
     href: "/resources/templates",
+    meta: "Checklists, validation kits, naming guides",
+    highlights: [
+      "Gap assessments",
+      "Validation templates",
+      "Project timelines",
+    ],
+    cta: "Browse templates",
   },
   {
     id: "standards-symbols",
     title: "Standards & Symbols",
-    description: "Complete ISO standards library and standardized medical device symbols for universal compliance understanding.",
+    description:
+      "Centralized ISO references and standardized medical device symbols for global regulatory alignment.",
     icon: PiBookOpenDuotone,
     href: "/resources/standards-symbols",
+    meta: "ISO library + symbol usage guidance",
+    highlights: ["ISO 15223-1", "Device symbol library", "Usage references"],
+    cta: "Explore standards",
   },
   {
     id: "blogs",
     title: "Blogs",
-    description: "Expert analysis of regulatory shifts and industry insights to help you stay ahead of compliance changes.",
+    description:
+      "Expert analysis of regulatory shifts with clear, actionable takeaways for labeling teams.",
     icon: PiNewspaperDuotone,
     href: "/resources/blogs",
+    meta: "Regulatory updates and field notes",
+    highlights: [
+      "FDA + EU MDR updates",
+      "Implementation guides",
+      "Release notes",
+    ],
+    cta: "Read insights",
   },
   {
     id: "toolkits",
     title: "Toolkits",
-    description: "Free compliance tools to streamline your labeling workflow. Coming soon!",
+    description:
+      "Free compliance tools to streamline labeling workflows, validation, and symbol management.",
     icon: PiWrenchDuotone,
     href: "/resources/toolkits",
+    meta: "Free tools, rolling releases",
+    highlights: ["Label generator", "Compliance checker", "Symbol manager"],
+    cta: "See toolkits",
   },
 ];
 
+// const resourcePillars = [
+//   {
+//     title: "Curated by regulatory experts",
+//     description: "Practical resources shaped by real audits and label reviews.",
+//   },
+//   {
+//     title: "Always aligned to standards",
+//     description: "ISO, FDA, and EU MDR updates distilled for quick action.",
+//   },
+//   {
+//     title: "Made to ship fast",
+//     description: "Download-ready assets that plug into your workflows.",
+//   },
+// ];
+
 export default function ResourcesHub() {
   const { resolvedTheme } = useTheme();
-  const [mounted, setMounted] = useState(false);
-
-  useEffect(() => {
-    setMounted(true);
-  }, []);
-
-  const badgeVariant = mounted && resolvedTheme === "dark" ? "outline" : "white";
+  const badgeVariant = resolvedTheme === "dark" ? "outline" : "white";
 
   return (
-    <div className="w-full mt-20 mb-20 pointer-events-auto">
-      <div className="max-w-6xl mx-auto mb-8 px-4">
-        <Badge variant={badgeVariant} className="mb-8 z-60 dark:px-2 dark:py-0.5">
+    <div className="w-full mt-16 mb-24 pointer-events-auto">
+      <div className="max-w-6xl mx-auto mb-10">
+        <Badge
+          variant={badgeVariant}
+          className="mb-8 z-60 dark:px-2 dark:py-0.5"
+        >
           <span className="font-medium">Resources</span>
         </Badge>
-        <div className="w-full flex flex-col md:flex-row items-start gap-4">
-          <h2 className="text-4xl md:text-5xl font-medium">
-            Everything You Need for Compliance
-          </h2>
+        <div className="w-full flex flex-col lg:flex-row items-start gap-8">
+          <h1 className="text-4xl md:text-5xl lg:text-6xl font-medium leading-tightest">
+            The library built for labeling teams
+          </h1>
+          <div className="hidden lg:block h-24 w-px bg-border" />
+          <p className="text-lg text-muted-foreground max-w-md">
+            Templates, standards, and expert analysis organized into a single
+            hub. Everything you need to move from draft to approved label with
+            confidence.
+          </p>
         </div>
+        <div className="mt-8 flex flex-wrap items-center gap-4">
+          <Button size="lg" variant="outline" asChild>
+            <Link href="/resources/standards-symbols">
+              <PiBookOpenDuotone /> Explore standards
+            </Link>
+          </Button>
+          <Button size="lg" asChild>
+            <Link href="/resources/templates">
+              <PiFilesDuotone />
+              Browse templates
+            </Link>
+          </Button>
+        </div>
+        {/* <div className="mt-10 grid grid-cols-1 md:grid-cols-3 gap-4">
+          {resourcePillars.map((pillar) => (
+            <div
+              key={pillar.title}
+              className="rounded-xl border border-border bg-background/70 p-5"
+            >
+              <p className="text-xs uppercase text-muted-foreground">Pillar</p>
+              <h3 className="mt-2 text-base font-semibold">{pillar.title}</h3>
+              <p className="mt-2 text-sm text-muted-foreground">
+                {pillar.description}
+              </p>
+            </div>
+          ))}
+        </div> */}
       </div>
 
-      <div className="max-w-6xl mx-auto px-4">
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-          {resources.map((resource) => (
-            <Card key={resource.id} className="hover:shadow-lg transition-shadow duration-300">
-              <CardHeader>
-                <div className="flex items-center gap-3">
-                  <div className="p-2 rounded-lg bg-primary/10">
-                    <resource.icon className="w-6 h-6 text-primary" />
+      <div className="relative w-full">
+        <div className="max-w-6xl mx-auto relative">
+          <DecorativeCornerCircleCustom
+            positionClassName="-bottom-15 -left-15"
+            rotation={270}
+          />
+          <DecorativeCornerCircleCustom
+            positionClassName="-bottom-15 -right-15"
+            rotation={180}
+          />
+          <DecorativeCornerCircleCustom
+            positionClassName="-top-15 -right-15"
+            rotation={90}
+          />
+
+          <div className="p-1 bg-accent border-border border rounded-[12px]">
+            <div className="grid grid-cols-1 lg:grid-cols-2 gap-1">
+              {resources.map((resource) => (
+                <div
+                  key={resource.id}
+                  className="flex h-full flex-col justify-between rounded-[10px] border border-border bg-background/80 p-6"
+                >
+                  <div>
+                    <div className="flex items-start justify-between gap-4">
+                      <div className="flex items-center gap-3">
+                        <div className="flex size-11 items-center justify-center rounded-xl bg-foreground text-background">
+                          <resource.icon className="size-5" />
+                        </div>
+                        <div>
+                          <h3 className="text-xl font-semibold">
+                            {resource.title}
+                          </h3>
+                          <p className="text-xs text-muted-foreground">
+                            {resource.meta}
+                          </p>
+                        </div>
+                      </div>
+                    </div>
+                    <p className="mt-4 text-sm text-foreground">
+                      {resource.description}
+                    </p>
+                    <div className="mt-4 space-y-2">
+                      {resource.highlights.map((highlight) => (
+                        <div
+                          key={highlight}
+                          className="flex items-center gap-2 text-sm text-muted-foreground"
+                        >
+                          <span className="size-1.5 rounded-full bg-foreground/60" />
+                          {highlight}
+                        </div>
+                      ))}
+                    </div>
                   </div>
-                  <CardTitle className="text-xl">{resource.title}</CardTitle>
+                  <div className="mt-6 flex items-center justify-between">
+                    <p className="text-xs uppercase tracking-wide text-muted-foreground">
+                      Updated regularly
+                    </p>
+                    <Button variant="outline" asChild>
+                      <Link href={resource.href}>{resource.cta}</Link>
+                    </Button>
+                  </div>
                 </div>
-              </CardHeader>
-              <CardContent>
-                <CardDescription className="text-base">
-                  {resource.description}
-                </CardDescription>
-              </CardContent>
-              <CardFooter>
-                <Link href={resource.href}>
-                  <Button variant="outline">Learn More</Button>
-                </Link>
-              </CardFooter>
-            </Card>
-          ))}
+              ))}
+            </div>
+          </div>
         </div>
+        <div className="absolute top-0 left-0 w-full h-0 border-b border-dashed border-border/80" />
+        <div className="absolute bottom-0 left-0 w-full h-0 border-b border-dashed border-border/80" />
       </div>
     </div>
   );

--- a/features/resources/blogs/BlogsSection.tsx
+++ b/features/resources/blogs/BlogsSection.tsx
@@ -1,32 +1,36 @@
 "use client";
 
 import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
 import { DecorativeCornerCircleCustom } from "@/components/ui/DecorativeCornerCircle";
 import { useTheme } from "next-themes";
-import { useEffect, useState } from "react";
+import Link from "next/link";
 import {
-  PiArrowRightDuotone,
   PiCalendarDuotone,
+  PiFileTextDuotone,
+  PiGlobeHemisphereWestDuotone,
   PiNewspaperDuotone,
+  PiShieldCheckDuotone,
 } from "react-icons/pi";
 
 const blogPosts = [
   {
     title: "Understanding FDA's New Labeling Requirements",
-    excerpt: "A comprehensive guide to the latest FDA labeling guidelines and how they impact your medical device documentation.",
+    excerpt:
+      "A comprehensive guide to the latest FDA labeling guidelines and how they impact your medical device documentation.",
     date: "2024-12-15",
     category: "Regulatory Update",
   },
   {
     title: "EU MDR Compliance: A Step-by-Step Approach",
-    excerpt: "Navigate the complexities of European Medical Device Regulation with this practical implementation guide.",
+    excerpt:
+      "Navigate the complexities of European Medical Device Regulation with this practical implementation guide.",
     date: "2024-12-01",
     category: "Compliance Guide",
   },
   {
     title: "ISO 15223-1:2021 Key Changes Explained",
-    excerpt: "Understanding the important updates to the international standard for medical device symbols.",
+    excerpt:
+      "Understanding the important updates to the international standard for medical device symbols.",
     date: "2024-11-20",
     category: "Standards",
   },
@@ -35,21 +39,30 @@ const blogPosts = [
 const newsUpdates = [
   {
     title: "FDA Announces Updated UDI Compliance Deadlines",
-    excerpt: "New timeline for Unique Device Identifier requirements gives manufacturers additional flexibility.",
+    highlight: "UDI timeline shift",
+    excerpt:
+      "New timeline for Unique Device Identifier requirements gives manufacturers additional flexibility.",
     date: "2024-12-10",
     source: "FDA",
+    icon: PiShieldCheckDuotone,
   },
   {
     title: "EU MDR Implementation Extended for Certain Devices",
-    excerpt: "European Commission grants transition period for specific medical device categories.",
+    highlight: "EU MDR extension",
+    excerpt:
+      "European Commission grants transition period for specific medical device categories.",
     date: "2024-12-05",
     source: "EU Commission",
+    icon: PiGlobeHemisphereWestDuotone,
   },
   {
     title: "New ISO Standard for Digital Labeling Published",
-    excerpt: "International Organization for Standardization releases guidance for electronic labeling.",
+    highlight: "ISO eLabel guidance",
+    excerpt:
+      "International Organization for Standardization releases guidance for electronic labeling.",
     date: "2024-11-28",
     source: "ISO",
+    icon: PiFileTextDuotone,
   },
 ];
 
@@ -62,19 +75,13 @@ const focusAreas = [
 
 export default function BlogsSection() {
   const { resolvedTheme } = useTheme();
-  const [mounted, setMounted] = useState(false);
-
-  useEffect(() => {
-    setMounted(true);
-  }, []);
-
-  const badgeVariant = mounted && resolvedTheme === "dark" ? "outline" : "white";
+  const badgeVariant = resolvedTheme === "dark" ? "outline" : "white";
   const featuredPost = blogPosts[0];
-  const latestPosts = blogPosts.slice(1);
 
   return (
-    <div className="w-full mt-12 mb-24 pointer-events-auto">
-      <div className="max-w-6xl mx-auto mb-12 px-4">
+    <div className="w-full mt-16 mb-24 pointer-events-auto relative">
+      <div className="absolute top-0 left-0 w-full h-0 border-b border-dashed border-border/80" />
+      <div className="max-w-6xl mx-auto mb-12">
         <Badge
           variant={badgeVariant}
           className="mb-8 z-60 dark:px-2 dark:py-0.5"
@@ -83,9 +90,9 @@ export default function BlogsSection() {
           <span className="font-medium">Blogs</span>
         </Badge>
         <div className="w-full flex flex-col lg:flex-row items-start gap-8">
-          <h2 className="text-4xl md:text-5xl lg:text-6xl font-medium leading-tight">
+          <h1 className="text-4xl md:text-5xl lg:text-6xl font-medium leading-tightest">
             Insights for labeling leaders who need clarity fast
-          </h2>
+          </h1>
           <div className="hidden lg:block h-24 w-px bg-border" />
           <p className="text-lg text-muted-foreground max-w-md">
             Clear, concise analysis of the regulatory shifts that matter most.
@@ -100,22 +107,16 @@ export default function BlogsSection() {
             </Badge>
           ))}
         </div>
-        <div className="mt-8 flex flex-wrap items-center gap-4">
-          <Button size="lg">Subscribe for updates</Button>
-          <Button size="lg" variant="outline">
-            See all posts
-          </Button>
-        </div>
       </div>
 
       <div className="relative w-full mb-16">
-        <div className="max-w-6xl mx-auto relative px-4">
+        <div className="max-w-6xl mx-auto relative">
           <DecorativeCornerCircleCustom
-            positionClassName="-bottom-15 -left-15"
-            rotation={180}
+            positionClassName="bottom-0 -left-15"
+            rotation={0}
           />
           <DecorativeCornerCircleCustom
-            positionClassName="-bottom-7.5 -right-22.5"
+            positionClassName="bottom-0 -right-15"
             rotation={90}
           />
           <DecorativeCornerCircleCustom
@@ -124,119 +125,126 @@ export default function BlogsSection() {
           />
 
           <div className="p-1 bg-accent border-border border rounded-[12px]">
-            <div className="grid grid-cols-1 lg:grid-cols-3 gap-1">
-              <div className="lg:col-span-2 rounded-[10px] border border-border bg-foreground text-background p-6">
-                <div className="flex items-center justify-between">
-                  <Badge
-                    variant="outline"
-                    className="border-background/40 text-background/80"
-                  >
-                    {featuredPost.category}
-                  </Badge>
-                  <span className="text-xs text-background/70">
-                    Featured
-                  </span>
-                </div>
-                <h3 className="mt-4 text-2xl font-semibold leading-tight">
-                  {featuredPost.title}
-                </h3>
-                <p className="mt-3 text-sm text-background/80">
-                  {featuredPost.excerpt}
-                </p>
-                <div className="mt-6 flex items-center justify-between">
-                  <div className="flex items-center gap-2 text-xs text-background/70">
-                    <PiCalendarDuotone className="size-4" />
-                    {featuredPost.date}
-                  </div>
-                  <Button
-                    variant="outline"
-                    className="border-background/40 text-background hover:bg-background hover:text-foreground"
-                  >
-                    Read featured story
-                  </Button>
-                </div>
-              </div>
-              <div className="rounded-[10px] border border-border bg-background/80 p-6">
-                <div className="flex items-center justify-between">
-                  <h3 className="text-lg font-semibold">Latest posts</h3>
-                  <Badge variant="outline" className="text-xs">
-                    Updated weekly
-                  </Badge>
-                </div>
-                <div className="mt-4 space-y-4">
-                  {latestPosts.map((post) => (
-                    <div
-                      key={post.title}
-                      className="rounded-lg border border-border p-4 transition-colors hover:bg-accent/40"
-                    >
-                      <Badge variant="outline" className="text-xs">
-                        {post.category}
-                      </Badge>
-                      <h4 className="mt-2 text-base font-semibold leading-snug">
-                        {post.title}
-                      </h4>
-                      <p className="mt-2 text-sm text-muted-foreground">
-                        {post.excerpt}
-                      </p>
-                      <div className="mt-3 flex items-center justify-between">
-                        <span className="text-xs text-muted-foreground">
-                          {post.date}
+            <div className="p-2 bg-white dark:bg-neutral-800 border-border border rounded-[12px]">
+              <Link
+                href="/resources/blogs"
+                className="group relative block overflow-hidden rounded-[10px] border border-border bg-black text-white transition-transform duration-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50 hover:-translate-y-0.5"
+                aria-label={`Read featured post: ${featuredPost.title}`}
+              >
+                <div className="absolute inset-0 opacity-35 [background-image:linear-gradient(to_right,rgba(255,255,255,0.12)_1px,transparent_1px),linear-gradient(to_bottom,rgba(255,255,255,0.12)_1px,transparent_1px)] [background-size:120px_120px]" />
+                <div className="absolute inset-0 bg-linear-to-br from-white/12 via-transparent to-white/5" />
+                <div className="relative grid grid-cols-1 lg:grid-cols-[1.25fr_0.75fr] gap-8 p-6 min-h-[420px]">
+                  <div className="flex flex-col justify-between">
+                    <div>
+                      <div className="flex flex-wrap items-center gap-3 text-xs text-white/70">
+                        <span className="font-semibold tracking-wide">
+                          Uprevit Insights
                         </span>
-                        <Button variant="link" className="px-0 text-sm">
-                          Read more
-                          <PiArrowRightDuotone className="ml-1 size-4" />
-                        </Button>
+                        <Badge
+                          variant="outline"
+                          className="border-white/30 text-white/80"
+                        >
+                          {featuredPost.category}
+                        </Badge>
+                        <span className="rounded-full border border-white/20 px-2 py-0.5 text-[11px] uppercase">
+                          Featured
+                        </span>
                       </div>
+                      <h3 className="mt-6 text-4xl md:text-5xl font-semibold leading-tight">
+                        {featuredPost.title}
+                      </h3>
+                      <p className="mt-4 text-sm text-white/70">
+                        {featuredPost.excerpt}
+                      </p>
                     </div>
-                  ))}
+                    <div className="mt-8 flex items-center gap-2 text-xs text-white/70">
+                      <PiCalendarDuotone className="size-4" />
+                      {featuredPost.date}
+                    </div>
+                  </div>
+                  <div className="flex flex-col justify-center gap-4 border-t border-white/10 pt-6 lg:border-t-0 lg:pl-6">
+                    <div className="text-xs uppercase tracking-widest text-white/50">
+                      Focus areas
+                    </div>
+                    <div className="space-y-3 text-sm font-medium text-white/70">
+                      <div>FDA labeling updates</div>
+                      <div>EU MDR enforcement timelines</div>
+                      <div>ISO symbol guidance</div>
+                      <div>Audit readiness playbooks</div>
+                    </div>
+                    <div className="mt-2 flex flex-wrap items-center gap-3 text-xs text-white/50">
+                      <span>Updated weekly</span>
+                      <span className="h-1 w-1 rounded-full bg-white/40" />
+                      <span>Actionable summaries</span>
+                    </div>
+                  </div>
                 </div>
-              </div>
+              </Link>
             </div>
           </div>
         </div>
-        <div className="absolute top-0 left-0 w-full h-px bg-border/60" />
-        <div className="absolute bottom-0 left-0 w-full h-px bg-border/60" />
+        <div className="absolute top-0 left-0 w-full h-0 border-b border-dashed border-border/80" />
+        <div className="absolute bottom-0 left-0 w-full h-0 border-b border-dashed border-border/80" />
       </div>
 
-      <div className="max-w-6xl mx-auto px-4">
-        <div className="flex flex-col lg:flex-row items-start gap-8 mb-8">
-          <h2 className="text-3xl md:text-4xl font-medium">
-            Regulatory briefings in plain language
-          </h2>
-          <p className="text-lg text-muted-foreground max-w-2xl">
-            We distill complex announcements into clear, actionable steps. Use
-            these briefings to align your labeling roadmap with upcoming
-            enforcement timelines.
-          </p>
-        </div>
-        <div className="p-1 bg-accent border-border border rounded-[12px]">
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-1">
-            {newsUpdates.map((news) => (
-              <div
-                key={news.title}
-                className="rounded-[10px] border border-border bg-background/80 p-6 transition-colors hover:bg-accent/40"
-              >
-                <div className="flex items-center justify-between">
-                  <Badge variant="secondary" className="text-xs">
-                    {news.source}
-                  </Badge>
-                  <span className="text-xs text-muted-foreground">
-                    {news.date}
-                  </span>
-                </div>
-                <h3 className="mt-4 text-lg font-semibold leading-tight">
-                  {news.title}
-                </h3>
-                <p className="mt-3 text-sm text-muted-foreground">
-                  {news.excerpt}
-                </p>
-                <Button variant="outline" size="sm" className="mt-4">
-                  Read full briefing
-                </Button>
-              </div>
-            ))}
+      <div className="relative">
+        <div className="relative max-w-6xl mx-auto">
+          <DecorativeCornerCircleCustom
+            positionClassName="-bottom-15 -left-15"
+            rotation={270}
+          />
+          <DecorativeCornerCircleCustom
+            positionClassName="-bottom-15 -right-15"
+            rotation={180}
+          />
+          <div className="p-1 bg-accent border-border border rounded-[12px]">
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-1">
+              {newsUpdates.map((news) => (
+                <Link
+                  key={news.title}
+                  href="/resources/blogs"
+                  className="group overflow-hidden rounded-[10px] border border-border bg-background/80 transition-transform duration-300 hover:-translate-y-0.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
+                  aria-label={`Read blog update: ${news.title}`}
+                >
+                  <div className="relative h-62 bg-black dark:bg-neutral-900 text-white">
+                    <div className="absolute inset-0 opacity-35 [background-image:linear-gradient(to_right,rgba(255,255,255,0.12)_1px,transparent_1px),linear-gradient(to_bottom,rgba(255,255,255,0.12)_1px,transparent_1px)] [background-size:120px_120px]" />
+                    <div className="absolute inset-0 bg-linear-to-br from-white/10 via-transparent to-white/5" />
+                    <div className="relative flex h-full flex-col justify-between p-4">
+                      <div className="flex items-center justify-between text-xs text-white/70">
+                        <span className="uppercase tracking-wide">
+                          {news.source}
+                        </span>
+                        <news.icon className="size-4" />
+                      </div>
+                      <div>
+                        <p className="text-[11px] uppercase tracking-widest text-white/50">
+                          Regulatory briefing
+                        </p>
+                        <h3 className="mt-2 text-lg font-semibold leading-tight">
+                          {news.highlight}
+                        </h3>
+                      </div>
+                    </div>
+                  </div>
+                  <div className="p-5">
+                    <h4 className="text-base font-semibold leading-tight">
+                      {news.title}
+                    </h4>
+                    <p className="mt-2 text-sm text-muted-foreground line-clamp-2">
+                      {news.excerpt}
+                    </p>
+                    <div className="mt-4 flex items-center gap-2 text-xs text-muted-foreground">
+                      <PiCalendarDuotone className="size-4" />
+                      {news.date}
+                    </div>
+                  </div>
+                </Link>
+              ))}
+            </div>
           </div>
         </div>
+        <div className="absolute top-0 left-0 w-full h-0 border-b border-dashed border-border/80" />
+        <div className="absolute bottom-0 left-0 w-full h-0 border-b border-dashed border-border/80" />
       </div>
     </div>
   );

--- a/features/resources/blogs/BlogsSection.tsx
+++ b/features/resources/blogs/BlogsSection.tsx
@@ -2,10 +2,14 @@
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { DecorativeCornerCircleCustom } from "@/components/ui/DecorativeCornerCircle";
 import { useTheme } from "next-themes";
 import { useEffect, useState } from "react";
-import { PiNewspaperDuotone, PiArrowRightDuotone, PiCalendarDuotone } from "react-icons/pi";
+import {
+  PiArrowRightDuotone,
+  PiCalendarDuotone,
+  PiNewspaperDuotone,
+} from "react-icons/pi";
 
 const blogPosts = [
   {
@@ -49,6 +53,13 @@ const newsUpdates = [
   },
 ];
 
+const focusAreas = [
+  "FDA updates",
+  "EU MDR shifts",
+  "ISO standards",
+  "Labeling operations",
+];
+
 export default function BlogsSection() {
   const { resolvedTheme } = useTheme();
   const [mounted, setMounted] = useState(false);
@@ -58,90 +69,171 @@ export default function BlogsSection() {
   }, []);
 
   const badgeVariant = mounted && resolvedTheme === "dark" ? "outline" : "white";
+  const featuredPost = blogPosts[0];
+  const latestPosts = blogPosts.slice(1);
 
   return (
-    <div className="w-full mt-10 mb-20 pointer-events-auto">
-      {/* Part 1: Navigate Compliance with Clarity */}
-      <div className="max-w-6xl mx-auto mb-16 px-4">
-        <Badge variant={badgeVariant} className="mb-8 z-60 dark:px-2 dark:py-0.5">
+    <div className="w-full mt-12 mb-24 pointer-events-auto">
+      <div className="max-w-6xl mx-auto mb-12 px-4">
+        <Badge
+          variant={badgeVariant}
+          className="mb-8 z-60 dark:px-2 dark:py-0.5"
+        >
+          <PiNewspaperDuotone className="text-foreground/60" />
           <span className="font-medium">Blogs</span>
         </Badge>
-        <div className="w-full flex flex-col md:flex-row items-start gap-4 mb-6">
-          <h2 className="text-4xl md:text-5xl font-medium">
-            Navigate Compliance with Clarity and Confidence
+        <div className="w-full flex flex-col lg:flex-row items-start gap-8">
+          <h2 className="text-4xl md:text-5xl lg:text-6xl font-medium leading-tight">
+            Insights for labeling leaders who need clarity fast
           </h2>
+          <div className="hidden lg:block h-24 w-px bg-border" />
+          <p className="text-lg text-muted-foreground max-w-md">
+            Clear, concise analysis of the regulatory shifts that matter most.
+            Stay ahead of enforcement changes with practical guidance you can
+            act on.
+          </p>
         </div>
-        <p className="text-lg text-muted-foreground max-w-3xl mb-8">
-          The medical device landscape is constantly evolving, making compliant labeling a continuous
-          challenge. Our blog and news section provides clear, expert analysis of the latest regulatory
-          shifts, giving you the critical knowledge to make informed decisions and stay ahead of
-          enforcement.
-        </p>
-
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-          {blogPosts.map((post, index) => (
-            <Card key={index} className="hover:shadow-lg transition-shadow duration-300">
-              <CardHeader>
-                <div className="flex items-center gap-2 mb-2">
-                  <Badge variant="outline">{post.category}</Badge>
-                </div>
-                <CardTitle className="text-lg leading-tight">{post.title}</CardTitle>
-                <CardDescription className="flex items-center gap-1 mt-2">
-                  <PiCalendarDuotone className="w-4 h-4" />
-                  {post.date}
-                </CardDescription>
-              </CardHeader>
-              <CardContent>
-                <CardDescription className="text-base mb-4">
-                  {post.excerpt}
-                </CardDescription>
-                <Button variant="link" className="px-0">
-                  Read More
-                  <PiArrowRightDuotone className="w-4 h-4 ml-1" />
-                </Button>
-              </CardContent>
-            </Card>
+        <div className="mt-6 flex flex-wrap gap-2">
+          {focusAreas.map((area) => (
+            <Badge key={area} variant="outline" className="text-xs">
+              {area}
+            </Badge>
           ))}
+        </div>
+        <div className="mt-8 flex flex-wrap items-center gap-4">
+          <Button size="lg">Subscribe for updates</Button>
+          <Button size="lg" variant="outline">
+            See all posts
+          </Button>
         </div>
       </div>
 
-      {/* Part 2: Decoding Regulatory Change */}
-      <div className="max-w-6xl mx-auto px-4">
-        <div className="border-t pt-16">
-          <div className="w-full flex flex-col md:flex-row items-start gap-4 mb-6">
-            <h2 className="text-4xl md:text-5xl font-medium">
-              Decoding Regulatory Change
-            </h2>
-          </div>
-          <p className="text-lg text-muted-foreground max-w-3xl mb-8">
-            Compliance is complex, but understanding it shouldn&apos;t be. We break down the latest
-            regulatory announcements from bodies worldwide, transforming complicated rules into clear,
-            actionable steps for your labeling teams. Get the crucial intelligence you need to
-            future-proof your product documentation.
-          </p>
+      <div className="relative w-full mb-16">
+        <div className="max-w-6xl mx-auto relative px-4">
+          <DecorativeCornerCircleCustom
+            positionClassName="-bottom-15 -left-15"
+            rotation={180}
+          />
+          <DecorativeCornerCircleCustom
+            positionClassName="-bottom-7.5 -right-22.5"
+            rotation={90}
+          />
+          <DecorativeCornerCircleCustom
+            positionClassName="-top-15 -right-15"
+            rotation={90}
+          />
 
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-            {newsUpdates.map((news, index) => (
-              <Card key={index} className="hover:shadow-md transition-shadow">
-                <CardHeader>
-                  <div className="flex items-center justify-between mb-2">
-                    <Badge variant="secondary">{news.source}</Badge>
+          <div className="p-1 bg-accent border-border border rounded-[12px]">
+            <div className="grid grid-cols-1 lg:grid-cols-3 gap-1">
+              <div className="lg:col-span-2 rounded-[10px] border border-border bg-foreground text-background p-6">
+                <div className="flex items-center justify-between">
+                  <Badge
+                    variant="outline"
+                    className="border-background/40 text-background/80"
+                  >
+                    {featuredPost.category}
+                  </Badge>
+                  <span className="text-xs text-background/70">
+                    Featured
+                  </span>
+                </div>
+                <h3 className="mt-4 text-2xl font-semibold leading-tight">
+                  {featuredPost.title}
+                </h3>
+                <p className="mt-3 text-sm text-background/80">
+                  {featuredPost.excerpt}
+                </p>
+                <div className="mt-6 flex items-center justify-between">
+                  <div className="flex items-center gap-2 text-xs text-background/70">
+                    <PiCalendarDuotone className="size-4" />
+                    {featuredPost.date}
                   </div>
-                  <CardTitle className="text-lg leading-tight">{news.title}</CardTitle>
-                  <CardDescription className="flex items-center gap-1 mt-2">
-                    <PiCalendarDuotone className="w-4 h-4" />
-                    {news.date}
-                  </CardDescription>
-                </CardHeader>
-                <CardContent>
-                  <CardDescription className="text-base mb-4">
-                    {news.excerpt}
-                  </CardDescription>
-                  <Button variant="outline" size="sm">
-                    Read Full Article
+                  <Button
+                    variant="outline"
+                    className="border-background/40 text-background hover:bg-background hover:text-foreground"
+                  >
+                    Read featured story
                   </Button>
-                </CardContent>
-              </Card>
+                </div>
+              </div>
+              <div className="rounded-[10px] border border-border bg-background/80 p-6">
+                <div className="flex items-center justify-between">
+                  <h3 className="text-lg font-semibold">Latest posts</h3>
+                  <Badge variant="outline" className="text-xs">
+                    Updated weekly
+                  </Badge>
+                </div>
+                <div className="mt-4 space-y-4">
+                  {latestPosts.map((post) => (
+                    <div
+                      key={post.title}
+                      className="rounded-lg border border-border p-4 transition-colors hover:bg-accent/40"
+                    >
+                      <Badge variant="outline" className="text-xs">
+                        {post.category}
+                      </Badge>
+                      <h4 className="mt-2 text-base font-semibold leading-snug">
+                        {post.title}
+                      </h4>
+                      <p className="mt-2 text-sm text-muted-foreground">
+                        {post.excerpt}
+                      </p>
+                      <div className="mt-3 flex items-center justify-between">
+                        <span className="text-xs text-muted-foreground">
+                          {post.date}
+                        </span>
+                        <Button variant="link" className="px-0 text-sm">
+                          Read more
+                          <PiArrowRightDuotone className="ml-1 size-4" />
+                        </Button>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div className="absolute top-0 left-0 w-full h-px bg-border/60" />
+        <div className="absolute bottom-0 left-0 w-full h-px bg-border/60" />
+      </div>
+
+      <div className="max-w-6xl mx-auto px-4">
+        <div className="flex flex-col lg:flex-row items-start gap-8 mb-8">
+          <h2 className="text-3xl md:text-4xl font-medium">
+            Regulatory briefings in plain language
+          </h2>
+          <p className="text-lg text-muted-foreground max-w-2xl">
+            We distill complex announcements into clear, actionable steps. Use
+            these briefings to align your labeling roadmap with upcoming
+            enforcement timelines.
+          </p>
+        </div>
+        <div className="p-1 bg-accent border-border border rounded-[12px]">
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-1">
+            {newsUpdates.map((news) => (
+              <div
+                key={news.title}
+                className="rounded-[10px] border border-border bg-background/80 p-6 transition-colors hover:bg-accent/40"
+              >
+                <div className="flex items-center justify-between">
+                  <Badge variant="secondary" className="text-xs">
+                    {news.source}
+                  </Badge>
+                  <span className="text-xs text-muted-foreground">
+                    {news.date}
+                  </span>
+                </div>
+                <h3 className="mt-4 text-lg font-semibold leading-tight">
+                  {news.title}
+                </h3>
+                <p className="mt-3 text-sm text-muted-foreground">
+                  {news.excerpt}
+                </p>
+                <Button variant="outline" size="sm" className="mt-4">
+                  Read full briefing
+                </Button>
+              </div>
             ))}
           </div>
         </div>

--- a/features/resources/standards/StandardsSymbolsSection.tsx
+++ b/features/resources/standards/StandardsSymbolsSection.tsx
@@ -2,18 +2,26 @@
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { DecorativeCornerCircleCustom } from "@/components/ui/DecorativeCornerCircle";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { useTheme } from "next-themes";
 import { useEffect, useState } from "react";
-import { PiImagesDuotone, PiFileTextDuotone, PiLinkDuotone } from "react-icons/pi";
+import { PiFileTextDuotone, PiImagesDuotone, PiLinkDuotone } from "react-icons/pi";
 
 const symbols = [
   {
     title: "Global Compliance Iconography",
-    description: "Ensure universal understanding and regulatory adherence with our comprehensive library of standardized medical device symbols.",
-    usage: "LinkedIn Ref, Cue Cards & Usage",
+    description:
+      "Ensure universal understanding with standardized medical device symbols aligned to global guidance.",
+    usage: "Reference sheets, cue cards, usage notes",
   },
+];
+
+const symbolHighlights = [
+  "Packaging & transport handling",
+  "Sterility and safety indicators",
+  "UDI and traceability markers",
+  "Region-specific compliance marks",
 ];
 
 const isoDocuments = [
@@ -46,87 +54,175 @@ export default function StandardsSymbolsSection() {
   const badgeVariant = mounted && resolvedTheme === "dark" ? "outline" : "white";
 
   return (
-    <div className="w-full mt-10 mb-20 pointer-events-auto">
-      <div className="max-w-6xl mx-auto mb-8 px-4">
-        <Badge variant={badgeVariant} className="mb-8 z-60 dark:px-2 dark:py-0.5">
+    <div className="w-full mt-12 mb-24 pointer-events-auto">
+      <div className="max-w-6xl mx-auto mb-10 px-4">
+        <Badge
+          variant={badgeVariant}
+          className="mb-8 z-60 dark:px-2 dark:py-0.5"
+        >
           <span className="font-medium">Standards & Symbols</span>
         </Badge>
-        <div className="w-full flex flex-col md:flex-row items-start gap-4">
-          <h2 className="text-4xl md:text-5xl font-medium">
-            Standards & Regulatory Symbols
+        <div className="w-full flex flex-col lg:flex-row items-start gap-8">
+          <h2 className="text-4xl md:text-5xl lg:text-6xl font-medium leading-tight">
+            Standards, symbols, and references for global compliance
           </h2>
+          <div className="hidden lg:block h-24 w-px bg-border" />
+          <p className="text-lg text-muted-foreground max-w-md">
+            Centralize symbol guidance and ISO references in one place so teams
+            can label confidently across markets.
+          </p>
         </div>
       </div>
 
-      <div className="max-w-6xl mx-auto px-4">
-        <Tabs defaultValue="symbols" className="w-full">
-          <TabsList className="grid w-full grid-cols-2 max-w-md">
-            <TabsTrigger value="symbols">Symbol Library</TabsTrigger>
-            <TabsTrigger value="iso">ISO Documents</TabsTrigger>
-          </TabsList>
+      <div className="relative w-full">
+        <div className="max-w-6xl mx-auto relative px-4">
+          <DecorativeCornerCircleCustom
+            positionClassName="-bottom-15 -left-15"
+            rotation={180}
+          />
+          <DecorativeCornerCircleCustom
+            positionClassName="-bottom-7.5 -right-22.5"
+            rotation={90}
+          />
+          <DecorativeCornerCircleCustom
+            positionClassName="-top-15 -right-15"
+            rotation={90}
+          />
 
-          <TabsContent value="symbols" className="mt-6">
-            <div className="space-y-6">
-              {symbols.map((symbol, index) => (
-                <Card key={index}>
-                  <CardHeader>
-                    <CardTitle className="flex items-center gap-2">
-                      <PiImagesDuotone className="w-6 h-6 text-primary" />
-                      {symbol.title}
-                    </CardTitle>
-                    <CardDescription className="text-base">
-                      {symbol.description}
-                    </CardDescription>
-                  </CardHeader>
-                  <CardContent>
-                    <div className="flex items-center gap-2 p-4 bg-muted rounded-lg">
-                      <PiLinkDuotone className="w-5 h-5 text-muted-foreground" />
-                      <span className="text-sm font-medium">{symbol.usage}</span>
-                    </div>
-                    <div className="mt-4">
-                      <Button variant="outline">
-                        Browse Symbol Library
-                      </Button>
-                    </div>
-                  </CardContent>
-                </Card>
-              ))}
-            </div>
-          </TabsContent>
-
-          <TabsContent value="iso" className="mt-6">
-            <Card>
-              <CardHeader>
-                <CardTitle className="flex items-center gap-2">
-                  <PiFileTextDuotone className="w-6 h-6 text-primary" />
-                  ISO Documents Repository
-                </CardTitle>
-                <CardDescription className="text-base">
-                  Access the complete, up-to-date library of critical ISO standards relevant to
-                  medical device labeling and compliance, all in one centralized location.
-                </CardDescription>
-              </CardHeader>
-              <CardContent>
-                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                  {isoDocuments.map((doc, index) => (
-                    <div
-                      key={index}
-                      className="p-4 border rounded-lg hover:bg-muted/50 transition-colors"
-                    >
-                      <h4 className="font-semibold">{doc.title}</h4>
-                      <p className="text-sm text-muted-foreground mt-1">
-                        {doc.description}
-                      </p>
-                      <Button variant="link" size="sm" className="mt-2 px-0">
-                        View Document
-                      </Button>
-                    </div>
-                  ))}
+          <div className="p-1 bg-accent border-border border rounded-[12px]">
+            <Tabs defaultValue="symbols" className="w-full">
+              <div className="flex flex-col lg:flex-row items-start justify-between gap-6 rounded-[10px] border border-border bg-background/80 p-6">
+                <div>
+                  <h3 className="text-xl font-semibold">Library explorer</h3>
+                  <p className="mt-2 text-sm text-muted-foreground">
+                    Switch between symbol guidance and ISO references without
+                    losing context.
+                  </p>
                 </div>
-              </CardContent>
-            </Card>
-          </TabsContent>
-        </Tabs>
+                <TabsList className="grid w-full max-w-md grid-cols-2">
+                  <TabsTrigger value="symbols">Symbol Library</TabsTrigger>
+                  <TabsTrigger value="iso">ISO Documents</TabsTrigger>
+                </TabsList>
+              </div>
+
+              <TabsContent value="symbols" className="mt-6">
+                <div className="grid grid-cols-1 lg:grid-cols-[1.2fr_1fr] gap-6">
+                  <div className="rounded-lg border border-border bg-background/90 p-6">
+                    {symbols.map((symbol) => (
+                      <div key={symbol.title}>
+                        <div className="flex items-center gap-2">
+                          <PiImagesDuotone className="size-6 text-primary" />
+                          <h4 className="text-lg font-semibold">
+                            {symbol.title}
+                          </h4>
+                        </div>
+                        <p className="mt-2 text-sm text-muted-foreground">
+                          {symbol.description}
+                        </p>
+                        <div className="mt-5 flex items-center gap-2 rounded-lg border border-border bg-muted/50 p-4">
+                          <PiLinkDuotone className="size-5 text-muted-foreground" />
+                          <span className="text-sm font-medium">
+                            {symbol.usage}
+                          </span>
+                        </div>
+                        <div className="mt-6 grid grid-cols-2 gap-3">
+                          {symbolHighlights.map((highlight) => (
+                            <div
+                              key={highlight}
+                              className="rounded-lg border border-border bg-background/80 p-3 text-xs text-muted-foreground"
+                            >
+                              {highlight}
+                            </div>
+                          ))}
+                        </div>
+                        <Button variant="outline" className="mt-6">
+                          Browse symbol library
+                        </Button>
+                      </div>
+                    ))}
+                  </div>
+                  <div className="rounded-lg border border-border bg-background/90 p-6">
+                    <h4 className="text-lg font-semibold">Quick access</h4>
+                    <p className="mt-2 text-sm text-muted-foreground">
+                      Save time with the most requested symbol sets and
+                      references.
+                    </p>
+                    <div className="mt-4 space-y-3">
+                      {symbolHighlights.map((item) => (
+                        <div
+                          key={item}
+                          className="flex items-center gap-3 rounded-lg border border-border p-3 text-sm"
+                        >
+                          <span className="size-1.5 rounded-full bg-foreground/60" />
+                          {item}
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                </div>
+              </TabsContent>
+
+              <TabsContent value="iso" className="mt-6">
+                <div className="grid grid-cols-1 lg:grid-cols-[1.1fr_1.3fr] gap-6">
+                  <div className="rounded-lg border border-border bg-background/90 p-6">
+                    <div className="flex items-center gap-2">
+                      <PiFileTextDuotone className="size-6 text-primary" />
+                      <h4 className="text-lg font-semibold">
+                        ISO Documents Repository
+                      </h4>
+                    </div>
+                    <p className="mt-2 text-sm text-muted-foreground">
+                      Access the latest ISO standards used in medical device
+                      labeling and compliance workflows.
+                    </p>
+                    <div className="mt-6 space-y-3">
+                      {isoDocuments.slice(0, 2).map((doc) => (
+                        <div
+                          key={doc.title}
+                          className="rounded-lg border border-border p-4"
+                        >
+                          <h5 className="text-sm font-semibold">{doc.title}</h5>
+                          <p className="mt-1 text-xs text-muted-foreground">
+                            {doc.description}
+                          </p>
+                        </div>
+                      ))}
+                    </div>
+                    <Button variant="outline" className="mt-6">
+                      Request full ISO access
+                    </Button>
+                  </div>
+                  <div className="rounded-lg border border-border bg-background/90 p-6">
+                    <div className="flex items-center justify-between">
+                      <h4 className="text-lg font-semibold">Latest standards</h4>
+                      <Badge variant="outline" className="text-xs">
+                        Updated
+                      </Badge>
+                    </div>
+                    <div className="mt-4 grid grid-cols-1 md:grid-cols-2 gap-4">
+                      {isoDocuments.map((doc) => (
+                        <div
+                          key={doc.title}
+                          className="rounded-lg border border-border p-4 transition-colors hover:bg-muted/50"
+                        >
+                          <h5 className="text-sm font-semibold">{doc.title}</h5>
+                          <p className="mt-1 text-xs text-muted-foreground">
+                            {doc.description}
+                          </p>
+                          <Button variant="link" size="sm" className="mt-2 px-0">
+                            View document
+                          </Button>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                </div>
+              </TabsContent>
+            </Tabs>
+          </div>
+        </div>
+        <div className="absolute top-0 left-0 w-full h-px bg-border/60" />
+        <div className="absolute bottom-0 left-0 w-full h-px bg-border/60" />
       </div>
     </div>
   );

--- a/features/resources/standards/StandardsSymbolsSection.tsx
+++ b/features/resources/standards/StandardsSymbolsSection.tsx
@@ -3,10 +3,13 @@
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { DecorativeCornerCircleCustom } from "@/components/ui/DecorativeCornerCircle";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { useTheme } from "next-themes";
-import { useEffect, useState } from "react";
-import { PiFileTextDuotone, PiImagesDuotone, PiLinkDuotone } from "react-icons/pi";
+import {
+  PiBookOpenDuotone,
+  PiFileTextDuotone,
+  PiImagesDuotone,
+  PiLinkDuotone,
+} from "react-icons/pi";
 
 const symbols = [
   {
@@ -27,7 +30,8 @@ const symbolHighlights = [
 const isoDocuments = [
   {
     title: "ISO 15223-1:2021",
-    description: "Symbols to be used with medical devices, labels, and labeling.",
+    description:
+      "Symbols to be used with medical devices, labels, and labeling.",
   },
   {
     title: "ISO 7000:2014",
@@ -45,27 +49,23 @@ const isoDocuments = [
 
 export default function StandardsSymbolsSection() {
   const { resolvedTheme } = useTheme();
-  const [mounted, setMounted] = useState(false);
-
-  useEffect(() => {
-    setMounted(true);
-  }, []);
-
-  const badgeVariant = mounted && resolvedTheme === "dark" ? "outline" : "white";
+  const badgeVariant = resolvedTheme === "dark" ? "outline" : "white";
 
   return (
-    <div className="w-full mt-12 mb-24 pointer-events-auto">
-      <div className="max-w-6xl mx-auto mb-10 px-4">
+    <div className="w-full mt-16 mb-24 pointer-events-auto relative">
+      <div className="absolute top-0 left-0 w-full h-0 border-b border-dashed border-border/80" />
+      <div className="max-w-6xl mx-auto mb-10">
         <Badge
           variant={badgeVariant}
           className="mb-8 z-60 dark:px-2 dark:py-0.5"
         >
+          <PiBookOpenDuotone />
           <span className="font-medium">Standards & Symbols</span>
         </Badge>
         <div className="w-full flex flex-col lg:flex-row items-start gap-8">
-          <h2 className="text-4xl md:text-5xl lg:text-6xl font-medium leading-tight">
+          <h1 className="text-4xl md:text-5xl lg:text-6xl font-medium leading-tightest">
             Standards, symbols, and references for global compliance
-          </h2>
+          </h1>
           <div className="hidden lg:block h-24 w-px bg-border" />
           <p className="text-lg text-muted-foreground max-w-md">
             Centralize symbol guidance and ISO references in one place so teams
@@ -75,14 +75,14 @@ export default function StandardsSymbolsSection() {
       </div>
 
       <div className="relative w-full">
-        <div className="max-w-6xl mx-auto relative px-4">
+        <div className="max-w-6xl mx-auto relative">
           <DecorativeCornerCircleCustom
             positionClassName="-bottom-15 -left-15"
-            rotation={180}
+            rotation={270}
           />
           <DecorativeCornerCircleCustom
-            positionClassName="-bottom-7.5 -right-22.5"
-            rotation={90}
+            positionClassName="-bottom-15 -right-15"
+            rotation={180}
           />
           <DecorativeCornerCircleCustom
             positionClassName="-top-15 -right-15"
@@ -90,35 +90,37 @@ export default function StandardsSymbolsSection() {
           />
 
           <div className="p-1 bg-accent border-border border rounded-[12px]">
-            <Tabs defaultValue="symbols" className="w-full">
+            <div className="flex flex-col gap-1">
               <div className="flex flex-col lg:flex-row items-start justify-between gap-6 rounded-[10px] border border-border bg-background/80 p-6">
                 <div>
-                  <h3 className="text-xl font-semibold">Library explorer</h3>
-                  <p className="mt-2 text-sm text-muted-foreground">
-                    Switch between symbol guidance and ISO references without
-                    losing context.
+                  <h2 className="text-lg font-semibold">
+                    Standards & symbol library
+                  </h2>
+                  <p className=" text-sm text-muted-foreground">
+                    One consolidated view for ISO guidance and symbol usage
+                    references.
                   </p>
                 </div>
-                <TabsList className="grid w-full max-w-md grid-cols-2">
-                  <TabsTrigger value="symbols">Symbol Library</TabsTrigger>
-                  <TabsTrigger value="iso">ISO Documents</TabsTrigger>
-                </TabsList>
               </div>
 
-              <TabsContent value="symbols" className="mt-6">
-                <div className="grid grid-cols-1 lg:grid-cols-[1.2fr_1fr] gap-6">
-                  <div className="rounded-lg border border-border bg-background/90 p-6">
-                    {symbols.map((symbol) => (
-                      <div key={symbol.title}>
-                        <div className="flex items-center gap-2">
-                          <PiImagesDuotone className="size-6 text-primary" />
-                          <h4 className="text-lg font-semibold">
-                            {symbol.title}
-                          </h4>
+              <div className="grid grid-cols-1 lg:grid-cols-2 gap-1">
+                <div className="rounded-[10px] border border-border bg-background/90 p-6 w-full">
+                  {symbols.map((symbol) => (
+                    <div
+                      key={symbol.title}
+                      className="flex flex-col gap-4 justify-between h-full"
+                    >
+                      <div>
+                        <div>
+                          <div className="flex items-center gap-2">
+                            <h4 className="text-base font-semibold">
+                              {symbol.title}
+                            </h4>
+                          </div>
+                          <p className="text-sm text-muted-foreground">
+                            {symbol.description}
+                          </p>
                         </div>
-                        <p className="mt-2 text-sm text-muted-foreground">
-                          {symbol.description}
-                        </p>
                         <div className="mt-5 flex items-center gap-2 rounded-lg border border-border bg-muted/50 p-4">
                           <PiLinkDuotone className="size-5 text-muted-foreground" />
                           <span className="text-sm font-medium">
@@ -135,46 +137,27 @@ export default function StandardsSymbolsSection() {
                             </div>
                           ))}
                         </div>
-                        <Button variant="outline" className="mt-6">
-                          Browse symbol library
-                        </Button>
                       </div>
-                    ))}
-                  </div>
-                  <div className="rounded-lg border border-border bg-background/90 p-6">
-                    <h4 className="text-lg font-semibold">Quick access</h4>
-                    <p className="mt-2 text-sm text-muted-foreground">
-                      Save time with the most requested symbol sets and
-                      references.
-                    </p>
-                    <div className="mt-4 space-y-3">
-                      {symbolHighlights.map((item) => (
-                        <div
-                          key={item}
-                          className="flex items-center gap-3 rounded-lg border border-border p-3 text-sm"
-                        >
-                          <span className="size-1.5 rounded-full bg-foreground/60" />
-                          {item}
-                        </div>
-                      ))}
+                      <Button variant="outline" className="w-auto self-start">
+                        Browse symbol library
+                      </Button>
                     </div>
-                  </div>
+                  ))}
                 </div>
-              </TabsContent>
 
-              <TabsContent value="iso" className="mt-6">
-                <div className="grid grid-cols-1 lg:grid-cols-[1.1fr_1.3fr] gap-6">
-                  <div className="rounded-lg border border-border bg-background/90 p-6">
-                    <div className="flex items-center gap-2">
-                      <PiFileTextDuotone className="size-6 text-primary" />
-                      <h4 className="text-lg font-semibold">
-                        ISO Documents Repository
-                      </h4>
+                <div className="rounded-[10px] flex flex-col gap-4 justify-between border border-border bg-background/90 p-6 w-full">
+                  <div>
+                    <div>
+                      <div className="flex items-center gap-2">
+                        <h4 className="text-base font-semibold">
+                          ISO Documents Repository
+                        </h4>
+                      </div>
+                      <p className="text-sm text-muted-foreground">
+                        Access the latest ISO standards used in medical device
+                        labeling and compliance workflows.
+                      </p>
                     </div>
-                    <p className="mt-2 text-sm text-muted-foreground">
-                      Access the latest ISO standards used in medical device
-                      labeling and compliance workflows.
-                    </p>
                     <div className="mt-6 space-y-3">
                       {isoDocuments.slice(0, 2).map((doc) => (
                         <div
@@ -188,41 +171,17 @@ export default function StandardsSymbolsSection() {
                         </div>
                       ))}
                     </div>
-                    <Button variant="outline" className="mt-6">
-                      Request full ISO access
-                    </Button>
                   </div>
-                  <div className="rounded-lg border border-border bg-background/90 p-6">
-                    <div className="flex items-center justify-between">
-                      <h4 className="text-lg font-semibold">Latest standards</h4>
-                      <Badge variant="outline" className="text-xs">
-                        Updated
-                      </Badge>
-                    </div>
-                    <div className="mt-4 grid grid-cols-1 md:grid-cols-2 gap-4">
-                      {isoDocuments.map((doc) => (
-                        <div
-                          key={doc.title}
-                          className="rounded-lg border border-border p-4 transition-colors hover:bg-muted/50"
-                        >
-                          <h5 className="text-sm font-semibold">{doc.title}</h5>
-                          <p className="mt-1 text-xs text-muted-foreground">
-                            {doc.description}
-                          </p>
-                          <Button variant="link" size="sm" className="mt-2 px-0">
-                            View document
-                          </Button>
-                        </div>
-                      ))}
-                    </div>
-                  </div>
+                  <Button variant="outline" className="w-auto self-start">
+                    Request full ISO access
+                  </Button>
                 </div>
-              </TabsContent>
-            </Tabs>
+              </div>
+            </div>
           </div>
         </div>
-        <div className="absolute top-0 left-0 w-full h-px bg-border/60" />
-        <div className="absolute bottom-0 left-0 w-full h-px bg-border/60" />
+        <div className="absolute top-0 left-0 w-full h-0 border-b border-dashed border-border/80" />
+        <div className="absolute bottom-0 left-0 w-full h-0 border-b border-dashed border-border/80" />
       </div>
     </div>
   );

--- a/features/resources/templates/TemplatesSection.tsx
+++ b/features/resources/templates/TemplatesSection.tsx
@@ -2,41 +2,66 @@
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion";
+import { DecorativeCornerCircleCustom } from "@/components/ui/DecorativeCornerCircle";
 import { useTheme } from "next-themes";
 import { useEffect, useState } from "react";
-import { PiDownloadDuotone, PiFileTextDuotone, PiCheckCircleDuotone } from "react-icons/pi";
+import {
+  PiCheckCircleDuotone,
+  PiDownloadDuotone,
+  PiFileTextDuotone,
+} from "react-icons/pi";
 
-const templates = [
+const templateItems = [
   {
-    category: "Checklist & Templates",
-    items: [
-      {
-        title: "Gap Assessment Checklist - Basic",
-        description: "Identify compliance gaps in your labeling process with this comprehensive checklist.",
-        type: "checklist",
-      },
-      {
-        title: "Validation Template (CSV)",
-        description: "Structured template for validating label data and ensuring accuracy.",
-        type: "template",
-      },
-      {
-        title: "Project Timeline & Gantt Template",
-        description: "Plan and track your labeling projects with this visual timeline template.",
-        type: "template",
-      },
-      {
-        title: "Standard File Naming Nomenclatures",
-        description: "Consistent naming conventions for medical device documentation.",
-        type: "guide",
-      },
-    ],
+    title: "Gap Assessment Checklist - Basic",
+    description:
+      "Identify compliance gaps in your labeling process with a structured, audit-ready checklist.",
+    type: "Checklist",
+    tags: ["Checklist"],
+    format: "PDF",
+  },
+  {
+    title: "Validation Template (CSV)",
+    description:
+      "Structured template for validating label data and ensuring accuracy across systems.",
+    type: "Validation",
+    tags: ["Template", "Validation"],
+    format: "CSV",
+  },
+  {
+    title: "Project Timeline & Gantt Template",
+    description:
+      "Plan and track labeling initiatives with a ready-to-use timeline tracker.",
+    type: "Template",
+    tags: ["Template"],
+    format: "XLSX",
+  },
+  {
+    title: "Standard File Naming Nomenclatures",
+    description:
+      "Align teams on consistent naming conventions for medical device documentation.",
+    type: "Guide",
+    tags: ["Guide"],
+    format: "PDF",
   },
 ];
 
 const tags = ["All", "Checklist", "Template", "Guide", "Validation"];
+
+const toolkitSteps = [
+  {
+    title: "Pick a template",
+    description: "Filter by asset type and download in your preferred format.",
+  },
+  {
+    title: "Customize for your workflow",
+    description: "Adapt checklists and validation sheets to match internal SOPs.",
+  },
+  {
+    title: "Share with reviewers",
+    description: "Use structured assets to speed up reviews and approvals.",
+  },
+];
 
 export default function TemplatesSection() {
   const { resolvedTheme } = useTheme();
@@ -48,80 +73,146 @@ export default function TemplatesSection() {
   }, []);
 
   const badgeVariant = mounted && resolvedTheme === "dark" ? "outline" : "white";
+  const filteredTemplates =
+    activeTag === "All"
+      ? templateItems
+      : templateItems.filter((item) => item.tags.includes(activeTag));
 
   return (
-    <div className="w-full mt-10 mb-20 pointer-events-auto">
-      <div className="max-w-6xl mx-auto mb-8 px-4">
-        <Badge variant={badgeVariant} className="mb-8 z-60 dark:px-2 dark:py-0.5">
+    <div className="w-full mt-12 mb-24 pointer-events-auto">
+      <div className="max-w-6xl mx-auto mb-10 px-4">
+        <Badge
+          variant={badgeVariant}
+          className="mb-8 z-60 dark:px-2 dark:py-0.5"
+        >
           <span className="font-medium">Templates</span>
         </Badge>
-        <div className="w-full flex flex-col md:flex-row items-start gap-4">
-          <h2 className="text-4xl md:text-5xl font-medium">
-            Practical Toolkits & Templates
+        <div className="w-full flex flex-col lg:flex-row items-start gap-8">
+          <h2 className="text-4xl md:text-5xl lg:text-6xl font-medium leading-tight">
+            Practical toolkits and templates built for audits
           </h2>
+          <div className="hidden lg:block h-24 w-px bg-border" />
+          <p className="text-lg text-muted-foreground max-w-md">
+            Download ready-to-use assets created by regulatory experts. Stop
+            rebuilding the basics and focus on quality review.
+          </p>
         </div>
-        <p className="mt-4 text-lg text-muted-foreground max-w-3xl">
-          The Regulatory Toolkit: Build Compliance Faster. Gain immediate access to a library of
-          battle-tested templates and checklists, designed by regulatory experts. Stop building
-          documents from scratch; simply leverage these verified assets for your medical device
-          documentation.
-        </p>
-      </div>
-
-      {/* Tags */}
-      <div className="max-w-6xl mx-auto px-4 mb-8">
-        <div className="flex flex-wrap gap-2">
-          {tags.map((tag) => (
-            <Button
-              key={tag}
-              variant={activeTag === tag ? "default" : "outline"}
-              size="sm"
-              onClick={() => setActiveTag(tag)}
-              className="rounded-full"
-            >
-              {tag}
-            </Button>
-          ))}
+        <div className="mt-8 flex flex-wrap items-center gap-4">
+          <Button size="lg">Download starter kit</Button>
+          <Button size="lg" variant="outline">
+            Request a custom pack
+          </Button>
         </div>
       </div>
 
-      {/* Templates Accordion */}
-      <div className="max-w-6xl mx-auto px-4">
-        <Accordion type="single" defaultValue="checklist-templates" className="w-full">
-          {templates.map((section, index) => (
-            <AccordionItem key={index} value={section.category.toLowerCase().replace(/\s+/g, "-")}>
-              <AccordionTrigger className="text-lg font-semibold">
-                <div className="flex items-center gap-2">
-                  <PiCheckCircleDuotone className="w-5 h-5" />
-                  {section.category}
+      <div className="relative w-full">
+        <div className="max-w-6xl mx-auto relative px-4">
+          <DecorativeCornerCircleCustom
+            positionClassName="-bottom-15 -left-15"
+            rotation={180}
+          />
+          <DecorativeCornerCircleCustom
+            positionClassName="-bottom-7.5 -right-22.5"
+            rotation={90}
+          />
+          <DecorativeCornerCircleCustom
+            positionClassName="-top-15 -right-15"
+            rotation={90}
+          />
+
+          <div className="p-1 bg-accent border-border border rounded-[12px]">
+            <div className="grid grid-cols-1 lg:grid-cols-[1.1fr_2fr] gap-1">
+              <div className="rounded-[10px] border border-border bg-background/80 p-6">
+                <div className="flex items-center gap-2 text-sm font-semibold">
+                  <PiCheckCircleDuotone className="size-5 text-foreground/60" />
+                  Built for fast adoption
                 </div>
-              </AccordionTrigger>
-              <AccordionContent>
-                <div className="grid grid-cols-1 md:grid-cols-2 gap-4 pt-4">
-                  {section.items.map((item, itemIndex) => (
-                    <Card key={itemIndex} className="hover:shadow-md transition-shadow">
-                      <CardHeader className="pb-2">
-                        <CardTitle className="text-base flex items-start gap-2">
-                          <PiFileTextDuotone className="w-5 h-5 mt-0.5 text-primary" />
-                          {item.title}
-                        </CardTitle>
-                      </CardHeader>
-                      <CardContent>
-                        <CardDescription className="mb-4">
-                          {item.description}
-                        </CardDescription>
-                        <Button variant="outline" size="sm" className="w-full">
-                          <PiDownloadDuotone className="w-4 h-4 mr-2" />
-                          Download
-                        </Button>
-                      </CardContent>
-                    </Card>
+                <p className="mt-3 text-sm text-muted-foreground">
+                  Each template includes clear guidance so teams can align
+                  quickly, reduce review cycles, and keep documentation
+                  consistent.
+                </p>
+                <div className="mt-6 space-y-4">
+                  {toolkitSteps.map((step, index) => (
+                    <div key={step.title} className="flex gap-3">
+                      <div className="flex size-8 items-center justify-center rounded-full border border-border text-xs font-semibold">
+                        {index + 1}
+                      </div>
+                      <div>
+                        <h4 className="text-sm font-semibold">{step.title}</h4>
+                        <p className="text-xs text-muted-foreground">
+                          {step.description}
+                        </p>
+                      </div>
+                    </div>
                   ))}
                 </div>
-              </AccordionContent>
-            </AccordionItem>
-          ))}
-        </Accordion>
+                <div className="mt-6 grid grid-cols-2 gap-3">
+                  <div className="rounded-lg border border-border bg-background/80 p-3">
+                    <p className="text-xs text-muted-foreground">Formats</p>
+                    <p className="text-sm font-semibold">PDF, CSV, XLSX</p>
+                  </div>
+                  <div className="rounded-lg border border-border bg-background/80 p-3">
+                    <p className="text-xs text-muted-foreground">Designed for</p>
+                    <p className="text-sm font-semibold">Regulatory audits</p>
+                  </div>
+                </div>
+              </div>
+
+              <div className="rounded-[10px] border border-border bg-background/80 p-6">
+                <div className="flex flex-wrap items-center gap-2">
+                  {tags.map((tag) => (
+                    <Button
+                      key={tag}
+                      variant={activeTag === tag ? "default" : "outline"}
+                      size="sm"
+                      onClick={() => setActiveTag(tag)}
+                      className="rounded-full"
+                    >
+                      {tag}
+                    </Button>
+                  ))}
+                </div>
+                <div className="mt-6 grid grid-cols-1 md:grid-cols-2 gap-4">
+                  {filteredTemplates.map((item) => (
+                    <div
+                      key={item.title}
+                      className="rounded-lg border border-border p-4 transition-colors hover:bg-accent/40"
+                    >
+                      <div className="flex items-start justify-between gap-4">
+                        <div>
+                          <div className="flex items-center gap-2">
+                            <PiFileTextDuotone className="size-5 text-primary" />
+                            <h4 className="text-base font-semibold">
+                              {item.title}
+                            </h4>
+                          </div>
+                          <p className="mt-2 text-sm text-muted-foreground">
+                            {item.description}
+                          </p>
+                        </div>
+                        <Badge variant="outline" className="text-xs">
+                          {item.type}
+                        </Badge>
+                      </div>
+                      <div className="mt-4 flex items-center justify-between">
+                        <span className="text-xs text-muted-foreground">
+                          {item.format}
+                        </span>
+                        <Button variant="outline" size="sm">
+                          <PiDownloadDuotone className="mr-2 size-4" />
+                          Download
+                        </Button>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div className="absolute top-0 left-0 w-full h-px bg-border/60" />
+        <div className="absolute bottom-0 left-0 w-full h-px bg-border/60" />
       </div>
     </div>
   );

--- a/features/resources/templates/TemplatesSection.tsx
+++ b/features/resources/templates/TemplatesSection.tsx
@@ -4,11 +4,11 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { DecorativeCornerCircleCustom } from "@/components/ui/DecorativeCornerCircle";
 import { useTheme } from "next-themes";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import {
-  PiCheckCircleDuotone,
   PiDownloadDuotone,
-  PiFileTextDuotone,
+  PiFilesDuotone,
+  PiTrayDuotone,
 } from "react-icons/pi";
 
 const templateItems = [
@@ -55,42 +55,39 @@ const toolkitSteps = [
   },
   {
     title: "Customize for your workflow",
-    description: "Adapt checklists and validation sheets to match internal SOPs.",
+    description:
+      "Adapt checklists and validation sheets to match internal SOPs.",
   },
   {
-    title: "Share with reviewers",
-    description: "Use structured assets to speed up reviews and approvals.",
+    title: "Share with teams",
+    description: "Use structured assets to speed up collaboration and reviews.",
   },
 ];
 
 export default function TemplatesSection() {
   const { resolvedTheme } = useTheme();
-  const [mounted, setMounted] = useState(false);
   const [activeTag, setActiveTag] = useState("All");
-
-  useEffect(() => {
-    setMounted(true);
-  }, []);
-
-  const badgeVariant = mounted && resolvedTheme === "dark" ? "outline" : "white";
+  const badgeVariant = resolvedTheme === "dark" ? "outline" : "white";
   const filteredTemplates =
     activeTag === "All"
       ? templateItems
       : templateItems.filter((item) => item.tags.includes(activeTag));
 
   return (
-    <div className="w-full mt-12 mb-24 pointer-events-auto">
-      <div className="max-w-6xl mx-auto mb-10 px-4">
+    <div className="w-full mt-16 mb-24 pointer-events-auto relative">
+      <div className="absolute top-0 left-0 w-full h-0 border-b border-dashed border-border/80" />
+      <div className="max-w-6xl mx-auto mb-10">
         <Badge
           variant={badgeVariant}
           className="mb-8 z-60 dark:px-2 dark:py-0.5"
         >
+          <PiFilesDuotone />
           <span className="font-medium">Templates</span>
         </Badge>
         <div className="w-full flex flex-col lg:flex-row items-start gap-8">
-          <h2 className="text-4xl md:text-5xl lg:text-6xl font-medium leading-tight">
-            Practical toolkits and templates built for audits
-          </h2>
+          <h1 className="text-4xl md:text-5xl lg:text-6xl font-medium leading-tightest">
+            Practical templates built for speed
+          </h1>
           <div className="hidden lg:block h-24 w-px bg-border" />
           <p className="text-lg text-muted-foreground max-w-md">
             Download ready-to-use assets created by regulatory experts. Stop
@@ -98,22 +95,25 @@ export default function TemplatesSection() {
           </p>
         </div>
         <div className="mt-8 flex flex-wrap items-center gap-4">
-          <Button size="lg">Download starter kit</Button>
           <Button size="lg" variant="outline">
+            <PiTrayDuotone />
             Request a custom pack
+          </Button>
+          <Button size="lg">
+            <PiDownloadDuotone /> Download starter kit
           </Button>
         </div>
       </div>
 
       <div className="relative w-full">
-        <div className="max-w-6xl mx-auto relative px-4">
+        <div className="max-w-6xl mx-auto relative">
           <DecorativeCornerCircleCustom
             positionClassName="-bottom-15 -left-15"
-            rotation={180}
+            rotation={270}
           />
           <DecorativeCornerCircleCustom
-            positionClassName="-bottom-7.5 -right-22.5"
-            rotation={90}
+            positionClassName="-bottom-15 -right-15"
+            rotation={180}
           />
           <DecorativeCornerCircleCustom
             positionClassName="-top-15 -right-15"
@@ -122,39 +122,46 @@ export default function TemplatesSection() {
 
           <div className="p-1 bg-accent border-border border rounded-[12px]">
             <div className="grid grid-cols-1 lg:grid-cols-[1.1fr_2fr] gap-1">
-              <div className="rounded-[10px] border border-border bg-background/80 p-6">
-                <div className="flex items-center gap-2 text-sm font-semibold">
-                  <PiCheckCircleDuotone className="size-5 text-foreground/60" />
-                  Built for fast adoption
-                </div>
-                <p className="mt-3 text-sm text-muted-foreground">
-                  Each template includes clear guidance so teams can align
-                  quickly, reduce review cycles, and keep documentation
-                  consistent.
-                </p>
-                <div className="mt-6 space-y-4">
-                  {toolkitSteps.map((step, index) => (
-                    <div key={step.title} className="flex gap-3">
-                      <div className="flex size-8 items-center justify-center rounded-full border border-border text-xs font-semibold">
-                        {index + 1}
-                      </div>
-                      <div>
-                        <h4 className="text-sm font-semibold">{step.title}</h4>
-                        <p className="text-xs text-muted-foreground">
-                          {step.description}
-                        </p>
-                      </div>
+              <div className="rounded-[10px] flex flex-col gap-4 justify-between border border-border bg-background/80 p-6">
+                <div>
+                  <div>
+                    <div className="flex items-center gap-2 text-base font-semibold">
+                      Built for fast adoption
                     </div>
-                  ))}
+                    <p className=" text-sm text-muted-foreground">
+                      Each template includes clear guidance so teams can align
+                      quickly, reduce review cycles, and keep documentation
+                      consistent.
+                    </p>
+                  </div>
+                  <div className="mt-6 space-y-4">
+                    {toolkitSteps.map((step, index) => (
+                      <div key={step.title} className="flex gap-3">
+                        <div className="flex size-8 items-center justify-center rounded-full border border-border text-xs font-semibold">
+                          {index + 1}
+                        </div>
+                        <div>
+                          <h4 className="text-sm font-semibold">
+                            {step.title}
+                          </h4>
+                          <p className="text-xs text-muted-foreground">
+                            {step.description}
+                          </p>
+                        </div>
+                      </div>
+                    ))}
+                  </div>
                 </div>
-                <div className="mt-6 grid grid-cols-2 gap-3">
+                <div className=" grid grid-cols-2 gap-3">
                   <div className="rounded-lg border border-border bg-background/80 p-3">
                     <p className="text-xs text-muted-foreground">Formats</p>
                     <p className="text-sm font-semibold">PDF, CSV, XLSX</p>
                   </div>
                   <div className="rounded-lg border border-border bg-background/80 p-3">
-                    <p className="text-xs text-muted-foreground">Designed for</p>
-                    <p className="text-sm font-semibold">Regulatory audits</p>
+                    <p className="text-xs text-muted-foreground">
+                      Designed for
+                    </p>
+                    <p className="text-sm font-semibold">Regulatory Affairs</p>
                   </div>
                 </div>
               </div>
@@ -173,17 +180,17 @@ export default function TemplatesSection() {
                     </Button>
                   ))}
                 </div>
-                <div className="mt-6 grid grid-cols-1 md:grid-cols-2 gap-4">
+                <div className="mt-6 grid grid-cols-1 md:grid-cols-2 gap-2">
                   {filteredTemplates.map((item) => (
                     <div
                       key={item.title}
-                      className="rounded-lg border border-border p-4 transition-colors hover:bg-accent/40"
+                      className="rounded-xl flex flex-col justify-between gap-2 border border-border p-2 transition-colors hover:bg-accent/40"
                     >
-                      <div className="flex items-start justify-between gap-4">
+                      <div className="flex items-start justify-between gap-2">
                         <div>
                           <div className="flex items-center gap-2">
-                            <PiFileTextDuotone className="size-5 text-primary" />
-                            <h4 className="text-base font-semibold">
+                            {/* <PiFileTextDuotone className="size-5 text-primary" /> */}
+                            <h4 className="text-sm font-semibold">
                               {item.title}
                             </h4>
                           </div>
@@ -211,8 +218,8 @@ export default function TemplatesSection() {
             </div>
           </div>
         </div>
-        <div className="absolute top-0 left-0 w-full h-px bg-border/60" />
-        <div className="absolute bottom-0 left-0 w-full h-px bg-border/60" />
+        <div className="absolute top-0 left-0 w-full h-0 border-b border-dashed border-border/80" />
+        <div className="absolute bottom-0 left-0 w-full h-0 border-b border-dashed border-border/80" />
       </div>
     </div>
   );

--- a/features/resources/toolkits/ToolkitsPlaceholder.tsx
+++ b/features/resources/toolkits/ToolkitsPlaceholder.tsx
@@ -4,23 +4,31 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { DecorativeCornerCircleCustom } from "@/components/ui/DecorativeCornerCircle";
 import { useTheme } from "next-themes";
-import { useEffect, useState } from "react";
-import { PiCheckCircleDuotone, PiClockDuotone, PiWrenchDuotone } from "react-icons/pi";
+import {
+  PiBinocularsDuotone,
+  PiCheckCircleDuotone,
+  PiClockDuotone,
+  PiHourglassLowDuotone,
+  PiWrenchDuotone,
+} from "react-icons/pi";
 
 const upcomingTools = [
   {
     title: "Label Generator",
-    description: "Create compliant medical device labels with automatic symbol inclusion and regulatory validation.",
+    description:
+      "Create compliant medical device labels with automatic symbol inclusion and regulatory validation.",
     status: "In Development",
   },
   {
     title: "Compliance Checker",
-    description: "Automated validation of your labels against FDA, EU MDR, and other regulatory requirements.",
+    description:
+      "Automated validation of your labels against FDA, EU MDR, and other regulatory requirements.",
     status: "Planned",
   },
   {
     title: "Symbol Library Manager",
-    description: "Organize and manage your organization's symbol library with version control and approval workflows.",
+    description:
+      "Organize and manage your organization's symbol library with version control and approval workflows.",
     status: "Planned",
   },
 ];
@@ -32,44 +40,25 @@ const toolkitBenefits = [
   "Built-in guidance tied to standards",
 ];
 
-const rolloutSteps = [
-  {
-    title: "Private beta",
-    description: "Early access for teams who want to co-design the workflows.",
-  },
-  {
-    title: "Core releases",
-    description: "Label generator + compliance checker shipped in waves.",
-  },
-  {
-    title: "Team rollout",
-    description: "Add symbol management and advanced audit reports.",
-  },
-];
-
 export default function ToolkitsPlaceholder() {
   const { resolvedTheme } = useTheme();
-  const [mounted, setMounted] = useState(false);
-
-  useEffect(() => {
-    setMounted(true);
-  }, []);
-
-  const badgeVariant = mounted && resolvedTheme === "dark" ? "outline" : "white";
+  const badgeVariant = resolvedTheme === "dark" ? "outline" : "white";
 
   return (
-    <div className="w-full mt-12 mb-24 pointer-events-auto">
-      <div className="max-w-6xl mx-auto mb-10 px-4">
+    <div className="w-full mt-16 mb-24 pointer-events-auto relative">
+      <div className="absolute top-0 left-0 w-full h-0 border-b border-dashed border-border/80" />
+      <div className="max-w-6xl mx-auto mb-10">
         <Badge
           variant={badgeVariant}
           className="mb-8 z-60 dark:px-2 dark:py-0.5"
         >
+          <PiWrenchDuotone />
           <span className="font-medium">Toolkits</span>
         </Badge>
         <div className="w-full flex flex-col lg:flex-row items-start gap-8">
-          <h2 className="text-4xl md:text-5xl lg:text-6xl font-medium leading-tight">
+          <h1 className="text-4xl md:text-5xl lg:text-6xl font-medium leading-tightest">
             Free compliance tools, built with labeling teams
-          </h2>
+          </h1>
           <div className="hidden lg:block h-24 w-px bg-border" />
           <p className="text-lg text-muted-foreground max-w-md">
             We are building a suite of free tools to reduce manual compliance
@@ -77,22 +66,26 @@ export default function ToolkitsPlaceholder() {
           </p>
         </div>
         <div className="mt-8 flex flex-wrap items-center gap-4">
-          <Button size="lg">Join the waitlist</Button>
           <Button size="lg" variant="outline">
+            <PiBinocularsDuotone />
             Request early access
+          </Button>
+          <Button size="lg">
+            <PiHourglassLowDuotone />
+            Join the waitlist
           </Button>
         </div>
       </div>
 
-      <div className="relative w-full mb-16">
-        <div className="max-w-6xl mx-auto relative px-4">
+      <div className="relative w-full mb-40">
+        <div className="max-w-6xl mx-auto relative">
           <DecorativeCornerCircleCustom
             positionClassName="-bottom-15 -left-15"
-            rotation={180}
+            rotation={270}
           />
           <DecorativeCornerCircleCustom
-            positionClassName="-bottom-7.5 -right-22.5"
-            rotation={90}
+            positionClassName="-bottom-15 -right-15"
+            rotation={180}
           />
           <DecorativeCornerCircleCustom
             positionClassName="-top-15 -right-15"
@@ -100,7 +93,7 @@ export default function ToolkitsPlaceholder() {
           />
 
           <div className="p-1 bg-accent border-border border rounded-[12px]">
-            <div className="grid grid-cols-1 lg:grid-cols-[1.3fr_1fr] gap-1">
+            <div className="grid grid-cols-1 lg:grid-cols-[1.2fr_1fr] gap-1">
               <div className="rounded-[10px] border border-border bg-foreground text-background p-6">
                 <div className="flex items-center justify-between">
                   <Badge
@@ -109,9 +102,9 @@ export default function ToolkitsPlaceholder() {
                   >
                     Coming soon
                   </Badge>
-                  <span className="text-xs text-background/70">
+                  {/* <span className="text-xs text-background/70">
                     3 tools in pipeline
-                  </span>
+                  </span> */}
                 </div>
                 <h3 className="mt-4 text-2xl font-semibold">
                   Build compliant labels without the manual chase
@@ -133,78 +126,45 @@ export default function ToolkitsPlaceholder() {
                 </div>
                 <Button
                   variant="outline"
-                  className="mt-6 border-background/40 text-background hover:bg-background hover:text-foreground"
+                  className="mt-6 border-background/40 text-foreground hover:bg-background hover:text-foreground"
                 >
                   Notify me on launch
                 </Button>
               </div>
-              <div className="rounded-[10px] border border-border bg-background/80 p-6">
-                <div className="flex items-center gap-2 text-sm font-semibold">
-                  <PiClockDuotone className="size-5 text-foreground/60" />
-                  Rollout plan
+              <div className="rounded-[10px] border border-border bg-background/80 p-4">
+                <div className="flex items-center justify-between">
+                  <h4 className="text-base font-semibold">
+                    What&apos;s coming next
+                  </h4>
                 </div>
-                <div className="mt-4 space-y-4">
-                  {rolloutSteps.map((step, index) => (
-                    <div key={step.title} className="flex gap-3">
-                      <div className="flex size-8 items-center justify-center rounded-full border border-border text-xs font-semibold">
-                        {index + 1}
+                <p className="text-sm text-muted-foreground">
+                  Track upcoming tools and claim early access.
+                </p>
+                <div className="mt-3 flex flex-col gap-2">
+                  {upcomingTools.map((tool) => (
+                    <div
+                      key={tool.title}
+                      className="rounded-[10px] border border-border bg-background/90 p-3 transition-colors hover:bg-accent/40"
+                    >
+                      <div className="flex items-center justify-between">
+                        <h5 className="text-sm font-semibold">{tool.title}</h5>
+                        <PiWrenchDuotone className="size-4 text-muted-foreground" />
                       </div>
-                      <div>
-                        <h4 className="text-sm font-semibold">{step.title}</h4>
-                        <p className="text-xs text-muted-foreground">
-                          {step.description}
-                        </p>
-                      </div>
+                      <p className="mt-1 text-xs text-muted-foreground">
+                        {tool.description}
+                      </p>
+                      {/* <div className="mt-2 text-[11px] uppercase tracking-wide text-muted-foreground">
+                        {tool.status}
+                      </div> */}
                     </div>
                   ))}
-                </div>
-                <div className="mt-6 rounded-lg border border-border bg-background/80 p-4">
-                  <p className="text-xs text-muted-foreground">Current focus</p>
-                  <p className="text-sm font-semibold">Label Generator beta</p>
                 </div>
               </div>
             </div>
           </div>
         </div>
-        <div className="absolute top-0 left-0 w-full h-px bg-border/60" />
-        <div className="absolute bottom-0 left-0 w-full h-px bg-border/60" />
-      </div>
-
-      <div className="max-w-6xl mx-auto px-4">
-        <div className="flex flex-col lg:flex-row items-start gap-8 mb-8">
-          <h2 className="text-3xl md:text-4xl font-medium">
-            What&apos;s coming next
-          </h2>
-          <p className="text-lg text-muted-foreground max-w-2xl">
-            Follow each release and decide where you want early access. Every
-            tool is free and purpose-built for medical device compliance.
-          </p>
-        </div>
-        <div className="p-1 bg-accent border-border border rounded-[12px]">
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-1">
-            {upcomingTools.map((tool) => (
-              <div
-                key={tool.title}
-                className="rounded-[10px] border border-border bg-background/80 p-6 transition-colors hover:bg-accent/40"
-              >
-                <div className="flex items-center justify-between">
-                  <Badge variant="outline" className="text-xs">
-                    {tool.status}
-                  </Badge>
-                  <PiWrenchDuotone className="size-5 text-muted-foreground" />
-                </div>
-                <h3 className="mt-4 text-lg font-semibold">{tool.title}</h3>
-                <p className="mt-2 text-sm text-muted-foreground">
-                  {tool.description}
-                </p>
-                <div className="mt-4 flex items-center gap-2 text-xs text-muted-foreground">
-                  <PiCheckCircleDuotone className="size-4" />
-                  Free for early adopters
-                </div>
-              </div>
-            ))}
-          </div>
-        </div>
+        <div className="absolute top-0 left-0 w-full h-0 border-b border-dashed border-border/80" />
+        <div className="absolute bottom-0 left-0 w-full h-0 border-b border-dashed border-border/80" />
       </div>
     </div>
   );

--- a/features/resources/toolkits/ToolkitsPlaceholder.tsx
+++ b/features/resources/toolkits/ToolkitsPlaceholder.tsx
@@ -1,10 +1,11 @@
 "use client";
 
 import { Badge } from "@/components/ui/badge";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { DecorativeCornerCircleCustom } from "@/components/ui/DecorativeCornerCircle";
 import { useTheme } from "next-themes";
 import { useEffect, useState } from "react";
-import { PiWrenchDuotone, PiClockDuotone } from "react-icons/pi";
+import { PiCheckCircleDuotone, PiClockDuotone, PiWrenchDuotone } from "react-icons/pi";
 
 const upcomingTools = [
   {
@@ -24,6 +25,28 @@ const upcomingTools = [
   },
 ];
 
+const toolkitBenefits = [
+  "Automated compliance checks and approvals",
+  "Reusable symbol and template libraries",
+  "Faster audit preparation for labeling teams",
+  "Built-in guidance tied to standards",
+];
+
+const rolloutSteps = [
+  {
+    title: "Private beta",
+    description: "Early access for teams who want to co-design the workflows.",
+  },
+  {
+    title: "Core releases",
+    description: "Label generator + compliance checker shipped in waves.",
+  },
+  {
+    title: "Team rollout",
+    description: "Add symbol management and advanced audit reports.",
+  },
+];
+
 export default function ToolkitsPlaceholder() {
   const { resolvedTheme } = useTheme();
   const [mounted, setMounted] = useState(false);
@@ -35,55 +58,150 @@ export default function ToolkitsPlaceholder() {
   const badgeVariant = mounted && resolvedTheme === "dark" ? "outline" : "white";
 
   return (
-    <div className="w-full mt-10 mb-20 pointer-events-auto">
-      <div className="max-w-6xl mx-auto mb-8 px-4">
-        <Badge variant={badgeVariant} className="mb-8 z-60 dark:px-2 dark:py-0.5">
+    <div className="w-full mt-12 mb-24 pointer-events-auto">
+      <div className="max-w-6xl mx-auto mb-10 px-4">
+        <Badge
+          variant={badgeVariant}
+          className="mb-8 z-60 dark:px-2 dark:py-0.5"
+        >
           <span className="font-medium">Toolkits</span>
         </Badge>
-        <div className="w-full flex flex-col md:flex-row items-start gap-4">
-          <h2 className="text-4xl md:text-5xl font-medium">
-            Free Compliance Tools
+        <div className="w-full flex flex-col lg:flex-row items-start gap-8">
+          <h2 className="text-4xl md:text-5xl lg:text-6xl font-medium leading-tight">
+            Free compliance tools, built with labeling teams
           </h2>
+          <div className="hidden lg:block h-24 w-px bg-border" />
+          <p className="text-lg text-muted-foreground max-w-md">
+            We are building a suite of free tools to reduce manual compliance
+            work and keep every label aligned to evolving regulations.
+          </p>
         </div>
-        <p className="mt-4 text-lg text-muted-foreground max-w-3xl">
-          Powerful tools to streamline your labeling workflow. All tools are free to use and designed
-          specifically for medical device regulatory compliance.
-        </p>
+        <div className="mt-8 flex flex-wrap items-center gap-4">
+          <Button size="lg">Join the waitlist</Button>
+          <Button size="lg" variant="outline">
+            Request early access
+          </Button>
+        </div>
+      </div>
+
+      <div className="relative w-full mb-16">
+        <div className="max-w-6xl mx-auto relative px-4">
+          <DecorativeCornerCircleCustom
+            positionClassName="-bottom-15 -left-15"
+            rotation={180}
+          />
+          <DecorativeCornerCircleCustom
+            positionClassName="-bottom-7.5 -right-22.5"
+            rotation={90}
+          />
+          <DecorativeCornerCircleCustom
+            positionClassName="-top-15 -right-15"
+            rotation={90}
+          />
+
+          <div className="p-1 bg-accent border-border border rounded-[12px]">
+            <div className="grid grid-cols-1 lg:grid-cols-[1.3fr_1fr] gap-1">
+              <div className="rounded-[10px] border border-border bg-foreground text-background p-6">
+                <div className="flex items-center justify-between">
+                  <Badge
+                    variant="outline"
+                    className="border-background/40 text-background/80"
+                  >
+                    Coming soon
+                  </Badge>
+                  <span className="text-xs text-background/70">
+                    3 tools in pipeline
+                  </span>
+                </div>
+                <h3 className="mt-4 text-2xl font-semibold">
+                  Build compliant labels without the manual chase
+                </h3>
+                <p className="mt-3 text-sm text-background/80">
+                  Each toolkit is designed to remove repetitive work, improve
+                  audit readiness, and keep teams aligned on regulatory
+                  standards.
+                </p>
+                <div className="mt-6 grid grid-cols-2 gap-3">
+                  {toolkitBenefits.map((benefit) => (
+                    <div
+                      key={benefit}
+                      className="rounded-lg border border-background/20 bg-background/10 p-3 text-xs text-background/80"
+                    >
+                      {benefit}
+                    </div>
+                  ))}
+                </div>
+                <Button
+                  variant="outline"
+                  className="mt-6 border-background/40 text-background hover:bg-background hover:text-foreground"
+                >
+                  Notify me on launch
+                </Button>
+              </div>
+              <div className="rounded-[10px] border border-border bg-background/80 p-6">
+                <div className="flex items-center gap-2 text-sm font-semibold">
+                  <PiClockDuotone className="size-5 text-foreground/60" />
+                  Rollout plan
+                </div>
+                <div className="mt-4 space-y-4">
+                  {rolloutSteps.map((step, index) => (
+                    <div key={step.title} className="flex gap-3">
+                      <div className="flex size-8 items-center justify-center rounded-full border border-border text-xs font-semibold">
+                        {index + 1}
+                      </div>
+                      <div>
+                        <h4 className="text-sm font-semibold">{step.title}</h4>
+                        <p className="text-xs text-muted-foreground">
+                          {step.description}
+                        </p>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+                <div className="mt-6 rounded-lg border border-border bg-background/80 p-4">
+                  <p className="text-xs text-muted-foreground">Current focus</p>
+                  <p className="text-sm font-semibold">Label Generator beta</p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div className="absolute top-0 left-0 w-full h-px bg-border/60" />
+        <div className="absolute bottom-0 left-0 w-full h-px bg-border/60" />
       </div>
 
       <div className="max-w-6xl mx-auto px-4">
-        <Card className="bg-muted/50 border-dashed">
-          <CardContent className="flex flex-col items-center justify-center py-16">
-            <PiWrenchDuotone className="w-16 h-16 text-muted-foreground/50 mb-4" />
-            <h3 className="text-2xl font-semibold mb-2">Coming Soon</h3>
-            <p className="text-muted-foreground text-center max-w-md">
-              We&apos;re working on building powerful free tools to help you with your compliance needs.
-              Stay tuned for updates!
-            </p>
-          </CardContent>
-        </Card>
-
-        {/* Upcoming Tools Preview */}
-        <div className="mt-12">
-          <h3 className="text-2xl font-semibold mb-6">What&apos;s Coming</h3>
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-            {upcomingTools.map((tool, index) => (
-              <Card key={index}>
-                <CardHeader>
-                  <CardTitle className="flex items-center gap-2">
-                    <PiClockDuotone className="w-5 h-5 text-muted-foreground" />
-                    {tool.title}
-                  </CardTitle>
-                  <CardDescription className="text-sm text-muted-foreground">
+        <div className="flex flex-col lg:flex-row items-start gap-8 mb-8">
+          <h2 className="text-3xl md:text-4xl font-medium">
+            What&apos;s coming next
+          </h2>
+          <p className="text-lg text-muted-foreground max-w-2xl">
+            Follow each release and decide where you want early access. Every
+            tool is free and purpose-built for medical device compliance.
+          </p>
+        </div>
+        <div className="p-1 bg-accent border-border border rounded-[12px]">
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-1">
+            {upcomingTools.map((tool) => (
+              <div
+                key={tool.title}
+                className="rounded-[10px] border border-border bg-background/80 p-6 transition-colors hover:bg-accent/40"
+              >
+                <div className="flex items-center justify-between">
+                  <Badge variant="outline" className="text-xs">
                     {tool.status}
-                  </CardDescription>
-                </CardHeader>
-                <CardContent>
-                  <CardDescription className="text-base">
-                    {tool.description}
-                  </CardDescription>
-                </CardContent>
-              </Card>
+                  </Badge>
+                  <PiWrenchDuotone className="size-5 text-muted-foreground" />
+                </div>
+                <h3 className="mt-4 text-lg font-semibold">{tool.title}</h3>
+                <p className="mt-2 text-sm text-muted-foreground">
+                  {tool.description}
+                </p>
+                <div className="mt-4 flex items-center gap-2 text-xs text-muted-foreground">
+                  <PiCheckCircleDuotone className="size-4" />
+                  Free for early adopters
+                </div>
+              </div>
             ))}
           </div>
         </div>


### PR DESCRIPTION
- Overhaul UI of `/resources` page, show all four sub-page cards
- Same way, overhaul UI of all the child pages under resources `toolkits, blogs, templates, symbols, and standards lib`