### PR TITLE
Hotfix v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.1] - 2026-05-24
+
+### Fixed
+
+- Fixed the production app build by using `product_description` when duplicating products.
+
 ## [0.3.0] - 2026-05-23
 
 ### Added

--- a/apps/app/features/workspace/products/DialogDuplicateProduct.tsx
+++ b/apps/app/features/workspace/products/DialogDuplicateProduct.tsx
@@ -66,7 +66,7 @@ export default function DialogDuplicateProduct({
     defaultValues: {
       ppn: "",
       productName: product.product_name,
-      description: product.description,
+      description: product.product_description,
       department: product.department_id,
       project: product.project_id,
       version: 1,

--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uprevit/app",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "private": true,
   "scripts": {
     "dev": "next dev -p 8080",

--- a/apps/marketing/package.json
+++ b/apps/marketing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uprevit/marketing",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "private": true,
   "scripts": {
     "dev": "next dev -p 3001",

--- a/bun.lock
+++ b/bun.lock
@@ -13,7 +13,7 @@
     },
     "apps/app": {
       "name": "@uprevit/app",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/modifiers": "^9.0.0",
@@ -89,7 +89,7 @@
     },
     "apps/marketing": {
       "name": "@uprevit/marketing",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "dependencies": {
         "@radix-ui/react-accordion": "^1.2.12",
         "@radix-ui/react-dropdown-menu": "^2.1.7",
@@ -122,7 +122,7 @@
     },
     "packages/ui": {
       "name": "@uprevit/ui",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "dependencies": {
         "@radix-ui/react-accordion": "^1.2.12",
         "@radix-ui/react-alert-dialog": "^1.1.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uprevit-ui",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "private": true,
   "packageManager": "bun@1.3.11",
   "workspaces": [

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uprevit/ui",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "private": true,
   "scripts": {
     "build": "tsc --noEmit",


### PR DESCRIPTION
- Fixes the production app build failure in product duplication by reading `product_description` from the product table item.
- Bumps frontend package versions and lockfile workspace metadata to `0.3.1`.
- Adds the `0.3.1` changelog entry for the hotfix.