### PR TITLE
feat: update upload structure to include productId and workspace-assets scope

### DIFF
--- a/apps/app/features/workspace/products/product/component-details/AddComponentDialog.tsx
+++ b/apps/app/features/workspace/products/product/component-details/AddComponentDialog.tsx
@@ -90,6 +90,8 @@ export default function AddComponentDialog({
         uploadRes = await uploadImage({
           file: data.image.file,
           contentType: data.image.file.type,
+          uploadScope: "product-assets",
+          productId,
         });
 
         console.log("S3 upload response:", uploadRes);

--- a/apps/app/features/workspace/products/product/component-details/EditComponentDialog.tsx
+++ b/apps/app/features/workspace/products/product/component-details/EditComponentDialog.tsx
@@ -129,6 +129,8 @@ export default function EditComponentDialog({
         const uploadRes = await uploadImage({
           file: data.image.file,
           contentType: data.image.file.type || "application/octet-stream",
+          uploadScope: "product-assets",
+          productId,
         });
         uploadedImageKey = uploadRes.key;
       }

--- a/apps/app/features/workspace/products/product/graphics-other-components/AddBarcodesDialog.tsx
+++ b/apps/app/features/workspace/products/product/graphics-other-components/AddBarcodesDialog.tsx
@@ -112,6 +112,8 @@ export default function AddBarcodesDialog({
         const s3UploadResult = await uploadFileToS3({
           file: data.image.file,
           contentType: data.image.file.type || "application/octet-stream",
+          uploadScope: "product-assets",
+          productId,
         });
 
         uploadedImageKey = s3UploadResult.key;

--- a/apps/app/features/workspace/products/product/graphics-other-components/AddOtherCompsDialog.tsx
+++ b/apps/app/features/workspace/products/product/graphics-other-components/AddOtherCompsDialog.tsx
@@ -75,6 +75,8 @@ export default function AddOtherCompsDialog({
         const s3UploadResult = await uploadFileToS3({
           file: data.image.file,
           contentType: data.image.file.type || "application/octet-stream",
+          uploadScope: "product-assets",
+          productId,
         });
 
         uploadedImageKey = s3UploadResult.key;

--- a/apps/app/features/workspace/products/product/graphics-other-components/AddSchematicsDialog.tsx
+++ b/apps/app/features/workspace/products/product/graphics-other-components/AddSchematicsDialog.tsx
@@ -75,6 +75,8 @@ export default function AddSchematicsDialog({
         const s3UploadResult = await uploadFileToS3({
           file: data.image.file,
           contentType: data.image.file.type || "application/octet-stream",
+          uploadScope: "product-assets",
+          productId,
         });
 
         uploadedImageKey = s3UploadResult.key;

--- a/apps/app/features/workspace/products/product/graphics-other-components/AddSymbolsDialog.tsx
+++ b/apps/app/features/workspace/products/product/graphics-other-components/AddSymbolsDialog.tsx
@@ -247,6 +247,8 @@ export default function AddSymbolsDialog({
         const s3UploadResult = await uploadFileToS3({
           file: data.image.file,
           contentType: data.image.file.type || "application/octet-stream",
+          uploadScope: "product-assets",
+          productId,
         });
 
         uploadedImageKey = s3UploadResult.key;

--- a/apps/app/features/workspace/products/product/graphics-other-components/EditBarcodesDialog.tsx
+++ b/apps/app/features/workspace/products/product/graphics-other-components/EditBarcodesDialog.tsx
@@ -167,6 +167,8 @@ export default function EditBarcodesDialog({
         const s3UploadResult = await uploadFileToS3({
           file: data.image.file,
           contentType: data.image.file.type || "application/octet-stream",
+          uploadScope: "product-assets",
+          productId,
         });
 
         uploadedImageKey = s3UploadResult.key;

--- a/apps/app/features/workspace/products/product/graphics-other-components/EditOtherComponentsDialog.tsx
+++ b/apps/app/features/workspace/products/product/graphics-other-components/EditOtherComponentsDialog.tsx
@@ -121,6 +121,8 @@ export default function EditOtherComponentsDialog({
         const s3UploadResult = await uploadFileToS3({
           file: data.image.file,
           contentType: data.image.file.type || "application/octet-stream",
+          uploadScope: "product-assets",
+          productId,
         });
 
         uploadedImageKey = s3UploadResult.key;

--- a/apps/app/features/workspace/products/product/graphics-other-components/EditSchematicsDialog.tsx
+++ b/apps/app/features/workspace/products/product/graphics-other-components/EditSchematicsDialog.tsx
@@ -121,6 +121,8 @@ export default function EditSchematicsDialog({
         const s3UploadResult = await uploadFileToS3({
           file: data.image.file,
           contentType: data.image.file.type || "application/octet-stream",
+          uploadScope: "product-assets",
+          productId,
         });
 
         uploadedImageKey = s3UploadResult.key;

--- a/apps/app/features/workspace/products/product/graphics-other-components/EditSymbolsDialog.tsx
+++ b/apps/app/features/workspace/products/product/graphics-other-components/EditSymbolsDialog.tsx
@@ -133,6 +133,8 @@ export default function EditSymbolsDialog({
         const s3UploadResult = await uploadFileToS3({
           file: data.image.file,
           contentType: data.image.file.type || "application/octet-stream",
+          uploadScope: "product-assets",
+          productId,
         });
 
         uploadedImageKey = s3UploadResult.key;

--- a/apps/app/features/workspace/products/product/label-tags/DialogAddLabelTag.tsx
+++ b/apps/app/features/workspace/products/product/label-tags/DialogAddLabelTag.tsx
@@ -78,6 +78,8 @@ export default function DialogAddLabelTag({
         const s3UploadResult = await uploadFileToS3({
           file: data.image.file,
           contentType: data.image.file.type || "application/octet-stream",
+          uploadScope: "product-assets",
+          productId,
         });
 
         uploadedImageKey = s3UploadResult.key;

--- a/apps/app/features/workspace/products/product/label-tags/DialogEditLabelTag.tsx
+++ b/apps/app/features/workspace/products/product/label-tags/DialogEditLabelTag.tsx
@@ -92,6 +92,8 @@ export default function DialogEditLabelTag({
         const s3UploadResult = await uploadFileToS3({
           file: data.image.file,
           contentType: data.image.file.type || "application/octet-stream",
+          uploadScope: "product-assets",
+          productId,
         });
 
         uploadedImageKey = s3UploadResult.key;

--- a/apps/app/features/workspace/products/product/label-tags/labelTagsTabs.tsx
+++ b/apps/app/features/workspace/products/product/label-tags/labelTagsTabs.tsx
@@ -135,6 +135,8 @@ export default function LabelTagsTabs({
         const s3UploadResult = await uploadFileToS3({
           file,
           contentType: file.type || "application/octet-stream",
+          uploadScope: "product-assets",
+          productId,
         });
         const uploadedKey = s3UploadResult.key;
 

--- a/apps/app/hooks/s3-storage/useUploadFilesToS3.ts
+++ b/apps/app/hooks/s3-storage/useUploadFilesToS3.ts
@@ -5,8 +5,11 @@ import { toast } from "sonner";
 interface S3SignedUrlRequest {
   file: File;
   contentType?: string;
-  uploadScope?: "product-assets" | "source-files";
+  uploadScope?: S3UploadScope;
+  productId?: string;
 }
+
+type S3UploadScope = "workspace-assets" | "product-assets" | "source-files";
 
 const PRODUCT_ASSET_CONTENT_TYPES = new Set([
   "image/png",
@@ -64,7 +67,7 @@ const resolveContentType = (file: File, providedType?: string): string => {
 
 const isAllowedContentType = (
   contentType: string,
-  uploadScope: "product-assets" | "source-files",
+  uploadScope: S3UploadScope,
 ) => {
   if (PRODUCT_ASSET_CONTENT_TYPES.has(contentType)) return true;
   if (uploadScope === "source-files") {
@@ -80,7 +83,8 @@ export function useUploadFilesToS3() {
     mutationFn: async ({
       file,
       contentType,
-      uploadScope = "product-assets",
+      uploadScope = "workspace-assets",
+      productId,
     }: S3SignedUrlRequest) => {
       const accessToken = auth.user?.access_token;
       if (!accessToken) {
@@ -93,13 +97,16 @@ export function useUploadFilesToS3() {
         throw new Error(`Unsupported file type: ${file.name}`);
       }
 
+      const presignRequestBody = {
+        fileName: file.name,
+        contentType: resolvedContentType,
+        uploadScope,
+        ...(productId ? { productId } : {}),
+      };
+
       const res = await fetch(`/api/s3-storage/presign-upload`, {
         method: "POST",
-        body: JSON.stringify({
-          fileName: file.name,
-          contentType: resolvedContentType,
-          uploadScope,
-        }),
+        body: JSON.stringify(presignRequestBody),
         headers: {
           Authorization: `Bearer ${accessToken}`,
           "Content-Type": "application/json",


### PR DESCRIPTION
Refactor the S3 upload process to support more granular file organization. 
The `useUploadFilesToS3` hook now supports a `workspace-assets` scope 
and accepts an optional `productId` to allow for structured S3 
bucket paths.

- Update `S3SignedUrlRequest` to include `productId` and a new 
  `S3UploadScope` type.
- Change default `uploadScope` from `product-assets` to `workspace-assets`.
- Update all product-related dialogs (components, barcodes, schematics, 
  symbols, and label tags) to pass `uploadScope: "product-assets"` 
  and the relevant `productId` during file uploads.

Closes #134