### PR TITLE
feat: add async report export UI

### DIFF
--- a/app/(app)/layout.tsx
+++ b/app/(app)/layout.tsx
@@ -9,6 +9,7 @@ import { useAuth } from "react-oidc-context";
 import { useGetUser } from "@/hooks/user/useGetUser";
 import { AppSidebar } from "@/components/common/AppSidebar";
 import { ProductExportJobNotifier } from "@/components/common/ProductExportJobNotifier";
+import { ReportExportJobNotifier } from "@/components/common/ReportExportJobNotifier";
 
 const getProfileValue = (
   profile: Record<string, unknown> | undefined,
@@ -76,6 +77,7 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
       <SidebarInset>
         <AppHeader />
         <ProductExportJobNotifier />
+        <ReportExportJobNotifier />
         <MainContentWrapper>{children}</MainContentWrapper>
       </SidebarInset>
     </SidebarProvider>

--- a/app/(app)/products/page.tsx
+++ b/app/(app)/products/page.tsx
@@ -3,10 +3,48 @@
 import ProductsPageProductTable from "@/features/workspace/products/ProductsPageProductTable";
 import CreateProductDialog from "@/features/workspace/products/CreateProductDialog";
 import { Button } from "@/components/ui/button";
+import { useGetProductExportJobs } from "@/hooks/product/useGetProductExportJobs";
+import { ExportJobStatus } from "@/types/export-job";
 import Link from "next/link";
 import { PiClockDuotone } from "react-icons/pi";
 
+const ACTIVE_EXPORT_JOB_STATUSES: ExportJobStatus[] = ["queued", "processing"];
+
 function ProductsPage() {
+  const { data: exportJobsData } = useGetProductExportJobs(
+    { page: 1 },
+    { enabled: true, pollWhenActive: true },
+  );
+
+  const productExportJobs = exportJobsData?.result.jobs ?? [];
+  const activeProductExportCount =
+    typeof exportJobsData?.result.activeJobsCount === "number"
+      ? exportJobsData.result.activeJobsCount
+      : productExportJobs.filter((job) =>
+          ACTIVE_EXPORT_JOB_STATUSES.includes(job.status),
+        ).length;
+  const latestProductExportJob = productExportJobs[0];
+
+  const renderProductExportIndicator = () => {
+    if (activeProductExportCount > 0) {
+      return (
+        <span className="inline-flex min-w-5 items-center justify-center rounded-full bg-amber-500 px-1.5 py-0.5 text-[10px] font-semibold text-white">
+          {activeProductExportCount}
+        </span>
+      );
+    }
+
+    if (latestProductExportJob?.status === "failed") {
+      return <span className="h-2 w-2 rounded-full bg-destructive" />;
+    }
+
+    if (latestProductExportJob?.status === "completed") {
+      return <span className="h-2 w-2 rounded-full bg-emerald-500" />;
+    }
+
+    return null;
+  };
+
   return (
     <div className="flex flex-col gap-2 p-2 h-full">
       <div className="flex flex-col items-start gap-4 justify-start border border-border bg-background rounded-xl p-4 w-full h-full">
@@ -20,9 +58,10 @@ function ProductsPage() {
           </div>
           <div className="flex items-center gap-2">
             <Button variant="secondary" size="sm" asChild>
-              <Link href="/products/exports">
+              <Link href="/products/exports" className="gap-1.5">
                 <PiClockDuotone />
                 Product Exports
+                {renderProductExportIndicator()}
               </Link>
             </Button>
             <CreateProductDialog />

--- a/app/(app)/reports/page.tsx
+++ b/app/(app)/reports/page.tsx
@@ -23,6 +23,7 @@ import { TagInput, Tag } from "@/components/ui/tag-input";
 import Link from "next/link";
 import { toast } from "sonner";
 import {
+  PiExportDuotone,
   PiMagnifyingGlassDuotone,
   PiFloppyDiskDuotone,
   PiFolderOpenDuotone,
@@ -36,6 +37,7 @@ import {
 import { cn } from "@/lib/utils";
 
 import { ExportButtons } from "@/features/workspace/reports/components/ExportButtons";
+import { ReportExportsTable } from "@/features/workspace/reports/components/ReportExportsTable";
 import {
   ExportFormat,
   ExportReportDialog,
@@ -44,8 +46,10 @@ import { LoadQueryDialog } from "@/features/workspace/reports/components/LoadQue
 import { SaveQueryDialog } from "@/features/workspace/reports/components/SaveQueryDialog";
 import { useQueryBuilderState } from "@/features/workspace/reports/hooks/useQueryBuilderState";
 import { useExportExcel, useExportPDF } from "@/hooks/reports/useExportReports";
+import { useGetReportExportJobs } from "@/hooks/reports/useGetReportExportJobs";
 import { useReportsQuery } from "@/hooks/reports/useReportsQuery";
 import { useSavedQueries } from "@/hooks/reports/useSavedQueries";
+import { ExportJobStatus } from "@/types/export-job";
 import { ReportsProduct, SavedQuery, QueryCondition } from "@/types/reports";
 import {
   QUERYABLE_TABS,
@@ -53,6 +57,8 @@ import {
   getFieldsForTab,
   Operator,
 } from "@/data/reports-config";
+
+const ACTIVE_EXPORT_JOB_STATUSES: ExportJobStatus[] = ["queued", "processing"];
 
 function ConditionRow({
   condition,
@@ -448,6 +454,10 @@ export default function Page() {
   const reportsQuery = useReportsQuery();
   const exportPDF = useExportPDF();
   const exportExcel = useExportExcel();
+  const { data: exportJobsData } = useGetReportExportJobs(
+    { page: 1 },
+    { enabled: true, pollWhenActive: true },
+  );
   const { queries: savedQueries, saveQuery, deleteQuery } = useSavedQueries();
 
   const [saveDialogOpen, setSaveDialogOpen] = useState(false);
@@ -510,30 +520,35 @@ export default function Page() {
     setExportDialogOpen(true);
   };
 
-  const handleExport = async (header: string, format: ExportFormat) => {
+  const handleExport = async (format: ExportFormat) => {
     if (!validateConditions()) {
       toast.error("Please fill in all required fields for each condition.");
       return;
     }
+
     try {
       if (format === "pdf") {
         await exportPDF.mutateAsync({
           conditions: getApiConditions(),
           conditionLogic,
-          reportHeader: header,
         });
-        toast.success("PDF report has been downloaded.");
+        toast.success("PDF export started.");
       } else {
         await exportExcel.mutateAsync({
           conditions: getApiConditions(),
           conditionLogic,
-          reportHeader: header,
         });
-        toast.success("Excel report has been downloaded.");
+        toast.success("Excel export started.");
       }
+
       setExportDialogOpen(false);
-    } catch {
-      toast.error(`Failed to export ${format.toUpperCase()}.`);
+      setActiveTab("exports");
+    } catch (error) {
+      toast.error(
+        error instanceof Error
+          ? error.message
+          : `Failed to start ${format.toUpperCase()} export.`,
+      );
     }
   };
 
@@ -545,6 +560,34 @@ export default function Page() {
 
   const isQueryValid = validateConditions();
   const hasResults = results && results.products.length > 0;
+  const reportExportJobs = exportJobsData?.result.jobs ?? [];
+  const activeReportExportCount =
+    typeof exportJobsData?.result.activeJobsCount === "number"
+      ? exportJobsData.result.activeJobsCount
+      : reportExportJobs.filter((job) =>
+          ACTIVE_EXPORT_JOB_STATUSES.includes(job.status),
+        ).length;
+  const latestReportExportJob = reportExportJobs[0];
+
+  const renderExportTabIndicator = () => {
+    if (activeReportExportCount > 0) {
+      return (
+        <span className="inline-flex min-w-5 items-center justify-center rounded-full bg-amber-500 px-1.5 py-0.5 text-[10px] font-semibold text-white">
+          {activeReportExportCount}
+        </span>
+      );
+    }
+
+    if (latestReportExportJob?.status === "failed") {
+      return <span className="h-2 w-2 rounded-full bg-destructive" />;
+    }
+
+    if (latestReportExportJob?.status === "completed") {
+      return <span className="h-2 w-2 rounded-full bg-emerald-500" />;
+    }
+
+    return null;
+  };
 
   return (
     <div className="min-h-screen bg-background">
@@ -596,6 +639,11 @@ export default function Page() {
                       >
                         <PiTableDuotone size={14} />
                         Results
+                      </TabsTrigger>
+                      <TabsTrigger value="exports" className="gap-1.5">
+                        <PiExportDuotone size={14} />
+                        Exports
+                        {renderExportTabIndicator()}
                       </TabsTrigger>
                     </TabsList>
                   </div>
@@ -757,6 +805,32 @@ export default function Page() {
                       />
                     </>
                   )}
+                </TabsContent>
+
+                <TabsContent value="exports" className="mt-0 space-y-4">
+                  <div className="flex items-center justify-between gap-3">
+                    <div className="flex items-center gap-3">
+                      <h3 className="text-sm font-semibold">Queued Exports</h3>
+                      {activeReportExportCount > 0 ? (
+                        <Badge className="bg-amber-500 text-white hover:bg-amber-500">
+                          {activeReportExportCount} active
+                        </Badge>
+                      ) : latestReportExportJob?.status === "failed" ? (
+                        <Badge variant="destructive">Latest failed</Badge>
+                      ) : latestReportExportJob?.status === "completed" ? (
+                        <Badge className="bg-emerald-500 text-white hover:bg-emerald-500">
+                          Latest ready
+                        </Badge>
+                      ) : (
+                        <Badge variant="secondary">No active exports</Badge>
+                      )}
+                    </div>
+                    <p className="text-xs text-muted-foreground">
+                      Start an export from the Results tab, then download it here
+                      when it is ready.
+                    </p>
+                  </div>
+                  <ReportExportsTable />
                 </TabsContent>
               </CardContent>
             </Tabs>

--- a/components/common/ReportExportJobNotifier.tsx
+++ b/components/common/ReportExportJobNotifier.tsx
@@ -5,6 +5,8 @@ import { useGetReportExportJobs } from "@/hooks/reports/useGetReportExportJobs";
 import { ExportJobStatus } from "@/types/export-job";
 import { toast } from "sonner";
 
+const TERMINAL_EXPORT_JOB_STATUSES: ExportJobStatus[] = ["completed", "failed"];
+
 export function ReportExportJobNotifier() {
   const { data } = useGetReportExportJobs(
     { page: 1 },
@@ -12,7 +14,12 @@ export function ReportExportJobNotifier() {
   );
 
   const initializedRef = useRef(false);
+  const mountedAtRef = useRef<number | null>(null);
   const previousStatusesRef = useRef<Record<string, ExportJobStatus>>({});
+
+  useEffect(() => {
+    mountedAtRef.current = Date.now();
+  }, []);
 
   useEffect(() => {
     const jobs = data?.result?.jobs;
@@ -23,15 +30,21 @@ export function ReportExportJobNotifier() {
       currentStatuses[job.jobId] = job.status;
     }
 
-    if (!initializedRef.current) {
-      initializedRef.current = true;
-      previousStatusesRef.current = currentStatuses;
-      return;
-    }
-
     for (const job of jobs) {
       const previousStatus = previousStatusesRef.current[job.jobId];
-      if (!previousStatus || previousStatus === job.status) continue;
+      const mountedAt = mountedAtRef.current;
+      const wasFirstObservedAfterMount =
+        !previousStatus &&
+        mountedAt !== null &&
+        TERMINAL_EXPORT_JOB_STATUSES.includes(job.status) &&
+        Date.parse(job.updatedAt) >= mountedAt;
+
+      if (
+        !wasFirstObservedAfterMount &&
+        (!previousStatus || previousStatus === job.status)
+      ) {
+        continue;
+      }
 
       if (job.status === "completed") {
         toast.success(`${job.format.toUpperCase()} report export is ready.`);
@@ -40,6 +53,10 @@ export function ReportExportJobNotifier() {
       if (job.status === "failed") {
         toast.error(job.errorMessage || "Report export failed.");
       }
+    }
+
+    if (!initializedRef.current) {
+      initializedRef.current = true;
     }
 
     previousStatusesRef.current = {

--- a/components/common/ReportExportJobNotifier.tsx
+++ b/components/common/ReportExportJobNotifier.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { useGetReportExportJobs } from "@/hooks/reports/useGetReportExportJobs";
+import { ExportJobStatus } from "@/types/export-job";
+import { toast } from "sonner";
+
+export function ReportExportJobNotifier() {
+  const { data } = useGetReportExportJobs(
+    { page: 1 },
+    { enabled: true, pollWhenActive: true },
+  );
+
+  const initializedRef = useRef(false);
+  const previousStatusesRef = useRef<Record<string, ExportJobStatus>>({});
+
+  useEffect(() => {
+    const jobs = data?.result?.jobs;
+    if (!jobs?.length) return;
+
+    const currentStatuses: Record<string, ExportJobStatus> = {};
+    for (const job of jobs) {
+      currentStatuses[job.jobId] = job.status;
+    }
+
+    if (!initializedRef.current) {
+      initializedRef.current = true;
+      previousStatusesRef.current = currentStatuses;
+      return;
+    }
+
+    for (const job of jobs) {
+      const previousStatus = previousStatusesRef.current[job.jobId];
+      if (!previousStatus || previousStatus === job.status) continue;
+
+      if (job.status === "completed") {
+        toast.success(`${job.format.toUpperCase()} report export is ready.`);
+      }
+
+      if (job.status === "failed") {
+        toast.error(job.errorMessage || "Report export failed.");
+      }
+    }
+
+    previousStatusesRef.current = {
+      ...previousStatusesRef.current,
+      ...currentStatuses,
+    };
+  }, [data]);
+
+  return null;
+}

--- a/features/workspace/reports/components/ExportButtons.tsx
+++ b/features/workspace/reports/components/ExportButtons.tsx
@@ -35,11 +35,11 @@ export function ExportButtons({
             className="gap-1.5"
           >
             <PiFilePdfDuotone size={16} className="text-red-500" />
-            {isExportingPDF ? "Exporting..." : "PDF"}
+            {isExportingPDF ? "Starting..." : "PDF"}
           </Button>
         </TooltipTrigger>
         <TooltipContent>
-          <p>Export results in PDF</p>
+          <p>Queue PDF export</p>
         </TooltipContent>
       </Tooltip>
 
@@ -53,11 +53,11 @@ export function ExportButtons({
             className="gap-1.5"
           >
             <PiMicrosoftExcelLogoDuotone size={16} className="text-green-600" />
-            {isExportingExcel ? "Exporting..." : "Excel"}
+            {isExportingExcel ? "Starting..." : "Excel"}
           </Button>
         </TooltipTrigger>
         <TooltipContent>
-          <p>Export results in Excel</p>
+          <p>Queue Excel export</p>
         </TooltipContent>
       </Tooltip>
     </div>

--- a/features/workspace/reports/components/ExportReportDialog.tsx
+++ b/features/workspace/reports/components/ExportReportDialog.tsx
@@ -1,6 +1,4 @@
 "use client";
-
-import { useState } from "react";
 import {
   Dialog,
   DialogContent,
@@ -10,11 +8,10 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
 import {
   PiFilePdfDuotone,
   PiMicrosoftExcelLogoDuotone,
+  PiClockCountdownDuotone,
   PiXCircleDuotone,
 } from "react-icons/pi";
 import { Spinner } from "@/components/ui/spinner";
@@ -24,7 +21,7 @@ export type ExportFormat = "pdf" | "excel";
 interface ExportReportDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  onExport: (header: string, format: ExportFormat) => Promise<void> | void;
+  onExport: (format: ExportFormat) => Promise<void> | void;
   isExporting?: boolean;
   format: ExportFormat;
 }
@@ -36,25 +33,14 @@ export function ExportReportDialog({
   isExporting,
   format,
 }: ExportReportDialogProps) {
-  const [header, setHeader] = useState("");
-
   const handleExport = () => {
-    if (header.trim()) {
-      onExport(header.trim(), format);
-    }
-  };
-
-  const handleOpenChange = (open: boolean) => {
-    if (!open) {
-      setHeader("");
-    }
-    onOpenChange(open);
+    onExport(format);
   };
 
   const isPDF = format === "pdf";
 
   return (
-    <Dialog open={open} onOpenChange={handleOpenChange}>
+    <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="sm:max-w-[400px] p-4">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
@@ -69,27 +55,31 @@ export function ExportReportDialog({
             Export as {isPDF ? "PDF" : "Excel"}
           </DialogTitle>
           <DialogDescription>
-            Enter a header name for your report. This will also be used as the
-            filename.
+            This export will run in the background so you can keep working while
+            the file is generated.
           </DialogDescription>
         </DialogHeader>
 
-        <div className="space-y-2">
-          <Label htmlFor="report-header">Report Header</Label>
-          <Input
-            id="report-header"
-            placeholder="e.g., Q4 Product Compliance Report"
-            value={header}
-            onChange={(e) => setHeader(e.target.value)}
-            onKeyDown={(e) => e.key === "Enter" && handleExport()}
-            autoFocus
-          />
+        <div className="rounded-lg border bg-muted/30 p-3">
+          <div className="flex items-start gap-2">
+            <PiClockCountdownDuotone className="mt-0.5 size-4 text-muted-foreground" />
+            <div className="space-y-1 text-sm">
+              <p className="font-medium text-foreground">
+                This export will be downloaded in the background.
+              </p>
+              <p className="text-muted-foreground">
+                We will queue a {isPDF ? "PDF" : "Excel"} export for the current
+                filtered results, and you can keep using the app while we show
+                progress in the Exports tab.
+              </p>
+            </div>
+          </div>
         </div>
 
         <DialogFooter>
           <Button
             variant="outline"
-            onClick={() => handleOpenChange(false)}
+            onClick={() => onOpenChange(false)}
             disabled={isExporting}
           >
             <PiXCircleDuotone />
@@ -97,7 +87,7 @@ export function ExportReportDialog({
           </Button>
           <Button
             onClick={handleExport}
-            disabled={!header.trim() || isExporting}
+            disabled={isExporting}
           >
             {isExporting ? (
               <Spinner />
@@ -106,7 +96,9 @@ export function ExportReportDialog({
             ) : (
               <PiMicrosoftExcelLogoDuotone size={16} />
             )}
-            {isExporting ? "Exporting..." : `Export ${isPDF ? "PDF" : "Excel"}`}
+            {isExporting
+              ? "Starting..."
+              : `Start ${isPDF ? "PDF" : "Excel"} Export`}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/features/workspace/reports/components/ExportReportDialog.tsx
+++ b/features/workspace/reports/components/ExportReportDialog.tsx
@@ -65,12 +65,12 @@ export function ExportReportDialog({
             <PiClockCountdownDuotone className="mt-0.5 size-4 text-muted-foreground" />
             <div className="space-y-1 text-sm">
               <p className="font-medium text-foreground">
-                This export will be downloaded in the background.
+                This export will be generated in the background.
               </p>
               <p className="text-muted-foreground">
                 We will queue a {isPDF ? "PDF" : "Excel"} export for the current
-                filtered results, and you can keep using the app while we show
-                progress in the Exports tab.
+                filtered results; you can keep using the app while progress is
+                shown in the Exports tab.
               </p>
             </div>
           </div>

--- a/features/workspace/reports/components/ReportExportsTable.tsx
+++ b/features/workspace/reports/components/ReportExportsTable.tsx
@@ -1,0 +1,468 @@
+"use client";
+
+import { useCallback, useMemo, useState } from "react";
+import { format } from "date-fns";
+import {
+  ColumnDef,
+  flexRender,
+  getCoreRowModel,
+  PaginationState,
+  useReactTable,
+} from "@tanstack/react-table";
+import type { IconType } from "react-icons";
+import {
+  PiArrowClockwiseDuotone,
+  PiCalendarDuotone,
+  PiCaretCircleDoubleLeftDuotone,
+  PiCaretCircleDoubleRightDuotone,
+  PiCaretCircleLeftDuotone,
+  PiCaretCircleRightDuotone,
+  PiCheckCircleDuotone,
+  PiClockDuotone,
+  PiDownloadDuotone,
+  PiFilePdfDuotone,
+  PiFileXlsDuotone,
+  PiHashDuotone,
+  PiWarningCircleDuotone,
+} from "react-icons/pi";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Pagination,
+  PaginationContent,
+  PaginationItem,
+} from "@/components/ui/pagination";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Spinner } from "@/components/ui/spinner";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { useDownloadReportExportJob } from "@/hooks/reports/useDownloadReportExportJob";
+import { useGetReportExportJobs } from "@/hooks/reports/useGetReportExportJobs";
+import { ExportJobStatus, ExportJobSummary } from "@/types/export-job";
+import { toast } from "sonner";
+
+const STATUS_FILTERS: Array<{ label: string; value: "all" | ExportJobStatus }> = [
+  { label: "All", value: "all" },
+  { label: "Queued", value: "queued" },
+  { label: "Processing", value: "processing" },
+  { label: "Completed", value: "completed" },
+  { label: "Failed", value: "failed" },
+];
+
+const getStatusBadgeVariant = (status: ExportJobStatus) => {
+  if (status === "completed") return "default" as const;
+  if (status === "failed") return "destructive" as const;
+  return "secondary" as const;
+};
+
+const formatDateTime = (value: string): string => {
+  try {
+    return format(new Date(value), "MMM d, yyyy • h:mm a");
+  } catch {
+    return value;
+  }
+};
+
+function StaticHeader({
+  title,
+  icon: Icon,
+}: {
+  title: string;
+  icon: IconType;
+}) {
+  return (
+    <div className="flex items-center gap-2 text-xs font-semibold text-foreground">
+      <Icon className="h-4 w-4 text-muted-foreground" />
+      <span>{title}</span>
+    </div>
+  );
+}
+
+export function ReportExportsTable() {
+  const [statusFilter, setStatusFilter] = useState<"all" | ExportJobStatus>(
+    "all",
+  );
+  const [pagination, setPagination] = useState<PaginationState>({
+    pageIndex: 0,
+    pageSize: 10,
+  });
+  const [downloadingJobIds, setDownloadingJobIds] = useState<Set<string>>(
+    new Set(),
+  );
+
+  const statuses = useMemo(
+    () => (statusFilter === "all" ? undefined : [statusFilter]),
+    [statusFilter],
+  );
+
+  const page = pagination.pageIndex + 1;
+
+  const { data, isLoading, isFetching, refetch, error } = useGetReportExportJobs(
+    {
+      page,
+      status: statuses,
+    },
+    { enabled: true, pollWhenActive: true },
+  );
+
+  const { mutate: requestDownload } = useDownloadReportExportJob();
+
+  const jobs = data?.result.jobs ?? [];
+  const paginationInfo = data?.result.pagination;
+  const totalCount = paginationInfo?.totalCount ?? jobs.length;
+  const currentLimit = paginationInfo?.limit ?? pagination.pageSize;
+  const startItem =
+    totalCount === 0 ? 0 : pagination.pageIndex * currentLimit + 1;
+  const endItem =
+    totalCount === 0
+      ? 0
+      : Math.min(pagination.pageIndex * currentLimit + jobs.length, totalCount);
+
+  const handleDownload = useCallback(
+    (jobId: string) => {
+      setDownloadingJobIds((prev) => {
+        const next = new Set(prev);
+        next.add(jobId);
+        return next;
+      });
+
+      requestDownload(
+        { jobId },
+        {
+          onSuccess: (response) => {
+            const link = document.createElement("a");
+            link.href = response.result.downloadUrl;
+            link.download =
+              response.result.fileName || `report-export-${response.result.jobId}`;
+            document.body.appendChild(link);
+            link.click();
+            link.remove();
+          },
+          onError: (downloadError) => {
+            toast.error(
+              downloadError instanceof Error
+                ? downloadError.message
+                : "Failed to prepare download",
+            );
+          },
+          onSettled: () => {
+            setDownloadingJobIds((prev) => {
+              const next = new Set(prev);
+              next.delete(jobId);
+              return next;
+            });
+          },
+        },
+      );
+    },
+    [requestDownload],
+  );
+
+  const columns = useMemo<ColumnDef<ExportJobSummary>[]>(
+    () => [
+      {
+        accessorKey: "format",
+        header: () => <StaticHeader title="Format" icon={PiFilePdfDuotone} />,
+        cell: ({ row }) => (
+          <div className="flex items-center gap-2 text-sm font-medium">
+            {row.original.format === "pdf" ? (
+              <PiFilePdfDuotone className="size-4 text-red-500" />
+            ) : (
+              <PiFileXlsDuotone className="size-4 text-green-600" />
+            )}
+            {row.original.format.toUpperCase()}
+          </div>
+        ),
+        size: 140,
+      },
+      {
+        accessorKey: "status",
+        header: () => <StaticHeader title="Status" icon={PiClockDuotone} />,
+        cell: ({ row }) => (
+          <Badge variant={getStatusBadgeVariant(row.original.status)}>
+            <span className="flex items-center gap-1.5 capitalize">
+              {row.original.status === "completed" ? (
+                <PiCheckCircleDuotone className="size-3" />
+              ) : row.original.status === "failed" ? (
+                <PiWarningCircleDuotone className="size-3" />
+              ) : (
+                <PiClockDuotone className="size-3" />
+              )}
+              {row.original.status}
+            </span>
+          </Badge>
+        ),
+        size: 150,
+      },
+      {
+        accessorKey: "createdAt",
+        header: () => <StaticHeader title="Created" icon={PiCalendarDuotone} />,
+        cell: ({ row }) => (
+          <span className="text-sm text-muted-foreground">
+            {formatDateTime(row.original.createdAt)}
+          </span>
+        ),
+        size: 210,
+      },
+      {
+        accessorKey: "attempts",
+        header: () => <StaticHeader title="Attempts" icon={PiHashDuotone} />,
+        cell: ({ row }) => <span className="text-sm">{row.original.attempts}</span>,
+        size: 110,
+      },
+      {
+        accessorKey: "errorMessage",
+        header: () => (
+          <StaticHeader title="Error" icon={PiWarningCircleDuotone} />
+        ),
+        cell: ({ row }) => (
+          <div title={row.original.errorMessage || undefined}>
+            <p className="line-clamp-2 break-words text-left text-sm text-destructive">
+              {row.original.errorMessage || "-"}
+            </p>
+          </div>
+        ),
+        size: 320,
+      },
+      {
+        id: "actions",
+        header: () => <StaticHeader title="Action" icon={PiDownloadDuotone} />,
+        cell: ({ row }) => (
+          <Button
+            variant="secondary"
+            size="sm"
+            disabled={
+              row.original.status !== "completed" ||
+              downloadingJobIds.has(row.original.jobId)
+            }
+            onClick={() => handleDownload(row.original.jobId)}
+          >
+            {downloadingJobIds.has(row.original.jobId) ? (
+              <Spinner className="size-3" />
+            ) : (
+              <PiDownloadDuotone />
+            )}
+            Download
+          </Button>
+        ),
+        size: 140,
+      },
+    ],
+    [downloadingJobIds, handleDownload],
+  );
+
+  const table = useReactTable({
+    data: jobs,
+    columns,
+    getCoreRowModel: getCoreRowModel(),
+    manualPagination: true,
+    pageCount: paginationInfo?.totalPages ?? 1,
+    rowCount: totalCount,
+    onPaginationChange: setPagination,
+    state: {
+      pagination,
+    },
+  });
+
+  return (
+    <div className="space-y-2 w-full">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div className="flex items-center justify-start w-full gap-3">
+          <Select
+            value={statusFilter}
+            onValueChange={(value) => {
+              setStatusFilter(value as "all" | ExportJobStatus);
+              setPagination((prev) => ({ ...prev, pageIndex: 0 }));
+            }}
+          >
+            <SelectTrigger className="h-8 w-40 text-xs">
+              <SelectValue placeholder="Filter status" />
+            </SelectTrigger>
+            <SelectContent>
+              {STATUS_FILTERS.map((option) => (
+                <SelectItem
+                  key={option.value}
+                  value={option.value}
+                  className="text-xs"
+                >
+                  {option.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+
+          <Button
+            variant="secondary"
+            size="sm"
+            onClick={() => refetch()}
+            disabled={isFetching}
+          >
+            {isFetching ? (
+              <Spinner className="size-3" />
+            ) : (
+              <PiArrowClockwiseDuotone />
+            )}
+            Refresh
+          </Button>
+        </div>
+      </div>
+
+      <div className="bg-background overflow-hidden rounded-xl border">
+        <Table className="table-fixed">
+          <TableHeader className="bg-muted">
+            {table.getHeaderGroups().map((headerGroup) => (
+              <TableRow key={headerGroup.id} className="hover:bg-transparent">
+                {headerGroup.headers.map((header) => (
+                  <TableHead
+                    key={header.id}
+                    style={{ width: `${header.getSize()}px` }}
+                    className="h-11 border-r border-border last:border-r-0"
+                  >
+                    {header.isPlaceholder
+                      ? null
+                      : flexRender(
+                          header.column.columnDef.header,
+                          header.getContext(),
+                        )}
+                  </TableHead>
+                ))}
+              </TableRow>
+            ))}
+          </TableHeader>
+          <TableBody>
+            {isLoading ? (
+              <TableRow>
+                <TableCell
+                  colSpan={columns.length}
+                  className="h-24 text-center text-muted-foreground"
+                >
+                  <div className="inline-flex items-center gap-2">
+                    <Spinner className="size-4" />
+                    Loading export jobs...
+                  </div>
+                </TableCell>
+              </TableRow>
+            ) : error ? (
+              <TableRow>
+                <TableCell
+                  colSpan={columns.length}
+                  className="h-24 text-center text-destructive"
+                >
+                  {error instanceof Error
+                    ? error.message
+                    : "Failed to load report export jobs"}
+                </TableCell>
+              </TableRow>
+            ) : table.getRowModel().rows.length ? (
+              table.getRowModel().rows.map((row) => (
+                <TableRow key={row.id} className="hover:bg-muted/30">
+                  {row.getVisibleCells().map((cell) => (
+                    <TableCell key={cell.id} className="align-top">
+                      {flexRender(
+                        cell.column.columnDef.cell,
+                        cell.getContext(),
+                      )}
+                    </TableCell>
+                  ))}
+                </TableRow>
+              ))
+            ) : (
+              <TableRow>
+                <TableCell
+                  colSpan={columns.length}
+                  className="h-24 text-center text-muted-foreground"
+                >
+                  No export jobs found.
+                </TableCell>
+              </TableRow>
+            )}
+          </TableBody>
+        </Table>
+      </div>
+
+      {paginationInfo ? (
+        <div className="flex items-center justify-between gap-8">
+          <div className="text-muted-foreground flex grow justify-end text-sm whitespace-nowrap">
+            <p
+              className="text-muted-foreground text-sm whitespace-nowrap"
+              aria-live="polite"
+            >
+              <span className="text-foreground">
+                {startItem}-{endItem}
+              </span>{" "}
+              of <span className="text-foreground">{totalCount}</span>
+            </p>
+          </div>
+
+          <div>
+            <Pagination>
+              <PaginationContent>
+                <PaginationItem>
+                  <Button
+                    variant="secondary"
+                    size="sm"
+                    className="disabled:pointer-events-none disabled:opacity-50"
+                    onClick={() => table.firstPage()}
+                    disabled={!table.getCanPreviousPage()}
+                    aria-label="Go to first page"
+                  >
+                    <PiCaretCircleDoubleLeftDuotone aria-hidden="true" />
+                  </Button>
+                </PaginationItem>
+                <PaginationItem>
+                  <Button
+                    variant="secondary"
+                    size="sm"
+                    className="disabled:pointer-events-none disabled:opacity-50"
+                    onClick={() => table.previousPage()}
+                    disabled={!table.getCanPreviousPage()}
+                    aria-label="Go to previous page"
+                  >
+                    <PiCaretCircleLeftDuotone aria-hidden="true" />
+                  </Button>
+                </PaginationItem>
+                <PaginationItem>
+                  <Button
+                    variant="secondary"
+                    size="sm"
+                    className="disabled:pointer-events-none disabled:opacity-50"
+                    onClick={() => table.nextPage()}
+                    disabled={!table.getCanNextPage()}
+                    aria-label="Go to next page"
+                  >
+                    <PiCaretCircleRightDuotone aria-hidden="true" />
+                  </Button>
+                </PaginationItem>
+                <PaginationItem>
+                  <Button
+                    variant="secondary"
+                    size="sm"
+                    className="disabled:pointer-events-none disabled:opacity-50"
+                    onClick={() => table.lastPage()}
+                    disabled={!table.getCanNextPage()}
+                    aria-label="Go to last page"
+                  >
+                    <PiCaretCircleDoubleRightDuotone aria-hidden="true" />
+                  </Button>
+                </PaginationItem>
+              </PaginationContent>
+            </Pagination>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/hooks/reports/useDownloadReportExportJob.ts
+++ b/hooks/reports/useDownloadReportExportJob.ts
@@ -1,0 +1,34 @@
+import { useMutation } from "@tanstack/react-query";
+import { AuthContextProps, useAuth } from "react-oidc-context";
+import { DownloadReportExportJobResponse } from "@/types/export-job";
+
+async function getReportExportDownloadUrl({
+  auth,
+  jobId,
+}: {
+  auth: AuthContextProps;
+  jobId: string;
+}): Promise<DownloadReportExportJobResponse> {
+  const response = await fetch(`/api/reports/exports/jobs/${jobId}/download`, {
+    headers: {
+      Authorization: `Bearer ${auth?.user?.access_token}`,
+      "Content-Type": "application/json",
+    },
+  });
+
+  if (!response.ok) {
+    const text = await response.text().catch(() => "");
+    throw new Error(text || "Failed to fetch report export download URL");
+  }
+
+  return response.json();
+}
+
+export function useDownloadReportExportJob() {
+  const auth = useAuth();
+
+  return useMutation({
+    mutationFn: ({ jobId }: { jobId: string }) =>
+      getReportExportDownloadUrl({ auth, jobId }),
+  });
+}

--- a/hooks/reports/useExportReports.ts
+++ b/hooks/reports/useExportReports.ts
@@ -1,16 +1,14 @@
-import { useMutation } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useAuth, AuthContextProps } from "react-oidc-context";
+import { EnqueueReportExportResponse } from "@/types/export-job";
 import { ReportsQueryRequest } from "@/types/reports";
 
 type ExportFormat = "pdf" | "excel";
 
-interface ExportRequest
-  extends Omit<ReportsQueryRequest, "pagination" | "workspaceId"> {
-  format: ExportFormat;
-  reportHeader?: string;
-}
+type ExportRequest = Omit<ReportsQueryRequest, "pagination">;
+type QueueableExportRequest = Omit<ExportRequest, "workspaceId">;
 
-async function exportReports({
+async function enqueueReportExport({
   payload,
   auth,
   format,
@@ -18,8 +16,8 @@ async function exportReports({
   payload: ExportRequest;
   auth: AuthContextProps;
   format: ExportFormat;
-}): Promise<Blob> {
-  const response = await fetch(`/api/reports/export/${format}`, {
+}): Promise<EnqueueReportExportResponse> {
+  const response = await fetch("/api/reports/exports", {
     method: "POST",
     headers: {
       Authorization: `Bearer ${auth?.user?.access_token}`,
@@ -28,85 +26,54 @@ async function exportReports({
     body: JSON.stringify({
       ...payload,
       workspaceId: auth?.user?.profile?.workspaceId,
+      format,
     }),
   });
 
   if (!response.ok) {
     const text = await response.text().catch(() => "");
-    throw new Error(text || `Failed to export as ${format.toUpperCase()}`);
+    throw new Error(text || `Failed to queue ${format.toUpperCase()} export`);
   }
 
-  const base64Data = await response.text();
-
-  const byteCharacters = atob(base64Data);
-  const byteNumbers = new Array(byteCharacters.length);
-  for (let i = 0; i < byteCharacters.length; i++) {
-    byteNumbers[i] = byteCharacters.charCodeAt(i);
-  }
-  const byteArray = new Uint8Array(byteNumbers);
-
-  const mimeType =
-    format === "pdf"
-      ? "application/pdf"
-      : "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
-
-  return new Blob([byteArray], { type: mimeType });
-}
-
-function downloadBlob(blob: Blob, filename: string) {
-  const url = window.URL.createObjectURL(blob);
-  const link = document.createElement("a");
-  link.href = url;
-  link.download = filename;
-  document.body.appendChild(link);
-  link.click();
-  document.body.removeChild(link);
-  window.URL.revokeObjectURL(url);
-}
-
-function sanitizeFilename(name: string): string {
-  return name
-    .replace(/[<>:"/\\|?*]/g, "")
-    .replace(/\s+/g, "_")
-    .substring(0, 100);
+  return response.json();
 }
 
 export function useExportPDF() {
   const auth = useAuth();
+  const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: async (payload: Omit<ExportRequest, "format">) => {
-      const blob = await exportReports({
-        payload: { ...payload, format: "pdf" },
+    mutationFn: async (payload: QueueableExportRequest) =>
+      enqueueReportExport({
+        payload: {
+          ...payload,
+          workspaceId: auth?.user?.profile?.workspaceId as string,
+        },
         auth,
         format: "pdf",
-      });
-      const timestamp = new Date().toISOString().split("T")[0];
-      const filename = payload.reportHeader
-        ? `${sanitizeFilename(payload.reportHeader)}_${timestamp}.pdf`
-        : `reports-report-${timestamp}.pdf`;
-      downloadBlob(blob, filename);
-      return blob;
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["report-export-jobs"] });
     },
   });
 }
 
 export function useExportExcel() {
   const auth = useAuth();
+  const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: async (payload: Omit<ExportRequest, "format">) => {
-      const blob = await exportReports({
-        payload: { ...payload, format: "excel" },
+    mutationFn: async (payload: QueueableExportRequest) =>
+      enqueueReportExport({
+        payload: {
+          ...payload,
+          workspaceId: auth?.user?.profile?.workspaceId as string,
+        },
         auth,
         format: "excel",
-      });
-      const timestamp = new Date().toISOString().split("T")[0];
-      const filename = payload.reportHeader
-        ? `${sanitizeFilename(payload.reportHeader)}_${timestamp}.xlsx`
-        : `reports-report-${timestamp}.xlsx`;
-      downloadBlob(blob, filename);
-      return blob;
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["report-export-jobs"] });
     },
   });
 }

--- a/hooks/reports/useGetReportExportJob.ts
+++ b/hooks/reports/useGetReportExportJob.ts
@@ -1,0 +1,43 @@
+import { useQuery } from "@tanstack/react-query";
+import { AuthContextProps, useAuth } from "react-oidc-context";
+import { GetReportExportJobResponse } from "@/types/export-job";
+
+async function getReportExportJob({
+  auth,
+  signal,
+  jobId,
+}: {
+  auth: AuthContextProps;
+  signal: AbortSignal;
+  jobId: string;
+}): Promise<GetReportExportJobResponse> {
+  const response = await fetch(`/api/reports/exports/jobs/${jobId}`, {
+    headers: {
+      Authorization: `Bearer ${auth?.user?.access_token}`,
+      "Content-Type": "application/json",
+    },
+    signal,
+  });
+
+  if (!response.ok) {
+    const text = await response.text().catch(() => "");
+    throw new Error(text || "Failed to fetch report export job");
+  }
+
+  return response.json();
+}
+
+export function useGetReportExportJob(
+  jobId?: string,
+  options?: { enabled?: boolean; refetchInterval?: number | false },
+) {
+  const auth = useAuth();
+
+  return useQuery({
+    queryKey: ["report-export-job", jobId],
+    queryFn: ({ signal }) =>
+      getReportExportJob({ auth, signal, jobId: jobId as string }),
+    enabled: (options?.enabled ?? true) && auth.isAuthenticated && Boolean(jobId),
+    refetchInterval: options?.refetchInterval,
+  });
+}

--- a/hooks/reports/useGetReportExportJobs.ts
+++ b/hooks/reports/useGetReportExportJobs.ts
@@ -1,0 +1,80 @@
+import { useQuery } from "@tanstack/react-query";
+import { AuthContextProps, useAuth } from "react-oidc-context";
+import {
+  ExportJobStatus,
+  GetReportExportJobsResponse,
+} from "@/types/export-job";
+
+const DEFAULT_ACTIVE_JOB_POLL_INTERVAL = 5000;
+const ACTIVE_EXPORT_JOB_STATUSES: ExportJobStatus[] = ["queued", "processing"];
+
+type GetReportExportJobsParams = {
+  page?: number;
+  status?: ExportJobStatus[];
+};
+
+async function getReportExportJobs({
+  auth,
+  signal,
+  page = 1,
+  status,
+}: {
+  auth: AuthContextProps;
+  signal: AbortSignal;
+  page?: number;
+  status?: ExportJobStatus[];
+}): Promise<GetReportExportJobsResponse> {
+  const params = new URLSearchParams();
+  params.set("page", String(page));
+  if (status?.length) {
+    params.set("status", status.join(","));
+  }
+
+  const response = await fetch(`/api/reports/exports/jobs?${params.toString()}`, {
+    headers: {
+      Authorization: `Bearer ${auth?.user?.access_token}`,
+      "Content-Type": "application/json",
+    },
+    signal,
+  });
+
+  if (!response.ok) {
+    const text = await response.text().catch(() => "");
+    throw new Error(text || "Failed to fetch report export jobs");
+  }
+
+  return response.json();
+}
+
+export function useGetReportExportJobs(
+  { page = 1, status }: GetReportExportJobsParams = {},
+  options?: {
+    enabled?: boolean;
+    pollWhenActive?: boolean;
+    activePollIntervalMs?: number;
+    refetchInterval?: number | false;
+  },
+) {
+  const auth = useAuth();
+
+  return useQuery({
+    queryKey: ["report-export-jobs", page, status?.join(",") || "all"],
+    queryFn: ({ signal }) => getReportExportJobs({ auth, signal, page, status }),
+    enabled: (options?.enabled ?? true) && auth.isAuthenticated,
+    refetchInterval: options?.pollWhenActive
+      ? (query) => {
+          const data = query.state.data;
+          const hasActiveJobs =
+            typeof data?.result.hasActiveJobs === "boolean"
+              ? data.result.hasActiveJobs
+              : (data?.result.jobs ?? []).some((job) =>
+                  ACTIVE_EXPORT_JOB_STATUSES.includes(job.status),
+                );
+
+          return hasActiveJobs
+            ? options?.activePollIntervalMs ?? DEFAULT_ACTIVE_JOB_POLL_INTERVAL
+            : false;
+        }
+      : options?.refetchInterval,
+  });
+}

--- a/types/export-job.ts
+++ b/types/export-job.ts
@@ -36,7 +36,7 @@ export interface ExportJobPagination {
   hasPrevPage: boolean;
 }
 
-export interface EnqueueProductExportResponse {
+export interface ExportEnqueueResponse {
   message: string;
   result: {
     jobId: string;
@@ -44,7 +44,7 @@ export interface EnqueueProductExportResponse {
   };
 }
 
-export interface GetProductExportJobsResponse {
+export interface GetExportJobsResponse {
   message: string;
   result: {
     jobs: ExportJobSummary[];
@@ -54,12 +54,12 @@ export interface GetProductExportJobsResponse {
   };
 }
 
-export interface GetProductExportJobResponse {
+export interface GetExportJobResponse {
   message: string;
   result: ExportJobSummary;
 }
 
-export interface DownloadProductExportJobResponse {
+export interface DownloadExportJobResponse {
   message: string;
   result: {
     jobId: string;
@@ -69,3 +69,19 @@ export interface DownloadProductExportJobResponse {
     expiresAt: string;
   };
 }
+
+export type EnqueueProductExportResponse = ExportEnqueueResponse;
+
+export type EnqueueReportExportResponse = ExportEnqueueResponse;
+
+export type GetProductExportJobsResponse = GetExportJobsResponse;
+
+export type GetReportExportJobsResponse = GetExportJobsResponse;
+
+export type GetProductExportJobResponse = GetExportJobResponse;
+
+export type GetReportExportJobResponse = GetExportJobResponse;
+
+export type DownloadProductExportJobResponse = DownloadExportJobResponse;
+
+export type DownloadReportExportJobResponse = DownloadExportJobResponse;


### PR DESCRIPTION
## Summary
- switch reports export UI from synchronous downloads to queued background exports backed by the new report export APIs
- add an Exports tab with job polling, status indicators, download actions, and report export completion notifications
- surface product export activity on the products page with the same lightweight status indicator pattern