### PR TITLE
Add in-app documentation with walkthrough videos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ next-env.d.ts
 /staging-e2e
 monorepo*
 .cursor
+.source/

--- a/apps/app/app/(app)/layout.tsx
+++ b/apps/app/app/(app)/layout.tsx
@@ -1,85 +1,25 @@
 "use client";
 
 import { AppHeader } from "@/components/common/AppHeader";
+import { AccessEligibilityGuard } from "@/components/common/AccessEligibilityGuard";
 import { MainContentWrapper } from "@/components/common/MainContentWrapper";
 import { SidebarInset, SidebarProvider } from "@uprevit/ui/components/ui/sidebar";
-import { useEffect } from "react";
-import { useRouter } from "next/navigation";
-import { useAuth } from "react-oidc-context";
-import { useGetUser } from "@/hooks/user/useGetUser";
 import { AppSidebar } from "@/components/common/AppSidebar";
 import { ProductExportJobNotifier } from "@/components/common/ProductExportJobNotifier";
 import { ReportExportJobNotifier } from "@/components/common/ReportExportJobNotifier";
 
-const getProfileValue = (
-  profile: Record<string, unknown> | undefined,
-  key: string,
-): string | undefined => {
-  const value = profile?.[key];
-  return typeof value === "string" && value.length > 0 ? value : undefined;
-};
-
 export default function AppLayout({ children }: { children: React.ReactNode }) {
-  const auth = useAuth();
-  const router = useRouter();
-  const { data: userProfileData, isLoading: isUserLoading } = useGetUser();
-
-  const profile = auth.user?.profile as Record<string, unknown> | undefined;
-  const userIdFromToken = getProfileValue(profile, "userId");
-  const tokenWorkspaceId = getProfileValue(profile, "workspaceId");
-  const tokenStatus = getProfileValue(profile, "status");
-
-  useEffect(() => {
-    if (auth.isLoading) return;
-
-    if (!auth.isAuthenticated || !auth.user?.profile) {
-      router.replace("/");
-      return;
-    }
-
-    if (userIdFromToken && isUserLoading) return;
-
-    const status = userProfileData?.user?.status || tokenStatus;
-    const workspaceId = userProfileData?.user?.workspaceId || tokenWorkspaceId;
-
-    if (status === "invited") {
-      router.replace("/onboarding/onboard-user");
-      return;
-    }
-
-    if (!workspaceId) {
-      router.replace("/onboarding/create-workspace");
-    }
-  }, [
-    auth.isAuthenticated,
-    auth.isLoading,
-    auth.user?.profile,
-    isUserLoading,
-    router,
-    tokenStatus,
-    tokenWorkspaceId,
-    userIdFromToken,
-    userProfileData?.user?.status,
-    userProfileData?.user?.workspaceId,
-  ]);
-
-  if (auth.isLoading || (userIdFromToken && isUserLoading)) {
-    return (
-      <div className="flex h-screen w-full items-center justify-center">
-        <p>Loading...</p>
-      </div>
-    );
-  }
-
   return (
-    <SidebarProvider>
-      <AppSidebar />
-      <SidebarInset>
-        <AppHeader />
-        <ProductExportJobNotifier />
-        <ReportExportJobNotifier />
-        <MainContentWrapper>{children}</MainContentWrapper>
-      </SidebarInset>
-    </SidebarProvider>
+    <AccessEligibilityGuard>
+      <SidebarProvider>
+        <AppSidebar />
+        <SidebarInset>
+          <AppHeader />
+          <ProductExportJobNotifier />
+          <ReportExportJobNotifier />
+          <MainContentWrapper>{children}</MainContentWrapper>
+        </SidebarInset>
+      </SidebarProvider>
+    </AccessEligibilityGuard>
   );
 }

--- a/apps/app/app/api/search/route.ts
+++ b/apps/app/app/api/search/route.ts
@@ -1,0 +1,6 @@
+import { source } from "@/lib/source";
+import { createFromSource } from "fumadocs-core/search/server";
+
+export const { GET } = createFromSource(source, {
+  language: "english",
+});

--- a/apps/app/app/api/search/route.ts
+++ b/apps/app/app/api/search/route.ts
@@ -1,6 +1,22 @@
+import { verifyCognitoAccessToken } from "@/lib/verify-cognito-access-token";
 import { source } from "@/lib/source";
 import { createFromSource } from "fumadocs-core/search/server";
+import type { NextRequest } from "next/server";
 
-export const { GET } = createFromSource(source, {
+const { GET: searchGET } = createFromSource(source, {
   language: "english",
 });
+
+export async function GET(request: NextRequest) {
+  const authorization = request.headers.get("authorization");
+  if (!authorization?.startsWith("Bearer ")) {
+    return Response.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const token = authorization.slice("Bearer ".length).trim();
+  if (!token || !(await verifyCognitoAccessToken(token))) {
+    return Response.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  return searchGET(request);
+}

--- a/apps/app/app/docs/[[...slug]]/page.tsx
+++ b/apps/app/app/docs/[[...slug]]/page.tsx
@@ -1,0 +1,56 @@
+import { source } from "@/lib/source";
+import {
+  DocsBody,
+  DocsDescription,
+  DocsPage,
+  DocsTitle,
+} from "fumadocs-ui/layouts/docs/page";
+import { notFound } from "next/navigation";
+import { getMDXComponents } from "@/components/mdx";
+import type { Metadata } from "next";
+import { createRelativeLink } from "fumadocs-ui/mdx";
+
+export default async function Page(props: PageProps<"/docs/[[...slug]]">) {
+  const params = await props.params;
+  const page = source.getPage(params.slug);
+  if (!page) notFound();
+
+  const MDX = page.data.body;
+
+  return (
+    <DocsPage
+      tableOfContent={{
+        style: "clerk",
+      }}
+      toc={page.data.toc}
+      full={page.data.full}
+    >
+      <DocsTitle>{page.data.title}</DocsTitle>
+      <DocsDescription>{page.data.description}</DocsDescription>
+      <DocsBody>
+        <MDX
+          components={getMDXComponents({
+            a: createRelativeLink(source, page),
+          })}
+        />
+      </DocsBody>
+    </DocsPage>
+  );
+}
+
+export async function generateStaticParams() {
+  return source.generateParams();
+}
+
+export async function generateMetadata(
+  props: PageProps<"/docs/[[...slug]]">,
+): Promise<Metadata> {
+  const params = await props.params;
+  const page = source.getPage(params.slug);
+  if (!page) notFound();
+
+  return {
+    title: page.data.title,
+    description: page.data.description,
+  };
+}

--- a/apps/app/app/docs/layout.tsx
+++ b/apps/app/app/docs/layout.tsx
@@ -1,0 +1,200 @@
+import { AccessEligibilityGuard } from "@/components/common/AccessEligibilityGuard";
+import { DocsLayout } from "fumadocs-ui/layouts/docs";
+import { baseOptions } from "@/lib/layout.shared";
+import {
+  PiArchiveDuotone,
+  PiBookmarkSimpleDuotone,
+  PiBookOpenDuotone,
+  PiBuildingsDuotone,
+  PiDatabaseDuotone,
+  PiExportDuotone,
+  PiFolderOpenDuotone,
+  PiGitBranchDuotone,
+  PiCompassDuotone,
+  PiHouseDuotone,
+  PiImageSquareDuotone,
+  PiKanbanDuotone,
+  PiLayoutDuotone,
+  PiMicrosoftExcelLogoDuotone,
+  PiPackageDuotone,
+  PiPictureInPictureDuotone,
+  PiPresentationChartDuotone,
+  PiTagChevronDuotone,
+} from "react-icons/pi";
+
+import { SectionSpacer } from "../../components/layout.client";
+import { RootProvider } from "fumadocs-ui/provider/next";
+
+export default function DocsRootLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <AccessEligibilityGuard>
+      <RootProvider>
+        <DocsLayout
+          tree={{
+            name: "Uprevit Docs",
+            type: "root",
+            children: [
+              {
+                name: "Introduction",
+                type: "page",
+                url: "/docs",
+                icon: <PiCompassDuotone />,
+              },
+              { type: "separator" },
+              {
+                name: "Getting Started",
+                type: "folder",
+                icon: <PiBookOpenDuotone />,
+                defaultOpen: true,
+                children: [
+                  {
+                    name: "Workspace",
+                    type: "page",
+                    url: "/docs/getting-started/workspace",
+                    icon: <PiHouseDuotone />,
+                  },
+                  {
+                    name: "Departments",
+                    type: "page",
+                    url: "/docs/getting-started/departments",
+                    icon: <PiBuildingsDuotone />,
+                  },
+                  {
+                    name: "Projects",
+                    type: "page",
+                    url: "/docs/getting-started/projects",
+                    icon: <PiKanbanDuotone />,
+                  },
+                  {
+                    name: "Products",
+                    type: "page",
+                    url: "/docs/getting-started/products",
+                    icon: <PiPackageDuotone />,
+                  },
+                ],
+              },
+              { type: "separator" },
+              {
+                name: "Product Documentation",
+                type: "folder",
+                icon: <PiPackageDuotone />,
+                defaultOpen: true,
+                children: [
+                  {
+                    name: "Product Information",
+                    type: "page",
+                    url: "/docs/product-documentation/product-information",
+                    icon: <PiLayoutDuotone />,
+                  },
+                  {
+                    name: "Compliance Information",
+                    type: "page",
+                    url: "/docs/product-documentation/compliance-information",
+                    icon: <PiBookOpenDuotone />,
+                  },
+                  {
+                    name: "Label Components",
+                    type: "page",
+                    url: "/docs/product-documentation/label-components",
+                    icon: <PiPictureInPictureDuotone />,
+                  },
+                  {
+                    name: "Symbols & Graphics",
+                    type: "page",
+                    url: "/docs/product-documentation/symbols-graphics",
+                    icon: <PiImageSquareDuotone />,
+                  },
+                  {
+                    name: "Product Specifications",
+                    type: "page",
+                    url: "/docs/product-documentation/product-specifications",
+                    icon: <PiMicrosoftExcelLogoDuotone />,
+                  },
+                  {
+                    name: "Operational Parameters",
+                    type: "page",
+                    url: "/docs/product-documentation/operational-parameters",
+                    icon: <PiDatabaseDuotone />,
+                  },
+                  {
+                    name: "Label Tags",
+                    type: "page",
+                    url: "/docs/product-documentation/label-tags",
+                    icon: <PiTagChevronDuotone />,
+                  },
+                ],
+              },
+              { type: "separator" },
+              {
+                name: "Source Files & Bookmarks",
+                type: "folder",
+                icon: <PiFolderOpenDuotone />,
+                defaultOpen: true,
+                children: [
+                  {
+                    name: "Source Files",
+                    type: "page",
+                    url: "/docs/source-files-bookmarks/source-files",
+                    icon: <PiFolderOpenDuotone />,
+                  },
+                  {
+                    name: "Bookmarks",
+                    type: "page",
+                    url: "/docs/source-files-bookmarks/bookmarks",
+                    icon: <PiBookmarkSimpleDuotone />,
+                  },
+                ],
+              },
+              { type: "separator" },
+              {
+                name: "Review & Outputs",
+                type: "folder",
+                icon: <PiPresentationChartDuotone />,
+                defaultOpen: true,
+                children: [
+                  {
+                    name: "Redlines and Versions",
+                    type: "page",
+                    url: "/docs/review-outputs/redlines-versions",
+                    icon: <PiGitBranchDuotone />,
+                  },
+                  {
+                    name: "Reports",
+                    type: "page",
+                    url: "/docs/review-outputs/reports",
+                    icon: <PiPresentationChartDuotone />,
+                  },
+                  {
+                    name: "Exports",
+                    type: "page",
+                    url: "/docs/review-outputs/exports",
+                    icon: <PiExportDuotone />,
+                  },
+                  {
+                    name: "Archives",
+                    type: "page",
+                    url: "/docs/review-outputs/archives",
+                    icon: <PiArchiveDuotone />,
+                  },
+                ],
+              },
+            ],
+          }}
+          sidebar={{
+            components: {
+              Separator: SectionSpacer,
+            },
+          }}
+          {...baseOptions()}
+          searchToggle={{ enabled: true }}
+        >
+          {children}
+        </DocsLayout>
+      </RootProvider>
+    </AccessEligibilityGuard>
+  );
+}

--- a/apps/app/app/docs/layout.tsx
+++ b/apps/app/app/docs/layout.tsx
@@ -22,6 +22,7 @@ import {
   PiTagChevronDuotone,
 } from "react-icons/pi";
 
+import { DocsSearchDialog } from "@/components/docs/DocsSearchDialog";
 import { SectionSpacer } from "../../components/layout.client";
 import { RootProvider } from "fumadocs-ui/provider/next";
 
@@ -32,7 +33,7 @@ export default function DocsRootLayout({
 }) {
   return (
     <AccessEligibilityGuard>
-      <RootProvider>
+      <RootProvider search={{ SearchDialog: DocsSearchDialog }}>
         <DocsLayout
           tree={{
             name: "Uprevit Docs",

--- a/apps/app/app/globals.css
+++ b/apps/app/app/globals.css
@@ -2,6 +2,10 @@
 @import "tw-animate-css";
 @source "../../../packages/ui/src";
 
+@import "fumadocs-ui/css/neutral.css";
+@import "fumadocs-ui/css/preset.css";
+@source "../../../node_modules/fumadocs-ui/dist/**/*.js";
+
 @custom-variant dark (&:is(.dark *));
 
 :root {

--- a/apps/app/components/common/AccessEligibilityGuard.tsx
+++ b/apps/app/components/common/AccessEligibilityGuard.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { useGetUser } from "@/hooks/user/useGetUser";
+import { useRouter } from "next/navigation";
+import { useEffect } from "react";
+import { useAuth } from "react-oidc-context";
+
+const getProfileValue = (
+  profile: Record<string, unknown> | undefined,
+  key: string,
+): string | undefined => {
+  const value = profile?.[key];
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+};
+
+export function AccessEligibilityGuard({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const auth = useAuth();
+  const router = useRouter();
+  const { data: userProfileData, isLoading: isUserLoading } = useGetUser();
+
+  const profile = auth.user?.profile;
+  const userIdFromToken = getProfileValue(profile, "userId");
+  const tokenWorkspaceId = getProfileValue(profile, "workspaceId");
+  const tokenStatus = getProfileValue(profile, "status");
+
+  useEffect(() => {
+    if (auth.isLoading) return;
+
+    if (!auth.isAuthenticated || !auth.user?.profile) {
+      router.replace("/");
+      return;
+    }
+
+    if (userIdFromToken && isUserLoading) return;
+
+    const status = userProfileData?.user?.status || tokenStatus;
+    const workspaceId = userProfileData?.user?.workspaceId || tokenWorkspaceId;
+
+    if (status === "invited") {
+      router.replace("/onboarding/onboard-user");
+      return;
+    }
+
+    if (!workspaceId) {
+      router.replace("/onboarding/create-workspace");
+    }
+  }, [
+    auth.isAuthenticated,
+    auth.isLoading,
+    auth.user?.profile,
+    isUserLoading,
+    router,
+    tokenStatus,
+    tokenWorkspaceId,
+    userIdFromToken,
+    userProfileData?.user?.status,
+    userProfileData?.user?.workspaceId,
+  ]);
+
+  if (auth.isLoading || (userIdFromToken && isUserLoading)) {
+    return (
+      <div className="flex h-screen w-full items-center justify-center">
+        <p>Loading...</p>
+      </div>
+    );
+  }
+
+  return children;
+}

--- a/apps/app/components/common/AppSidebar.tsx
+++ b/apps/app/components/common/AppSidebar.tsx
@@ -15,8 +15,8 @@ import {
   SidebarMenuSubItem,
   SidebarRail,
 } from "@uprevit/ui/components/ui/sidebar";
-import Image from "next/image";
 import Link from "next/link";
+import { UprevitLogo } from "@/components/common/UprevitLogo";
 import {
   PiArchiveDuotone,
   PiBookmarkSimpleDuotone,
@@ -115,12 +115,18 @@ const data = {
       ],
     },
     {
-      title: "Settings",
+      title: "Help",
+
       items: [
         {
           title: "Settings",
           url: "/settings",
           icon: PiGearDuotone,
+        },
+        {
+          title: "Documentation",
+          url: "/docs",
+          icon: PiBookOpenDuotone,
         },
       ],
     },
@@ -185,20 +191,7 @@ export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
           href="/"
           className="flex items-center gap-1 p-0.5 rounded  data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground"
         >
-          <div className="relative flex aspect-square mb-1 size-8 rounded-xl items-center justify-center">
-            <Image
-              src="/uprevit-logo-black.svg"
-              alt="Uprevit logo"
-              fill
-              className="object-contain dark:hidden p-0.5"
-            />
-            <Image
-              src="/uprevit-logo-white.svg"
-              alt="Uprevit logo"
-              fill
-              className="hidden object-contain dark:block p-0.5"
-            />
-          </div>
+          <UprevitLogo className="mb-1 rounded-xl" />
           <div className="grid flex-1 text-left text-sm leading-tight">
             <div className="flex items-center gap-2">
               <span className="truncate text-lg text-foreground font-black ">

--- a/apps/app/components/common/UprevitLogo.tsx
+++ b/apps/app/components/common/UprevitLogo.tsx
@@ -1,0 +1,30 @@
+import Image from "next/image";
+import { cn } from "@uprevit/ui/lib/utils";
+
+type UprevitLogoProps = {
+  className?: string;
+};
+
+export function UprevitLogo({ className }: UprevitLogoProps) {
+  return (
+    <div
+      className={cn(
+        "relative flex aspect-square size-8 shrink-0 items-center justify-center",
+        className,
+      )}
+    >
+      <Image
+        src="/uprevit-logo-black.svg"
+        alt="Uprevit logo"
+        fill
+        className="object-contain p-0.5 dark:hidden"
+      />
+      <Image
+        src="/uprevit-logo-white.svg"
+        alt="Uprevit logo"
+        fill
+        className="hidden object-contain p-0.5 dark:block"
+      />
+    </div>
+  );
+}

--- a/apps/app/components/docs/DocsSearchDialog.tsx
+++ b/apps/app/components/docs/DocsSearchDialog.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { useDocsSearch } from "fumadocs-core/search/client";
+import {
+  SearchDialog,
+  SearchDialogClose,
+  SearchDialogContent,
+  SearchDialogFooter,
+  SearchDialogHeader,
+  SearchDialogIcon,
+  SearchDialogInput,
+  SearchDialogList,
+  SearchDialogOverlay,
+} from "fumadocs-ui/components/dialog/search";
+import type { ComponentProps } from "react";
+import { useAuth } from "react-oidc-context";
+
+type DocsSearchDialogProps = Omit<
+  ComponentProps<typeof SearchDialog>,
+  "search" | "onSearchChange" | "isLoading" | "children"
+>;
+
+export function DocsSearchDialog(props: DocsSearchDialogProps) {
+  const auth = useAuth();
+  const accessToken = auth.user?.access_token;
+
+  const { search, setSearch, query } = useDocsSearch(
+    {
+      client: {
+        deps: [accessToken],
+        async search(searchQuery) {
+          const url = new URL("/api/search", window.location.origin);
+          url.searchParams.set("query", searchQuery);
+
+          const headers: HeadersInit = {};
+          if (accessToken) {
+            headers.Authorization = `Bearer ${accessToken}`;
+          }
+
+          const response = await fetch(url, { headers });
+          if (!response.ok) {
+            throw new Error(await response.text());
+          }
+
+          return response.json();
+        },
+      },
+      delayMs: 100,
+    },
+    [accessToken],
+  );
+
+  return (
+    <SearchDialog
+      {...props}
+      search={search}
+      onSearchChange={setSearch}
+      isLoading={query.isLoading}
+    >
+      <SearchDialogOverlay />
+      <SearchDialogContent>
+        <SearchDialogHeader>
+          <SearchDialogIcon />
+          <SearchDialogInput />
+          <SearchDialogClose />
+        </SearchDialogHeader>
+        <SearchDialogList
+          items={query.data !== "empty" ? query.data : null}
+        />
+      </SearchDialogContent>
+      <SearchDialogFooter />
+    </SearchDialog>
+  );
+}

--- a/apps/app/components/docs/DocsVideo.tsx
+++ b/apps/app/components/docs/DocsVideo.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import { useDocumentationVideoUrl } from "@/hooks/docs/useDocumentationVideoUrl";
+import {
+  VideoPlayer,
+  VideoPlayerContent,
+  VideoPlayerControlBar,
+  VideoPlayerMuteButton,
+  VideoPlayerPlayButton,
+  VideoPlayerSeekBackwardButton,
+  VideoPlayerSeekForwardButton,
+  VideoPlayerTimeDisplay,
+  VideoPlayerTimeRange,
+  VideoPlayerVolumeRange,
+} from "@uprevit/ui/components/kibo-ui/video-player";
+import { cn } from "@uprevit/ui/lib/utils";
+
+type DocsVideoProps = {
+  videoKey: string;
+  title?: string;
+  caption?: string;
+  className?: string;
+};
+
+export function DocsVideo({
+  videoKey,
+  title,
+  caption,
+  className,
+}: DocsVideoProps) {
+  const { data, isLoading, isError, error, isFetching } =
+    useDocumentationVideoUrl(videoKey);
+
+  if (isLoading || (isFetching && !data?.url)) {
+    return (
+      <div
+        className={cn(
+          "my-6 aspect-video w-full animate-pulse rounded-lg bg-muted",
+          className,
+        )}
+        aria-busy="true"
+        aria-label={title ? `Loading video: ${title}` : "Loading video"}
+      />
+    );
+  }
+
+  if (isError || !data?.url) {
+    return (
+      <p className="my-6 rounded-lg border border-destructive/30 bg-destructive/5 px-4 py-3 text-sm text-destructive">
+        {error instanceof Error
+          ? error.message
+          : "This video could not be loaded."}
+      </p>
+    );
+  }
+
+  return (
+    <figure className={cn("my-6", className)}>
+      <VideoPlayer
+        key={data.url}
+        className="aspect-video w-full overflow-hidden rounded-2xl outline-1 outline-border outline-offset-0"
+      >
+        <VideoPlayerContent
+          slot="media"
+          src={data.url}
+          playsInline
+          preload="metadata"
+          title={title}
+          aria-label={title}
+          className="size-full object-contain"
+        />
+        <VideoPlayerControlBar>
+          <VideoPlayerPlayButton />
+          <VideoPlayerSeekBackwardButton />
+          <VideoPlayerSeekForwardButton />
+          <VideoPlayerTimeRange />
+          <VideoPlayerTimeDisplay showDuration />
+          <VideoPlayerMuteButton />
+          <VideoPlayerVolumeRange />
+        </VideoPlayerControlBar>
+      </VideoPlayer>
+      {caption ? (
+        <figcaption className="mt-2 text-center text-sm text-muted-foreground">
+          {caption}
+        </figcaption>
+      ) : null}
+    </figure>
+  );
+}

--- a/apps/app/components/docs/DocsVideo.tsx
+++ b/apps/app/components/docs/DocsVideo.tsx
@@ -14,9 +14,10 @@ import {
   VideoPlayerVolumeRange,
 } from "@uprevit/ui/components/kibo-ui/video-player";
 import { cn } from "@uprevit/ui/lib/utils";
+import type { DocumentationVideoKey } from "@/types/documentation-video";
 
 type DocsVideoProps = {
-  videoKey: string;
+  videoKey: DocumentationVideoKey;
   title?: string;
   caption?: string;
   className?: string;

--- a/apps/app/components/layout.client.tsx
+++ b/apps/app/components/layout.client.tsx
@@ -1,0 +1,8 @@
+"use client";
+
+import type { FC } from "react";
+import type { Separator } from "fumadocs-core/page-tree";
+
+export const SectionSpacer: FC<{ item: Separator }> = () => {
+  return <div className="my-1" aria-hidden="true" />;
+};

--- a/apps/app/components/mdx.tsx
+++ b/apps/app/components/mdx.tsx
@@ -1,0 +1,15 @@
+import defaultMdxComponents from "fumadocs-ui/mdx";
+import type { MDXComponents } from "mdx/types";
+
+export function getMDXComponents(components?: MDXComponents) {
+  return {
+    ...defaultMdxComponents,
+    ...components,
+  } satisfies MDXComponents;
+}
+
+export const useMDXComponents = getMDXComponents;
+
+declare global {
+  type MDXProvidedComponents = ReturnType<typeof getMDXComponents>;
+}

--- a/apps/app/components/mdx.tsx
+++ b/apps/app/components/mdx.tsx
@@ -1,9 +1,11 @@
 import defaultMdxComponents from "fumadocs-ui/mdx";
 import type { MDXComponents } from "mdx/types";
+import { DocsVideo } from "@/components/docs/DocsVideo";
 
 export function getMDXComponents(components?: MDXComponents) {
   return {
     ...defaultMdxComponents,
+    DocsVideo,
     ...components,
   } satisfies MDXComponents;
 }

--- a/apps/app/content/docs/getting-started/departments.mdx
+++ b/apps/app/content/docs/getting-started/departments.mdx
@@ -5,6 +5,8 @@ description: Create and manage departments, assign members, and link projects.
 
 **Departments** group work inside your workspace—for example by function, site, or product line. Every **project** belongs to exactly one department, and products inherit that structure through their project assignment.
 
+<DocsVideo videoKey="department.departments-tab" title="Departments tab walkthrough" />
+
 ## Viewing departments
 
 - **List:** `/departments` — cards with name, description, manager, and member count.

--- a/apps/app/content/docs/getting-started/departments.mdx
+++ b/apps/app/content/docs/getting-started/departments.mdx
@@ -1,0 +1,88 @@
+---
+title: Departments
+description: Create and manage departments, assign members, and link projects.
+---
+
+**Departments** group work inside your workspace—for example by function, site, or product line. Every **project** belongs to exactly one department, and products inherit that structure through their project assignment.
+
+## Viewing departments
+
+- **List:** `/departments` — cards with name, description, manager, and member count.
+- **Detail:** `/departments/{departmentId}` — full profile, member list, audit metadata, and a table of projects in this department.
+
+Anyone signed in can browse departments and open detail pages. **Share** copies a direct link to the department page.
+
+## Creating a department
+
+<Callout type="warn" title="Admin only">
+Creating a department requires **Admin** privileges.
+</Callout>
+
+1. Open **Departments** and click **Create Department**.
+2. Fill in the form:
+
+| Field | Required | Notes |
+|-------|----------|-------|
+| **Department name** | Yes | Display name. |
+| **Description** | Yes | Max **220** characters. |
+| **Manager** | No | Free-text manager name. |
+| **Image** | No | Optional department image (uploaded to storage). |
+| **Members** | No | Search and add workspace users from the user picker. |
+
+3. Submit. The new department appears on the list and is available when creating projects and products.
+
+## Updating a department
+
+<Callout type="warn" title="Admin only">
+Updating a department or changing its member list requires **Admin** privileges.
+</Callout>
+
+On the department detail page:
+
+1. Click **Update**.
+2. Change name, description, manager, image, or members (same rules as create).
+3. Save.
+
+The detail page shows **Created** and **Updated** audit badges when available.
+
+## Assigning members
+
+Admins add or remove users through **Add users** on create/update dialogs. All members can view the member list on the detail page via the members control, but only admins can change assignments.
+
+## Projects in a department
+
+The department detail page lists all projects scoped to that department. Use filters and sorting on the table, then open a project to manage products there.
+
+## Archiving a department
+
+<Callout type="warn" title="Admin only">
+Archiving a department requires **Admin** privileges.
+</Callout>
+
+1. On the department detail page, choose **Archive**.
+2. Type the **exact department name** to confirm.
+3. The department moves to **Archive → Departments** (`/archive`).
+
+Archived departments are hidden from normal lists but remain recoverable.
+
+## Restoring a department
+
+<Callout type="warn" title="Admin only">
+Restoring an archived department requires **Admin** privileges.
+</Callout>
+
+1. Go to **Archive** (`/archive`) → **Departments** tab.
+2. Find the department and click **Restore**.
+3. Confirm in the dialog.
+
+The department returns to active use with its projects and associations intact.
+
+## Activity logs
+
+On the department detail page, admins can open the **Logs** tab (`?tab=logs`) for audit history. Non-admins see the overview without the logs tab.
+
+## Related topics
+
+- [Projects](/docs/getting-started/projects) — created under a department.
+- [Products](/docs/getting-started/products) — linked via department when created.
+- [Archives](/docs/review-outputs/archives) — restore and browse archived departments.

--- a/apps/app/content/docs/getting-started/meta.json
+++ b/apps/app/content/docs/getting-started/meta.json
@@ -1,0 +1,4 @@
+{
+  "title": "Getting Started",
+  "pages": ["workspace", "departments", "projects", "products"]
+}

--- a/apps/app/content/docs/getting-started/products.mdx
+++ b/apps/app/content/docs/getting-started/products.mdx
@@ -1,0 +1,107 @@
+---
+title: Products
+description: Create products, track status and versions, and open the seven documentation tabs.
+---
+
+A **product** in Uprevit is a labeling documentation record: metadata, seven structured tabs, versions, and outputs (PDF, Excel, reports). Products always belong to a **department** and **project** in your workspace hierarchy.
+
+## Product list
+
+Open **Products** (`/products`) to see all products you can access. The table includes:
+
+| Column | Meaning |
+|--------|---------|
+| **Product name** | Display name. |
+| **PPN** | Product Plan Number (unique identifier). |
+| **Project / Department** | Structural placement. |
+| **Status** | `Draft`, `Submitted`, or `Archived`. |
+| **Version** | Numeric version (e.g. v1, v2). |
+| **Progress** | Tab completion percentage (0–7 tabs). |
+
+Click a row to open **Product Information** for that product. Use the row menu for shortcuts without navigating away.
+
+## Creating a product
+
+Any signed-in workspace member can create a product.
+
+1. Click **Create New Product**.
+2. Complete the form:
+
+| Field | Required | Notes |
+|-------|----------|-------|
+| **Product name** | Yes | |
+| **PPN (Product Plan Number)** | Yes | Minimum **10** characters; must start with a letter or digit; use alphanumeric characters for the full identifier. |
+| **Description** | Yes | Non-empty; max **220** characters. |
+| **Department** | Yes | Searchable selector. |
+| **Project** | Yes | Enabled after department is chosen; lists projects in that department only. |
+| **Version** | Fixed | New products start at version **1** (displayed as 1.0). |
+| **Status** | Fixed | New products start as **Draft**. |
+
+3. Submit. Uprevit opens the product documentation workflow starting at **Product Information**.
+
+## Editing basic product fields
+
+From the products table menu, **Edit** updates **product name** and **description** only. PPN, department, project, version, and status are not changed from this dialog.
+
+For full metadata (markets, UDI-DI, custom fields, etc.), use the **Product Information** tab.
+
+## Product documentation tabs
+
+After opening a product, the sidebar shows seven tabs:
+
+1. [Product Information](/docs/product-documentation/product-information)
+2. [Compliance Information](/docs/product-documentation/compliance-information)
+3. [Label Components](/docs/product-documentation/label-components)
+4. [Symbols & Graphics](/docs/product-documentation/symbols-graphics)
+5. [Product Specifications](/docs/product-documentation/product-specifications)
+6. [Operational Parameters](/docs/product-documentation/operational-parameters)
+7. [Label Tags](/docs/product-documentation/label-tags)
+
+Mark each tab **complete** from the product header when finished. Progress reaches **100%** when all seven tabs are complete—required before **Submit**.
+
+## Status and versions
+
+| Status | Meaning |
+|--------|---------|
+| **Draft** | Editable; default for new products and new versions. |
+| **Submitted** | Locked snapshot; editing disabled on all tabs. |
+| **Archived** | Removed from active work; listed under Archive. |
+
+**Submit** (product header) is available at 100% tab completion and locks the current version. To continue work, create a **New version** from the products table when status is **Submitted**—see [Redlines and Versions](/docs/review-outputs/redlines-versions).
+
+## Row actions
+
+| Action | Who can use | Notes |
+|--------|-------------|-------|
+| Edit name/description | All users | |
+| New version | All users | Only when status is **Submitted**. |
+| Share | All users | Copies product URL. |
+| Bookmark | All users | Adds to bookmark folders; see [Bookmarks](/docs/source-files-bookmarks/bookmarks). |
+| Export PDF | All users | Queues async job; see [Exports](/docs/review-outputs/exports). |
+| Archive | **Admin only** | Moves product to archived status. |
+
+<Callout type="warn" title="Admin only">
+**Archive** on the products table sets status to **archived** and is restricted to admins.
+</Callout>
+
+## Archiving and restoring products
+
+Admins archive products from the table menu. Restore archived products from **Archive → Products** (`/archive`). Restored products return to **Draft** status.
+
+## Product header tools
+
+On any product tab, the header provides:
+
+- **Version** switcher — jump between versions of the same product lineage.
+- **Compare versions** — redline view; documented in [Redlines and Versions](/docs/review-outputs/redlines-versions).
+- **Tab completion** toggle — mark current tab complete or incomplete.
+- **Submit** — lock version when all tabs are complete.
+- **Export PDF** — queue a PDF export job.
+
+While a PDF export is in progress, editing and submit may be temporarily locked.
+
+## Related topics
+
+- Product tabs — **Product Documentation** section in this guide.
+- [Source Files](/docs/source-files-bookmarks/source-files) — link folders from Product Information.
+- [Redlines and Versions](/docs/review-outputs/redlines-versions) — submit and compare workflow.

--- a/apps/app/content/docs/getting-started/products.mdx
+++ b/apps/app/content/docs/getting-started/products.mdx
@@ -5,6 +5,8 @@ description: Create products, track status and versions, and open the seven docu
 
 A **product** in Uprevit is a labeling documentation record: metadata, seven structured tabs, versions, and outputs (PDF, Excel, reports). Products always belong to a **department** and **project** in your workspace hierarchy.
 
+<DocsVideo videoKey="product.products-intro" title="Products tab introduction" />
+
 ## Product list
 
 Open **Products** (`/products`) to see all products you can access. The table includes:

--- a/apps/app/content/docs/getting-started/projects.mdx
+++ b/apps/app/content/docs/getting-started/projects.mdx
@@ -5,6 +5,8 @@ description: Create projects under departments, assign members, and manage produ
 
 **Projects** sit between departments and products. Each project belongs to one **department** and holds the products your team documents for a specific initiative, SKU family, or submission.
 
+<DocsVideo videoKey="projects.projects-tab" title="Projects tab walkthrough" />
+
 ## Viewing projects
 
 - **List:** `/projects` — searchable cards across the workspace.

--- a/apps/app/content/docs/getting-started/projects.mdx
+++ b/apps/app/content/docs/getting-started/projects.mdx
@@ -1,0 +1,87 @@
+---
+title: Projects
+description: Create projects under departments, assign members, and manage products.
+---
+
+**Projects** sit between departments and products. Each project belongs to one **department** and holds the products your team documents for a specific initiative, SKU family, or submission.
+
+## Viewing projects
+
+- **List:** `/projects` — searchable cards across the workspace.
+- **Detail:** `/projects/{projectId}` — project profile, members, and a filterable **products** table for that project only.
+
+All signed-in users can view and share project links. Row actions on the products table link into product documentation.
+
+## Creating a project
+
+<Callout type="warn" title="Admin only">
+Creating a project requires **Admin** privileges.
+</Callout>
+
+1. Open **Projects** and click **Create Project** (or use the control on the list page).
+2. Fill in the form:
+
+| Field | Required | Notes |
+|-------|----------|-------|
+| **Project name** | Yes | Display name. |
+| **Project number** | Yes | Internal or regulatory reference number. |
+| **Description** | Yes | Max **220** characters. |
+| **Department** | Yes | Searchable list; projects are always scoped to one department. |
+| **Project manager** | No | Free-text name. |
+| **Image** | No | Optional project image. |
+| **Members** | No | Workspace users assigned to the project. |
+
+3. Submit. The project appears under its department and in the global projects list.
+
+## Updating a project
+
+<Callout type="warn" title="Admin only">
+Updating a project or changing members requires **Admin** privileges.
+</Callout>
+
+On the project detail page:
+
+1. Click **Update**.
+2. Edit fields (department can be changed via searchable selector on update).
+3. Save.
+
+## Assigning members
+
+Same pattern as departments: admins manage members on create/update; everyone can view the member list on the detail page.
+
+## Products on a project
+
+The project detail page shows all products where `project_id` matches this project. Use list controls to filter and sort, then open a product row to enter the seven documentation tabs.
+
+When **creating a product**, you must pick a department first; the **project** dropdown then lists only projects in that department.
+
+## Archiving a project
+
+<Callout type="warn" title="Admin only">
+Archiving a project requires **Admin** privileges.
+</Callout>
+
+1. On the project detail page, choose **Archive**.
+2. Type the **exact project name** to confirm.
+3. The project moves to **Archive → Projects**.
+
+Products already tied to the project remain in the database; archive behavior for products is separate (see [Archives](/docs/review-outputs/archives)).
+
+## Restoring a project
+
+<Callout type="warn" title="Admin only">
+Restoring an archived project requires **Admin** privileges.
+</Callout>
+
+1. Go to **Archive** → **Projects** tab.
+2. Click **Restore** on the row and confirm.
+
+## Activity logs
+
+Admins can view the **Logs** tab on the project detail page for audit entries.
+
+## Related topics
+
+- [Departments](/docs/getting-started/departments) — parent grouping.
+- [Products](/docs/getting-started/products) — created within a project.
+- [Archives](/docs/review-outputs/archives) — archived project recovery.

--- a/apps/app/content/docs/getting-started/workspace.mdx
+++ b/apps/app/content/docs/getting-started/workspace.mdx
@@ -1,0 +1,79 @@
+---
+title: Workspace
+description: Your organization container—departments, projects, products, and workspace settings.
+---
+
+A **workspace** is the top-level container for everything in Uprevit. One workspace represents your company or organization. All departments, projects, products, users, and source files belong to a single workspace.
+
+## What lives in a workspace
+
+| Concept | Purpose |
+|---------|---------|
+| **Departments** | Organizational groupings (e.g. Regulatory, Packaging). |
+| **Projects** | Work streams within a department. |
+| **Products** | Labeling documentation records tied to a department and project. |
+| **Users** | Members invited to collaborate in the workspace. |
+| **Source files** | Shared folder tree for reference documents. |
+
+The **Dashboard** (`/dashboard`) summarizes activity: department and project cards, plus a table of recent products.
+
+## Workspace information
+
+Open **Settings** (`/settings`) and select the **Workspace** tab to view:
+
+| Field | Description |
+|-------|-------------|
+| **Workspace name** | Display name for your organization in Uprevit. |
+| **Company name** | Legal or commercial company name. |
+| **Description** | Short summary of the workspace. |
+| **Workspace ID** | System identifier (copyable from the tab). |
+| **Logo** | Optional branding image (PNG, JPG, JPEG, GIF, or WebP). |
+| **User count** | Number of members in the workspace. |
+
+Billing and plan fields may appear as placeholders depending on your deployment; plan management is not covered in this guide.
+
+## Updating workspace details
+
+<Callout type="warn" title="Admin only">
+Only **Admin** users can edit workspace details. Non-admins can view the Workspace tab but receive an insufficient-privileges message if they try to open the edit dialog.
+</Callout>
+
+1. Go to **Settings → Workspace**.
+2. Click **Edit Workspace**.
+3. Update **Workspace name**, **Company name**, or **Description** (all required).
+4. Optionally upload or replace the **logo** (uploaded to secure storage).
+5. Save changes.
+
+Workspace creation happens during **admin onboarding** (first-time setup) with the same core fields plus admin contact details.
+
+## Members and admins
+
+From **Settings** you can also:
+
+- **Profile** — Any user can update their own profile.
+- **Users** — View workspace members.
+- **Admins** — View users with admin privileges.
+
+<Callout type="warn" title="Admin only">
+**Invite members** (name and email rows) is restricted to admins. Invited users receive access to the workspace according to your identity provider configuration.
+</Callout>
+
+Admins are determined by membership in the `admin` group on your sign-in token. If you need admin access, contact an existing workspace administrator.
+
+## Navigation
+
+The **Workspace** section of the sidebar includes:
+
+- **Dashboard** — Overview and recent products.
+- **Departments** — List and detail pages.
+- **Projects** — List and detail pages.
+- **Products** — Product list and entry into documentation tabs.
+
+## Typical setup flow (admins)
+
+1. Create or complete the workspace during onboarding.
+2. Invite team members from Settings.
+3. Create **departments**, then **projects** under each department.
+4. Team members create **products** under the appropriate project.
+
+See [Departments](/docs/getting-started/departments), [Projects](/docs/getting-started/projects), and [Products](/docs/getting-started/products) for the next steps.

--- a/apps/app/content/docs/index.mdx
+++ b/apps/app/content/docs/index.mdx
@@ -1,0 +1,133 @@
+---
+title: Introduction
+description: Learn how to organize your workspace, document medical device labeling products, and produce reviewed outputs.
+---
+
+import {
+  PiArchiveDuotone,
+  PiBookmarkSimpleDuotone,
+  PiBuildingsDuotone,
+  PiExportDuotone,
+  PiFolderOpenDuotone,
+  PiGitBranchDuotone,
+  PiHouseDuotone,
+  PiKanbanDuotone,
+  PiLayoutDuotone,
+  PiPackageDuotone,
+  PiPresentationChartDuotone,
+} from "react-icons/pi";
+
+Uprevit helps teams document medical device labeling in one place—from workspace setup through reviewed outputs.
+
+## How it fits together
+
+```text
+Workspace → Departments → Projects → Products → 7 documentation tabs
+```
+
+Each **product** is where labeling work lives: seven tabs for structured data, plus source files, bookmarks, version review, and exports.
+
+## Documentation topics
+
+Each card below opens a guide for that part of Uprevit. Jump to whatever you need—you do not have to read them in sequence. The order follows the same flow as above: set up **workspace → departments → projects → products**, then product tabs, files, review, and outputs when they become relevant to your work.
+
+<Cards>
+  <Card
+    title="Workspace"
+    href="/docs/getting-started/workspace"
+    description="Your organization container, settings, and who can manage them."
+    icon={<PiHouseDuotone />}
+  />
+  <Card
+    title="Departments"
+    href="/docs/getting-started/departments"
+    description="Group teams and projects; admins create and maintain departments."
+    icon={<PiBuildingsDuotone />}
+  />
+  <Card
+    title="Projects"
+    href="/docs/getting-started/projects"
+    description="Work streams under a department; where products are filed."
+    icon={<PiKanbanDuotone />}
+  />
+  <Card
+    title="Products"
+    href="/docs/getting-started/products"
+    description="Create products, track status and versions, open documentation tabs."
+    icon={<PiPackageDuotone />}
+  />
+  <Card
+    title="Product documentation"
+    href="/docs/product-documentation/product-information"
+    description="Complete all seven tabs and mark each one complete before submit."
+    icon={<PiLayoutDuotone />}
+  />
+  <Card
+    title="Redlines and versions"
+    href="/docs/review-outputs/redlines-versions"
+    description="Submit a version, compare changes, and start a new draft when needed."
+    icon={<PiGitBranchDuotone />}
+  />
+  <Card
+    title="Source files"
+    href="/docs/source-files-bookmarks/source-files"
+    description="Store and browse reference folders linked to products."
+    icon={<PiFolderOpenDuotone />}
+  />
+  <Card
+    title="Bookmarks"
+    href="/docs/source-files-bookmarks/bookmarks"
+    description="Personal folders of products for quick access."
+    icon={<PiBookmarkSimpleDuotone />}
+  />
+  <Card
+    title="Reports"
+    href="/docs/review-outputs/reports"
+    description="Query products across tabs and export result sets."
+    icon={<PiPresentationChartDuotone />}
+  />
+  <Card
+    title="Exports"
+    href="/docs/review-outputs/exports"
+    description="Download PDFs, Excel jobs, and specification workbooks."
+    icon={<PiExportDuotone />}
+  />
+  <Card
+    title="Archives"
+    href="/docs/review-outputs/archives"
+    description="Archive and restore departments, projects, and products."
+    icon={<PiArchiveDuotone />}
+  />
+</Cards>
+
+## Roles
+
+Everyone in a workspace signs in with one of two roles. Your organization assigns which role you have.
+
+<Cards>
+  <Card
+    title="Member"
+    description="The default role for people doing labeling work day to day."
+  >
+
+    - Browse departments, projects, and products
+    - Create products and complete all seven documentation tabs
+    - Submit versions, compare redlines, and export outputs
+    - Use source files, bookmarks, and reports
+
+  </Card>
+  <Card
+    title="Admin"
+    description="Additional control over workspace structure and lifecycle."
+  >
+
+    - Everything a member can do
+    - Edit workspace details and invite people
+    - Create, update, archive, and restore departments and projects
+    - Archive products and view archive activity logs
+    - Assign members to departments and projects
+
+  </Card>
+</Cards>
+
+If an action is restricted, please contact your organization's workspace admin.

--- a/apps/app/content/docs/index.mdx
+++ b/apps/app/content/docs/index.mdx
@@ -19,6 +19,8 @@ import {
 
 Uprevit helps teams document medical device labeling in one place—from workspace setup through reviewed outputs.
 
+<DocsVideo videoKey="getting-started.welcome-dashboard" title="Welcome dashboard overview" />
+
 ## How it fits together
 
 ```text

--- a/apps/app/content/docs/meta.json
+++ b/apps/app/content/docs/meta.json
@@ -1,0 +1,4 @@
+{
+  "title": "Uprevit Documentation",
+  "pages": ["index"]
+}

--- a/apps/app/content/docs/product-documentation/compliance-information.mdx
+++ b/apps/app/content/docs/product-documentation/compliance-information.mdx
@@ -5,6 +5,8 @@ description: Regulatory standards and packaging or labeling languages.
 
 The **Compliance Information** tab (`/products/{productId}/compliance-information`) documents regulatory standards and the languages used on packaging or labeling for this product version.
 
+<DocsVideo videoKey="product.compliance-tab" title="Compliance Information tab walkthrough" />
+
 ## Sections
 
 ### Compliance standards

--- a/apps/app/content/docs/product-documentation/compliance-information.mdx
+++ b/apps/app/content/docs/product-documentation/compliance-information.mdx
@@ -1,0 +1,54 @@
+---
+title: Compliance Information
+description: Regulatory standards and packaging or labeling languages.
+---
+
+The **Compliance Information** tab (`/products/{productId}/compliance-information`) documents regulatory standards and the languages used on packaging or labeling for this product version.
+
+## Sections
+
+### Compliance standards
+
+Each standard is a card with:
+
+| Field | Required | Notes |
+|-------|----------|-------|
+| **Standard / Regulation** | Yes | Pick from the preset library (`COMPLIANCE_STANDARDS`) or enter a custom standard name. |
+| **Standard description** | Auto or manual | Filled automatically for presets; enter manually for custom standards. |
+
+**Actions:** Add, edit, or delete standards while the product is in **Draft**.
+
+### Languages
+
+Manage the set of languages for labeling:
+
+| Field | Notes |
+|-------|-------|
+| **Language code, name, country** | Selected in bulk via **Manage Languages**; supports presets and individual picks. |
+
+One dialog updates the full language list for the product.
+
+## Editing workflow
+
+1. Open **Compliance Information** from the product sidebar.
+2. Under **Compliance Standards**, click **Add Standard** or use row actions on existing cards.
+3. Under **Languages**, open **Manage Languages**, select languages, and save.
+4. Mark the tab complete in the header when finished.
+
+Submitted products cannot add, edit, or delete standards or languages until a new draft version exists.
+
+## Tab completion
+
+Use the header toggle to mark **Compliance Information** complete (`update_compliance_tab_completion`).
+
+## Version comparison (redline)
+
+In compare mode, standards and languages show per-item **NEW**, **DEL**, and **MOD** badges with inline old/new values.
+
+See **[Redlines and Versions](/docs/review-outputs/redlines-versions)** for how to enable and read redline views across tabs.
+
+## Related topics
+
+- [Product Information](/docs/product-documentation/product-information) — core metadata.
+- [Label Components](/docs/product-documentation/label-components) — physical label parts.
+- [Reports](/docs/review-outputs/reports) — query compliance fields across products.

--- a/apps/app/content/docs/product-documentation/label-components.mdx
+++ b/apps/app/content/docs/product-documentation/label-components.mdx
@@ -1,0 +1,44 @@
+---
+title: Label Components
+description: Physical label components with images, dimensions, and types.
+---
+
+**Label Components** (`/products/{productId}/label-components`) catalogs each physical labeling element—labels, tags, stickers, packaging panels, and similar items—with optional images and structured attributes.
+
+## Component fields
+
+| Field | Required | Notes |
+|-------|----------|-------|
+| **Component number** | Yes | Unique identifier within the product. |
+| **Component type** | Yes | Preprinted, Blank, or N/A. |
+| **Description** | No | |
+| **Dimensions** | No | Free text (e.g. size notation). |
+| **Label type** | No | Multiple tags (e.g. primary, secondary). |
+| **Image** | No | Uploaded to product asset storage; stored as a file key. |
+
+## Adding and editing
+
+1. Click **Add Label Component**.
+2. Fill required fields and optionally upload an image.
+3. Submit—the table lists all components with expandable rows.
+4. Use row actions to **Edit** or **Delete**.
+
+Sort columns by image, number, description, label types, dimensions, or type.
+
+Draft products allow full CRUD. **Submitted** products disable add, edit, and delete.
+
+## Tab completion
+
+Mark **Label Components** complete from the product header when all components for this version are documented.
+
+## Version comparison (redline)
+
+Compare mode highlights changed cells in the table and shows OLD/NEW image pairs. Removed components stay visible with deletion styling; actions on removed rows are disabled.
+
+Full steps for compare mode: **[Redlines and Versions](/docs/review-outputs/redlines-versions)**.
+
+## Related topics
+
+- [Symbols & Graphics](/docs/product-documentation/symbols-graphics) — symbols and schematics separate from physical components.
+- [Label Tags](/docs/product-documentation/label-tags) — annotated label artwork.
+- [Exports](/docs/review-outputs/exports) — PDF includes label component data.

--- a/apps/app/content/docs/product-documentation/label-components.mdx
+++ b/apps/app/content/docs/product-documentation/label-components.mdx
@@ -5,6 +5,8 @@ description: Physical label components with images, dimensions, and types.
 
 **Label Components** (`/products/{productId}/label-components`) catalogs each physical labeling element—labels, tags, stickers, packaging panels, and similar items—with optional images and structured attributes.
 
+<DocsVideo videoKey="product.label-components" title="Label Components tab walkthrough" />
+
 ## Component fields
 
 | Field | Required | Notes |

--- a/apps/app/content/docs/product-documentation/label-tags.mdx
+++ b/apps/app/content/docs/product-documentation/label-tags.mdx
@@ -5,6 +5,8 @@ description: Label images by type with annotations, legends, and tagged exports.
 
 **Label Tags** (`/products/{productId}/label-tags`) manages label artwork grouped by **type** (e.g. primary label, IFU panel). You can upload images, annotate them with callouts and shapes, define a legend, and save a flattened **tagged image** for documentation outputs.
 
+<DocsVideo videoKey="product.label-tags" title="Label Tags tab walkthrough" />
+
 ## Structure
 
 - **Type tabs** — One tab per distinct label type on this product.

--- a/apps/app/content/docs/product-documentation/label-tags.mdx
+++ b/apps/app/content/docs/product-documentation/label-tags.mdx
@@ -1,0 +1,53 @@
+---
+title: Label Tags
+description: Label images by type with annotations, legends, and tagged exports.
+---
+
+**Label Tags** (`/products/{productId}/label-tags`) manages label artwork grouped by **type** (e.g. primary label, IFU panel). You can upload images, annotate them with callouts and shapes, define a legend, and save a flattened **tagged image** for documentation outputs.
+
+## Structure
+
+- **Type tabs** — One tab per distinct label type on this product.
+- **Label entries** — Each has name, optional description, optional type override, base image, annotation state, legend items, and optional tagged PNG output.
+
+## Fields
+
+| Field | Required | Notes |
+|-------|----------|-------|
+| **Name** | Yes | |
+| **Type** | No | Drives top-level grouping tabs. |
+| **Description** | No | |
+| **Image** | No | Base label artwork (S3). |
+| **Legend items** | Optional | Color, shape, and text per legend entry; text required per item when defined. |
+| **Tagged image** | Via save flow | Rendered PNG after annotation, uploaded on confirm. |
+
+## Adding and editing labels
+
+1. Click **Add Label** and fill metadata; upload an image if needed.
+2. Select a **type** tab to work on that group’s artwork.
+3. Open the **annotation editor** on the image (marker.js tools: callouts, arrows, shapes, text).
+4. Define **Legend** entries that explain annotations.
+5. **Save tagged image** — confirm dialog renders the annotated PNG, uploads it, and stores annotation state.
+
+### Unsaved annotation guard
+
+If annotations changed but are not saved, switching type tabs or leaving the page prompts you to save or discard.
+
+## Submitted products
+
+Add, edit, annotate, and delete are disabled when status is **Submitted**.
+
+## Tab completion
+
+Mark **Label Tags** complete in the header when all required label types are documented and tagged images are saved as needed.
+
+## Version comparison (redline)
+
+Compare mode groups changes by type and shows field diffs (name, description, type) plus OLD/NEW image blocks.
+
+Workflow details: **[Redlines and Versions](/docs/review-outputs/redlines-versions)**.
+
+## Related topics
+
+- [Label Components](/docs/product-documentation/label-components) — structured component list vs annotated artwork.
+- [Exports](/docs/review-outputs/exports) — PDF export includes label tag content.

--- a/apps/app/content/docs/product-documentation/meta.json
+++ b/apps/app/content/docs/product-documentation/meta.json
@@ -1,0 +1,12 @@
+{
+  "title": "Product Documentation",
+  "pages": [
+    "product-information",
+    "compliance-information",
+    "label-components",
+    "symbols-graphics",
+    "product-specifications",
+    "operational-parameters",
+    "label-tags"
+  ]
+}

--- a/apps/app/content/docs/product-documentation/operational-parameters.mdx
+++ b/apps/app/content/docs/product-documentation/operational-parameters.mdx
@@ -1,0 +1,38 @@
+---
+title: Operational Parameters
+description: Spreadsheet workbook for operational and environmental parameters.
+---
+
+**Operational Parameters** (`/products/{productId}/operational-parameters`) uses the same spreadsheet interface as [Product Specifications](/docs/product-documentation/product-specifications), but stores a **separate workbook** for operational, environmental, or process parameters distinct from the main specification table.
+
+## Workbook structure
+
+Identical model to Product Specifications:
+
+- User-defined **headers**
+- **Column types** (`constant`, `variable`, `na`)
+- **Cell** grid with optional formats, order, and widths
+
+## Editing and saving
+
+- Inline cell editing, add/remove rows and columns, find & replace, undo/redo.
+- **Save** persists to the `operational-parameters` tab (`add_operational_parameters`).
+- **Auto-save** uses a separate browser preference key per product (`operational-parameters-auto-save-{productId}`).
+
+Submitted products lock the grid to read-only.
+
+## Tab completion
+
+Mark **Operational Parameters** complete from the product header when finished.
+
+## Version comparison (redline)
+
+Compare mode diffs `operational_parameters` workbook data with the same **Highlight** and **Inline** display modes as Product Specifications.
+
+For how to start and end a comparison session, see **[Redlines and Versions](/docs/review-outputs/redlines-versions)**.
+
+## Related topics
+
+- [Product Specifications](/docs/product-documentation/product-specifications)
+- [Reports](/docs/review-outputs/reports) — query operational parameter fields when configured in report categories
+- [Exports](/docs/review-outputs/exports)

--- a/apps/app/content/docs/product-documentation/product-information.mdx
+++ b/apps/app/content/docs/product-documentation/product-information.mdx
@@ -1,0 +1,75 @@
+---
+title: Product Information
+description: Core product metadata, custom fields, dates, and linked source files.
+---
+
+**Product Information** is the first tab in the product documentation workflow (`/products/{productId}/product-information`). It holds identifying metadata, scheduling dates, regulatory geography, device classification, custom fields, and links to related **source file** folders.
+
+## Opening the tab
+
+From the product list, click a product row—or use the sidebar **Product Information** link when viewing any product.
+
+## Fields on the page
+
+### Standard fields (edit dialog)
+
+| Field | Required | Notes |
+|-------|----------|-------|
+| **Product name** | Yes | Also shown in the product header. |
+| **Description** | No | Longer narrative than the list description. |
+| **Target date** | No | Planned completion date. |
+| **Market / Geography** | Yes* | Choose from preset markets or enter a custom value. |
+| **Country of origin** | Yes* | Preset country or custom entry. |
+| **OEM / Contract manufacturer** | Yes | |
+| **Commercial / Clinical** | Yes | Commercial or Clinical use. |
+| **Manufacturing location** | No | |
+| **Class of device** | No | Preset device class groups or custom. |
+| **Basic UDI-DI** | No | Unique Device Identification (when applicable). |
+
+\*Required means you must provide either a preset selection or custom text.
+
+### Read-only on this tab
+
+- **Status** — Draft, Submitted, or Archived.
+- **Actual completion date** — Set automatically when you **Submit** the product version.
+- **Created / Modified** — Audit metadata.
+- **Linked source files** — Links to folders in **Source Files** tied to this product.
+
+### Custom fields
+
+Add organization-specific label/value pairs:
+
+| Field | Required |
+|-------|----------|
+| **Label** | Yes (when editing a custom field) |
+| **Value** | Yes |
+
+Use **Add custom field**, **Edit**, or **Delete** from the custom fields section.
+
+## Editing
+
+1. Click **Edit Product** for standard fields.
+2. Use the custom field actions for additional rows.
+3. Save—changes persist immediately to this product version.
+
+When status is **Submitted**, edit actions are disabled until you create a [new version](/docs/review-outputs/redlines-versions).
+
+## Tab completion
+
+Toggle **Mark tab complete** in the product header when Product Information is finished. This counts toward the seven-tab progress bar required for submit.
+
+## Activity logs
+
+Use **View logs** (or navigate to `/products/{productId}/logs`) for a detailed change history on this product.
+
+## Version comparison (redline)
+
+To see what changed in Product Information between versions, use **Compare Versions** in the product header. Field-level highlights and custom-field badges (NEW / DEL / MOD) appear on this tab.
+
+For the full comparison workflow, see **[Redlines and Versions](/docs/review-outputs/redlines-versions)**—that page is the canonical guide; this tab does not duplicate those steps.
+
+## Related topics
+
+- [Products](/docs/getting-started/products) — create and list products.
+- [Source Files](/docs/source-files-bookmarks/source-files) — folders linked from this tab.
+- [Redlines and Versions](/docs/review-outputs/redlines-versions) — submit and compare.

--- a/apps/app/content/docs/product-documentation/product-information.mdx
+++ b/apps/app/content/docs/product-documentation/product-information.mdx
@@ -5,6 +5,8 @@ description: Core product metadata, custom fields, dates, and linked source file
 
 **Product Information** is the first tab in the product documentation workflow (`/products/{productId}/product-information`). It holds identifying metadata, scheduling dates, regulatory geography, device classification, custom fields, and links to related **source file** folders.
 
+<DocsVideo videoKey="product.product-information" title="Product Information tab walkthrough" />
+
 ## Opening the tab
 
 From the product list, click a product row—or use the sidebar **Product Information** link when viewing any product.

--- a/apps/app/content/docs/product-documentation/product-specifications.mdx
+++ b/apps/app/content/docs/product-documentation/product-specifications.mdx
@@ -1,0 +1,68 @@
+---
+title: Product Specifications
+description: Spreadsheet-style specification data with save, filters, and export.
+---
+
+**Product Specifications** (`/products/{productId}/product-specifications`) is a workbook-style grid for structured specification data: column headers, column types (constant, variable, N/A), and cell values.
+
+## Workbook structure
+
+| Part | Description |
+|------|-------------|
+| **Headers** | Column names you define. |
+| **Column types** | Per column: `constant`, `variable`, or `na`. |
+| **Cells** | Values at row/column intersections. |
+| **Column order / widths / formats** | Layout and display preferences. |
+
+There is no per-cell required validation—the grid is free-form for your specification template.
+
+## Editing
+
+- Click cells to edit values inline.
+- Add or remove **rows** and **columns** from toolbar actions.
+- Use **Find & Replace** (Ctrl+R) for bulk text updates.
+- **Undo / Redo** for recent grid changes.
+
+### Saving
+
+- **Save** — writes the workbook to the server (`add_product_data` on the product-specifications tab).
+- **Auto-save** — optional per-product preference stored in the browser; when enabled, changes save automatically.
+
+A **beforeunload** warning appears if you leave with unsaved manual changes.
+
+### Submitted products
+
+When status is **Submitted**, the grid is **read-only**: no edits, save, or auto-save.
+
+## Toolbar extras
+
+- **Filters** — narrow visible rows.
+- **Page info** — keyboard shortcuts and grid help.
+- **Export** — download the current grid immediately as an Excel workbook (local export, not the async jobs queue).
+
+For workspace-wide PDF/Excel jobs, see [Exports](/docs/review-outputs/exports).
+
+## Tab completion
+
+Mark **Product Specifications** complete in the header when the workbook is finalized for this version.
+
+## Version comparison (redline)
+
+In compare mode the grid shows the **current** version’s data with differences against the selected older version:
+
+- **Highlight** mode — changed cells emphasized.
+- **Inline** mode — strikethrough old values with new values beside them.
+
+Header and column-type changes are diffed as well.
+
+This tab participates in redline display but does not define the workflow—see **[Redlines and Versions](/docs/review-outputs/redlines-versions)** for Compare Versions, clearing comparison, and switching tabs while comparing.
+
+## Legacy spec archive route
+
+A separate read-only route (`/products/{productId}/product-spec-archive`) exists for historical Univer-based viewers and side-by-side spreadsheet comparison. Day-to-day editing uses this **Product Specifications** tab.
+
+## Related topics
+
+- [Operational Parameters](/docs/product-documentation/operational-parameters) — same grid behavior, separate workbook.
+- [Redlines and Versions](/docs/review-outputs/redlines-versions)
+- [Exports](/docs/review-outputs/exports)

--- a/apps/app/content/docs/product-documentation/product-specifications.mdx
+++ b/apps/app/content/docs/product-documentation/product-specifications.mdx
@@ -5,6 +5,8 @@ description: Spreadsheet-style specification data with save, filters, and export
 
 **Product Specifications** (`/products/{productId}/product-specifications`) is a workbook-style grid for structured specification data: column headers, column types (constant, variable, N/A), and cell values.
 
+<DocsVideo videoKey="product.product-specifications" title="Product Specifications tab walkthrough" />
+
 ## Workbook structure
 
 | Part | Description |

--- a/apps/app/content/docs/product-documentation/symbols-graphics.mdx
+++ b/apps/app/content/docs/product-documentation/symbols-graphics.mdx
@@ -1,0 +1,78 @@
+---
+title: Symbols & Graphics
+description: Symbols, schematics, barcodes, and other graphical assets.
+---
+
+**Symbols & Graphics** (`/products/{productId}/symbols-graphics`) organizes graphical assets into four internal categories. Each item can include text, descriptions, label-presence tags, and optional images.
+
+## Sub-tabs
+
+| Sub-tab | Entity type | Typical content |
+|---------|-------------|-----------------|
+| **Symbols** | Symbols | Standard library symbols or custom symbol text |
+| **Schematics** | Schematics | Diagrams and schematic artwork |
+| **Barcodes** | Barcodes | Barcode data and counts |
+| **Other Components** | Other Components | Additional graphical elements |
+
+Switch sub-tabs at the top of the page; each has its own table and **Add** action.
+
+## Fields by type
+
+### Symbols
+
+| Field | Required |
+|-------|----------|
+| **Symbol text** | Yes |
+| **Text present** | Yes (yes/no) |
+| **Label presence** | No (tags) |
+| **Image** | No |
+| **Standard symbol** | No | When picked from the standard library |
+
+### Schematics
+
+| Field | Required |
+|-------|----------|
+| **Name** | Yes |
+| **Description** | No |
+| **Label presence** | No |
+| **Image** | No |
+
+### Barcodes
+
+| Field | Required |
+|-------|----------|
+| **Barcode data** | Yes |
+| **Count** | Yes |
+| **Description** | No |
+| **Label presence** | No |
+| **Image** | No |
+
+### Other components
+
+| Field | Required |
+|-------|----------|
+| **Component name** | Yes |
+| **Description** | No |
+| **Label presence** | No |
+| **Image** | No |
+
+Images upload to **product-assets** storage.
+
+## Editing
+
+Use the sub-tab **Add** button and row **Edit** / **Delete** actions. All changes are blocked when the product is **Submitted**.
+
+## Tab completion
+
+Mark **Symbols & Graphics** complete in the header after all required assets are entered.
+
+## Version comparison (redline)
+
+Redline groups changes across all entities, then filters into each sub-tab. Tables use highlighted cells; images show side-by-side OLD/NEW previews.
+
+See **[Redlines and Versions](/docs/review-outputs/redlines-versions)** for enabling compare mode and clearing it.
+
+## Related topics
+
+- [Label Components](/docs/product-documentation/label-components) — physical components vs graphical symbols.
+- [Label Tags](/docs/product-documentation/label-tags) — annotated label images.

--- a/apps/app/content/docs/product-documentation/symbols-graphics.mdx
+++ b/apps/app/content/docs/product-documentation/symbols-graphics.mdx
@@ -5,6 +5,8 @@ description: Symbols, schematics, barcodes, and other graphical assets.
 
 **Symbols & Graphics** (`/products/{productId}/symbols-graphics`) organizes graphical assets into four internal categories. Each item can include text, descriptions, label-presence tags, and optional images.
 
+<DocsVideo videoKey="product.symbols-graphics" title="Symbols and Graphics tab walkthrough" />
+
 ## Sub-tabs
 
 | Sub-tab | Entity type | Typical content |

--- a/apps/app/content/docs/review-outputs/archives.mdx
+++ b/apps/app/content/docs/review-outputs/archives.mdx
@@ -1,0 +1,83 @@
+---
+title: Archives
+description: Archive and restore departments, projects, and products.
+---
+
+The **Archive** page (`/archive`) is where you browse entities removed from active lists and restore them when appropriate. Archiving is different from **product version submit**—archive removes organizational units or marks products as archived status.
+
+## Archive tabs
+
+| Tab | What it lists |
+|-----|----------------|
+| **Departments** | Departments with `isArchived` set. |
+| **Projects** | Archived projects. |
+| **Products** | Products with status **Archived**. |
+
+Any signed-in user can open `/archive` and browse tables. **Restore** and archive **creation** are admin-restricted (below).
+
+## Archiving departments
+
+<Callout type="warn" title="Admin only">
+Archiving a department requires **Admin** privileges.
+</Callout>
+
+1. Open `/departments/{departmentId}`.
+2. Choose **Archive**.
+3. Type the **exact department name** to confirm.
+4. The department disappears from active lists and appears under **Archive → Departments**.
+
+## Archiving projects
+
+<Callout type="warn" title="Admin only">
+Archiving a project requires **Admin** privileges.
+</Callout>
+
+Same flow on `/projects/{projectId}` with exact **project name** confirmation.
+
+## Archiving products
+
+<Callout type="warn" title="Admin only">
+Archiving a product requires **Admin** privileges.
+</Callout>
+
+1. On `/products`, open the row menu.
+2. Choose **Archive** and confirm.
+3. Status becomes **archived**; the product moves to **Archive → Products**.
+
+Non-admins may see the menu entry but receive an insufficient-privileges message when confirming.
+
+## Restoring entities
+
+<Callout type="warn" title="Admin only">
+Restoring departments, projects, or products requires **Admin** privileges.
+</Callout>
+
+1. Go to `/archive` and select the correct tab.
+2. Click **Restore** on the row.
+3. Confirm in the dialog.
+
+| Entity | After restore |
+|--------|----------------|
+| **Department** | Active; `isArchived` cleared. |
+| **Project** | Active; `isArchived` cleared. |
+| **Product** | Status returns to **Draft** (editable again). |
+
+## Archive activity logs
+
+<Callout type="warn" title="Admin only">
+The **Logs** toggle on `/archive` is visible only to admins. It opens the activity panel with `scopeType: archive`.
+</Callout>
+
+Use archive logs to review who archived or restored entities and when.
+
+## Product spec archive route (not workspace archive)
+
+`/products/{productId}/product-spec-archive` is a **read-only historical specification viewer** (legacy Univer layout), sometimes used with `?compareVersion=` for side-by-side spreadsheets. It is **not** the same as archiving a product on `/archive`.
+
+For version comparison workflow, see [Redlines and Versions](/docs/review-outputs/redlines-versions).
+
+## Related topics
+
+- [Departments](/docs/getting-started/departments) — create before archive.
+- [Projects](/docs/getting-started/projects)
+- [Products](/docs/getting-started/products) — archive vs submit.

--- a/apps/app/content/docs/review-outputs/exports.mdx
+++ b/apps/app/content/docs/review-outputs/exports.mdx
@@ -1,0 +1,65 @@
+---
+title: Exports
+description: Product PDF exports, report exports, and specification workbook downloads.
+---
+
+Uprevit supports **asynchronous export jobs** (PDF and Excel) and **immediate spreadsheet download** from specification grids.
+
+## Product PDF exports
+
+### Queue a job
+
+From a product:
+
+- **Product header → Export PDF**, or
+- **Products table row menu → Export to PDF**
+
+The job is created via the product exports API. While **queued** or **processing**, the product header may lock submit, tab completion, and additional PDF requests.
+
+### Track and download
+
+| Route | Purpose |
+|-------|---------|
+| `/products/exports` | All product export jobs for your workspace access. |
+| Product header link | **View Export Jobs** when a job is active. |
+
+When status is **Completed**, download the file from the exports table. **Failed** jobs show an error state—retry from the product if needed.
+
+### Product Excel (async)
+
+The application supports Excel export jobs through the same jobs infrastructure. Entry points in the UI may be limited compared to PDF; check the products table and export dialogs in your deployment.
+
+## Report exports
+
+From **Reports** results:
+
+1. Run a query.
+2. Choose **Export PDF** or **Export Excel** on the result set.
+3. Confirm in the dialog.
+
+Jobs appear under **Report Exports** on `/reports` with the same status lifecycle (queued → processing → completed / failed). Downloads use the reports export API.
+
+## Immediate specification export
+
+On **Product Specifications** and **Operational Parameters** grids, the toolbar **Export** button downloads the **current workbook** as Excel immediately—this does not use the background job queue.
+
+Use async product PDF export when you need a packaged document across tabs.
+
+## Export formats and targets
+
+| Format | Typical target |
+|--------|----------------|
+| **PDF** | Full product documentation snapshot |
+| **Excel** | Product specifications, operational parameters, or report result sets |
+
+Job records include `format`, `status`, and `target` (product, product_specifications, operational_parameters, report).
+
+## Permissions
+
+Exports are available to authenticated members. No admin-only restriction applies.
+
+## Related topics
+
+- [Redlines and Versions](/docs/review-outputs/redlines-versions) — submit before exporting final snapshots.
+- [Reports](/docs/review-outputs/reports) — query then export.
+- [Product Specifications](/docs/product-documentation/product-specifications) — inline Excel export.

--- a/apps/app/content/docs/review-outputs/meta.json
+++ b/apps/app/content/docs/review-outputs/meta.json
@@ -1,0 +1,4 @@
+{
+  "title": "Review & Outputs",
+  "pages": ["redlines-versions", "reports", "exports", "archives"]
+}

--- a/apps/app/content/docs/review-outputs/redlines-versions.mdx
+++ b/apps/app/content/docs/review-outputs/redlines-versions.mdx
@@ -1,0 +1,93 @@
+---
+title: Redlines and Versions
+description: Submit product versions, compare changes across versions, and create new drafts.
+---
+
+This page is the **canonical guide** for product versioning and redline (comparison) review in Uprevit. Other documentation pages link here instead of repeating the full workflow.
+
+Uprevit does not use a separate “approver” role in the UI. The lifecycle is: **Draft → Submit (lock) → New version (new draft)**.
+
+## Concepts
+
+| Term | Meaning |
+|------|---------|
+| **Version** | Numeric revision on a product (`v1`, `v2`, …). New versions share lineage via `parent_id`. |
+| **Draft** | Editable; new products and new versions start here. |
+| **Submitted** | Locked snapshot—all seven tabs read-only for that version ID. |
+| **Redline / compare** | Read-only diff of an older version against the version you are viewing. |
+| **Tab completion** | Each of the seven tabs can be marked complete; **100%** (7/7) is required to submit. |
+
+## Tab completion and submit
+
+1. Open each product tab and enter data.
+2. In the product header, toggle **Mark tab complete** when a tab is finished.
+3. When progress shows **100%**, **Submit** becomes available.
+4. Confirm in the submit dialog.
+
+Submit:
+
+- Sets status to **Submitted**
+- Records **actual completion date** (today)
+- Disables editing on all tabs for that product ID
+
+## Creating a new version
+
+After submit, continue work by branching a new draft:
+
+1. On `/products`, open the row menu for a **Submitted** product.
+2. Choose **New version** (also available from version dialogs on the product).
+3. Uprevit copies data into a new product record: **Draft** status, incremented version, tabs marked incomplete.
+4. You are navigated to the new version’s **Product Information** tab.
+
+Only **Submitted** versions can spawn a new version.
+
+## Switching versions
+
+Use **View Versions** in the product header to jump between IDs in the same lineage. The current tab path is preserved (e.g. stay on Label Components when switching from v1 to v2).
+
+## Compare versions (redline)
+
+Redline is for **reviewing what changed** between an older submitted (or draft) version and the version open in the URL.
+
+### Start comparison
+
+1. Open any product tab for the **newer** version you want as the “current” side.
+2. In the header, open **Compare Versions**.
+3. Select an older version (only versions with a lower version number appear).
+4. The URL gains `?compareVersion={olderProductId}`.
+
+### While comparing
+
+- A banner summarizes change counts on tabs that support counts (e.g. Product Information, Compliance, Label Components).
+- **Product Specifications** and **Operational Parameters** offer **Highlight** vs **Inline** diff modes on the grid.
+- **Label Tags** and **Symbols & Graphics** show image and field-level OLD/NEW styling.
+- Sidebar links to other product tabs **keep** `compareVersion` so you can review the full product diff without re-selecting.
+
+### End comparison
+
+Click **Clear comparison** in the header (or remove the query parameter). The page returns to normal edit or read-only mode based on status.
+
+### Technical note
+
+The client loads `all-tabs` data for both version IDs and computes a structural diff (`added`, `removed`, `modified`, `unchanged`). Redline is read-only—it does not write merged data.
+
+## Edit locks beyond submit
+
+| Condition | Effect |
+|-----------|--------|
+| **Submitted** | No tab edits. |
+| **PDF export in progress** | Header may lock submit, tab completion, and further exports until the job finishes. |
+
+## Where redline appears
+
+All seven documentation tabs participate. Product tab docs describe tab-specific fields and link here for compare workflow.
+
+## Product logs
+
+Per-product change history lives at `/products/{productId}/logs`. Use it alongside redline when you need audit timestamps and actors, not field-level diffs.
+
+## Related topics
+
+- [Products](/docs/getting-started/products) — status and row actions.
+- [Exports](/docs/review-outputs/exports) — export submitted snapshots.
+- [Archives](/docs/review-outputs/archives) — archived products vs version lineage.

--- a/apps/app/content/docs/review-outputs/redlines-versions.mdx
+++ b/apps/app/content/docs/review-outputs/redlines-versions.mdx
@@ -7,6 +7,8 @@ This page is the **canonical guide** for product versioning and redline (compari
 
 Uprevit does not use a separate “approver” role in the UI. The lifecycle is: **Draft → Submit (lock) → New version (new draft)**.
 
+<DocsVideo videoKey="product.product-plan-review-overview" title="Product plan review and versions overview" />
+
 ## Concepts
 
 | Term | Meaning |

--- a/apps/app/content/docs/review-outputs/reports.mdx
+++ b/apps/app/content/docs/review-outputs/reports.mdx
@@ -5,6 +5,8 @@ description: Query products across tabs and export report results.
 
 **Reports** (`/reports`) lets you search products workspace-wide using conditions on root product fields and on data from each documentation tab.
 
+<DocsVideo videoKey="reports-analytics.overview" title="Reports and Analytics overview" />
+
 ## Query builder
 
 Build up to **10 conditions** combined with **AND** or **OR**:

--- a/apps/app/content/docs/review-outputs/reports.mdx
+++ b/apps/app/content/docs/review-outputs/reports.mdx
@@ -1,0 +1,60 @@
+---
+title: Reports
+description: Query products across tabs and export report results.
+---
+
+**Reports** (`/reports`) lets you search products workspace-wide using conditions on root product fields and on data from each documentation tab.
+
+## Query builder
+
+Build up to **10 conditions** combined with **AND** or **OR**:
+
+| Piece | Description |
+|-------|-------------|
+| **Category** | Maps to a product area: Product (root), Product Information, Compliance, Label Components, Symbols & Graphics, and other tab-backed fields defined in the report configuration. |
+| **Field** | Attribute within that category. |
+| **Operator** | Equals, does not equal, contains, does not contain, exists, does not exist, contains any, contains all. |
+| **Value** | Text, select, or multi-select depending on field type. |
+
+Click **Run query** to execute. Results paginate in the **Results** tab.
+
+### Example categories
+
+- **Product** — status, product name, PPN, version.
+- **Product Information** — market, country of origin, commercial/clinical, UDI-DI, and related metadata.
+- **Compliance** — standards and languages (where exposed in config).
+- **Label Components / Symbols** — array-backed fields with existence and containment operators.
+
+Exact fields mirror `QUERYABLE_TABS` in the application configuration and may expand as tabs gain query support.
+
+## Saved queries
+
+**Save** and **Load** store named queries in your browser (`localStorage` key `uprevit_reports_saved_queries`). Saved queries are local to your machine, not shared workspace-wide.
+
+## Results
+
+The results table lists matching products with key columns for identification. Open a product from results by navigating to its documentation URL.
+
+From results you can queue **Export PDF** or **Export Excel** for the current result set (async jobs—see [Exports](/docs/review-outputs/exports)).
+
+## Report export jobs
+
+The **Report Exports** section on the same page lists background jobs:
+
+| Status | Meaning |
+|--------|---------|
+| **Queued** | Waiting to process. |
+| **Processing** | Generating file. |
+| **Completed** | Ready to download. |
+| **Failed** | Error; retry or contact support. |
+
+A layout-level notifier toast can alert you when jobs complete while you work elsewhere.
+
+## Permissions
+
+Reports are available to all authenticated workspace members. No admin-only gate applies to building or running queries.
+
+## Related topics
+
+- [Exports](/docs/review-outputs/exports) — download completed report files.
+- Product documentation tabs — define the fields you filter on.

--- a/apps/app/content/docs/source-files-bookmarks/bookmarks.mdx
+++ b/apps/app/content/docs/source-files-bookmarks/bookmarks.mdx
@@ -1,0 +1,56 @@
+---
+title: Bookmarks
+description: Personal folders of bookmarked products for quick access.
+---
+
+**Bookmarked Products** (`/bookmarked-products`) is separate from **source file folder bookmarks**. Here you organize **products** into personal folders for fast return to in-progress labeling work.
+
+## Pages
+
+| Route | Purpose |
+|-------|---------|
+| `/bookmarked-products` | Your bookmark folders. |
+| `/bookmarked-products/{folderId}` | Products saved inside one folder. |
+
+## Folder actions
+
+| Action | How |
+|--------|-----|
+| **Create folder** | **Create Folder** on the main bookmarked products page. |
+| **Rename folder** | Edit action on a folder card. |
+| **Delete folder** | Delete action with confirmation. |
+
+## Adding products
+
+**From the products table**
+
+1. Open the row menu on `/products`.
+2. Choose **Add to Bookmarks**.
+3. Pick an existing folder or create one in the dialog.
+
+**From inside a folder**
+
+1. Open `/bookmarked-products/{folderId}`.
+2. Use **Add products** to search and select products.
+
+## Removing products
+
+Inside a folder, remove a product with **Remove from folder** (confirm dialog). This only removes the bookmark reference—the product itself is unchanged.
+
+## Permissions
+
+Any signed-in user manages their own bookmark folders and product membership. Admins have no special bookmark UI beyond normal access.
+
+## Source file bookmarks vs product bookmarks
+
+| Feature | Location | What is saved |
+|---------|----------|----------------|
+| **Source file folder bookmark** | `/source-files` | A folder in the source file tree |
+| **Product bookmark** | `/bookmarked-products` | A product reference in a user folder |
+
+See [Source Files](/docs/source-files-bookmarks/source-files) for the document library.
+
+## Related topics
+
+- [Products](/docs/getting-started/products) — row menu bookmark action.
+- [Source Files](/docs/source-files-bookmarks/source-files)

--- a/apps/app/content/docs/source-files-bookmarks/meta.json
+++ b/apps/app/content/docs/source-files-bookmarks/meta.json
@@ -1,0 +1,4 @@
+{
+  "title": "Source Files & Bookmarks",
+  "pages": ["source-files", "bookmarks"]
+}

--- a/apps/app/content/docs/source-files-bookmarks/source-files.mdx
+++ b/apps/app/content/docs/source-files-bookmarks/source-files.mdx
@@ -7,6 +7,8 @@ description: Workspace folder tree for reference documents linked to products.
 
 Folders can nest under parents and may optionally link to a **product** so teammates can open related assets from [Product Information](/docs/product-documentation/product-information).
 
+<DocsVideo videoKey="working-with-files.source-files-archive-bookmarks" title="Source Files, Archive, and Bookmarks tabs" />
+
 ## Browsing
 
 | Route | Purpose |

--- a/apps/app/content/docs/source-files-bookmarks/source-files.mdx
+++ b/apps/app/content/docs/source-files-bookmarks/source-files.mdx
@@ -1,0 +1,57 @@
+---
+title: Source Files
+description: Workspace folder tree for reference documents linked to products.
+---
+
+**Source Files** (`/source-files`) is a workspace-wide file library organized as folders and files. Use it to store reference PDFs, artwork, standards extracts, and other materials—not the structured product tabs themselves.
+
+Folders can nest under parents and may optionally link to a **product** so teammates can open related assets from [Product Information](/docs/product-documentation/product-information).
+
+## Browsing
+
+| Route | Purpose |
+|-------|---------|
+| `/source-files` | Root folders plus **Bookmarked Folders** section. |
+| `/source-files/view/{folderId}` | Contents of one folder: subfolders, files, uploads. |
+
+Switch **card**, **list**, or **big grid** view on folder pages for different density.
+
+## Folder actions
+
+| Action | Description |
+|--------|-------------|
+| **Create folder** | Add a folder at root or inside another folder; optionally associate with a product. |
+| **Edit folder** | Rename or update folder metadata. |
+| **Delete folder** | Remove folder (confirm dialog). |
+| **Upload files** | Add one or more files into the current folder. |
+
+## File actions
+
+On each file:
+
+- **Preview** — images open in a preview dialog.
+- **Download** — save a copy locally.
+- **Delete** — remove the file with confirmation.
+
+## Bookmarking folders
+
+Toggle the bookmark icon on a folder card to add it to your personal **Bookmarked Folders** list. Bookmarked folders appear on `/source-files` filtered by context (root vs inside a parent folder).
+
+Bookmarks are per user and do not change folder permissions for others.
+
+## Activity logs
+
+On `/source-files`, toggle **Logs** to open the activity panel (`scopeType: source-files`). Any signed-in user can view these logs in the current application—unlike archive logs, this is not admin-restricted.
+
+## Linking from products
+
+On **Product Information**, **Linked source files** shows folders tied to the product. Links open the folder in Source Files.
+
+## Permissions
+
+Source file and folder CRUD is available to authenticated workspace members. There is no separate admin gate on these actions in the UI.
+
+## Related topics
+
+- [Bookmarks](/docs/source-files-bookmarks/bookmarks) — product bookmark folders (separate feature).
+- [Product Information](/docs/product-documentation/product-information) — product-side links into folders.

--- a/apps/app/hooks/docs/useDocumentationVideoUrl.ts
+++ b/apps/app/hooks/docs/useDocumentationVideoUrl.ts
@@ -2,7 +2,10 @@
 
 import { useQuery } from "@tanstack/react-query";
 import { useAuth, type AuthContextProps } from "react-oidc-context";
-import type { DocumentationVideoSignedUrlResponse } from "@/types/documentation-video";
+import type {
+  DocumentationVideoKey,
+  DocumentationVideoSignedUrlResponse,
+} from "@/types/documentation-video";
 
 const REFRESH_BUFFER_MS = 2 * 60 * 1000;
 
@@ -17,7 +20,7 @@ async function fetchDocumentationVideoUrl({
   signal,
   auth,
 }: {
-  videoKey: string;
+  videoKey: DocumentationVideoKey;
   signal: AbortSignal;
   auth: AuthContextProps;
 }) {
@@ -44,7 +47,7 @@ async function fetchDocumentationVideoUrl({
   return (await response.json()) as DocumentationVideoSignedUrlResponse;
 }
 
-export function useDocumentationVideoUrl(videoKey: string) {
+export function useDocumentationVideoUrl(videoKey: DocumentationVideoKey) {
   const auth = useAuth();
 
   return useQuery({

--- a/apps/app/hooks/docs/useDocumentationVideoUrl.ts
+++ b/apps/app/hooks/docs/useDocumentationVideoUrl.ts
@@ -1,0 +1,64 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { useAuth, type AuthContextProps } from "react-oidc-context";
+import type { DocumentationVideoSignedUrlResponse } from "@/types/documentation-video";
+
+const REFRESH_BUFFER_MS = 2 * 60 * 1000;
+
+function getStaleTimeMs(expiresAt: string): number {
+  const expiresMs = new Date(expiresAt).getTime();
+  const staleMs = expiresMs - Date.now() - REFRESH_BUFFER_MS;
+  return Math.max(staleMs, 0);
+}
+
+async function fetchDocumentationVideoUrl({
+  videoKey,
+  signal,
+  auth,
+}: {
+  videoKey: string;
+  signal: AbortSignal;
+  auth: AuthContextProps;
+}) {
+  const accessToken = auth.user?.access_token;
+  if (!accessToken) {
+    throw new Error("User is not authenticated");
+  }
+
+  const response = await fetch(
+    `/api/docs/videos/${encodeURIComponent(videoKey)}/signed-url`,
+    {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
+      signal,
+    },
+  );
+
+  if (!response.ok) {
+    const text = await response.text().catch(() => "");
+    throw new Error(text || "Failed to load documentation video");
+  }
+
+  return (await response.json()) as DocumentationVideoSignedUrlResponse;
+}
+
+export function useDocumentationVideoUrl(videoKey: string) {
+  const auth = useAuth();
+
+  return useQuery({
+    queryKey: ["docs-video-url", videoKey],
+    queryFn: async ({ signal }) => {
+      const data = await fetchDocumentationVideoUrl({ videoKey, signal, auth });
+      return data.result;
+    },
+    enabled: auth.isAuthenticated && Boolean(videoKey),
+    staleTime: (query) => {
+      const expiresAt = query.state.data?.expiresAt;
+      if (!expiresAt) return 0;
+      return getStaleTimeMs(expiresAt);
+    },
+    gcTime: 0,
+  });
+}

--- a/apps/app/lib/docs-nav-title.tsx
+++ b/apps/app/lib/docs-nav-title.tsx
@@ -1,0 +1,10 @@
+import { UprevitLogo } from "@/components/common/UprevitLogo";
+
+export function docsNavTitle() {
+  return (
+    <>
+      <UprevitLogo />
+      <span className="font-semibold mt-0.5">Uprevit Docs</span>
+    </>
+  );
+}

--- a/apps/app/lib/layout.shared.tsx
+++ b/apps/app/lib/layout.shared.tsx
@@ -1,0 +1,29 @@
+import { buttonVariants } from "@uprevit/ui/components/ui/button";
+import type { BaseLayoutProps } from "fumadocs-ui/layouts/shared";
+import Link from "next/link";
+import { PiArrowLeftDuotone } from "react-icons/pi";
+import { docsNavTitle } from "@/lib/docs-nav-title";
+
+export function baseOptions(): BaseLayoutProps {
+  return {
+    nav: {
+      title: docsNavTitle(),
+      url: "/docs",
+    },
+    links: [
+      {
+        type: "custom",
+        children: (
+          <Link
+            href="/dashboard"
+            className={buttonVariants({ variant: "outline" })}
+          >
+            <PiArrowLeftDuotone />
+            Back to App
+          </Link>
+        ),
+        secondary: true,
+      },
+    ],
+  };
+}

--- a/apps/app/lib/source.ts
+++ b/apps/app/lib/source.ts
@@ -1,0 +1,7 @@
+import { docs } from "collections/server";
+import { loader } from "fumadocs-core/source";
+
+export const source = loader({
+  baseUrl: "/docs",
+  source: docs.toFumadocsSource(),
+});

--- a/apps/app/lib/verify-cognito-access-token.ts
+++ b/apps/app/lib/verify-cognito-access-token.ts
@@ -1,0 +1,31 @@
+import { createRemoteJWKSet, jwtVerify } from "jose";
+
+const issuer = process.env.NEXT_PUBLIC_COGNITO_AUTHORITY;
+const clientId = process.env.NEXT_PUBLIC_CLIENT_ID;
+
+let jwks: ReturnType<typeof createRemoteJWKSet> | undefined;
+
+function getJwks() {
+  if (!issuer) {
+    throw new Error("NEXT_PUBLIC_COGNITO_AUTHORITY is not configured");
+  }
+
+  jwks ??= createRemoteJWKSet(new URL(`${issuer}/.well-known/jwks.json`));
+  return jwks;
+}
+
+export async function verifyCognitoAccessToken(token: string): Promise<boolean> {
+  if (!issuer) return false;
+
+  try {
+    const { payload } = await jwtVerify(token, getJwks(), { issuer });
+
+    if (clientId && payload.client_id !== clientId) {
+      return false;
+    }
+
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/apps/app/next.config.mjs
+++ b/apps/app/next.config.mjs
@@ -1,6 +1,6 @@
-import type { NextConfig } from "next";
+import { createMDX } from "fumadocs-mdx/next";
 
-const nextConfig: NextConfig = {
+const nextConfig = {
   transpilePackages: ["@uprevit/ui"],
   images: {
     remotePatterns: [
@@ -49,4 +49,6 @@ const nextConfig: NextConfig = {
   },
 };
 
-export default nextConfig;
+const withMDX = createMDX();
+
+export default withMDX(nextConfig);

--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -10,7 +10,6 @@
     "check-types": "tsc --noEmit"
   },
   "dependencies": {
-    "@uprevit/ui": "workspace:*",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/modifiers": "^9.0.0",
     "@dnd-kit/sortable": "^10.0.0",
@@ -44,14 +43,19 @@
     "@tanstack/react-query-devtools": "^5.85.5",
     "@tanstack/react-table": "^8.21.3",
     "@tanstack/react-virtual": "^3.13.16",
+    "@types/mdx": "^2.0.13",
     "@univerjs/presets": "^0.8.1",
     "@univerjs/sheets-zen-editor": "^0.8.3",
     "@uploadthing/react": "^7.3.3",
+    "@uprevit/ui": "workspace:*",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
     "country-flag-icons": "^1.6.4",
     "date-fns": "^4.2.1",
+    "fumadocs-core": "^16.9.1",
+    "fumadocs-mdx": "^15.0.8",
+    "fumadocs-ui": "^16.9.1",
     "lucide-react": "^0.555.0",
     "motion": "^12.34.0",
     "next": "16.0.10",
@@ -72,13 +76,13 @@
     "xlsx-js-style": "^1.2.0"
   },
   "devDependencies": {
-    "@tailwindcss/postcss": "^4",
+    "@tailwindcss/postcss": "^4.3.0",
     "@types/node": "^20",
     "@types/react": "19.2.7",
     "@types/react-dom": "19.2.3",
     "eslint": "^9",
     "eslint-config-next": "16.0.7",
-    "tailwindcss": "^4",
+    "tailwindcss": "^4.3.0",
     "typescript": "^5"
   },
   "overrides": {

--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -56,6 +56,7 @@
     "fumadocs-core": "^16.9.1",
     "fumadocs-mdx": "^15.0.8",
     "fumadocs-ui": "^16.9.1",
+    "jose": "^6.2.3",
     "lucide-react": "^0.555.0",
     "motion": "^12.34.0",
     "next": "16.0.10",

--- a/apps/app/source.config.ts
+++ b/apps/app/source.config.ts
@@ -1,0 +1,7 @@
+import { defineDocs, defineConfig } from "fumadocs-mdx/config";
+
+export const docs = defineDocs({
+  dir: "content/docs",
+});
+
+export default defineConfig();

--- a/apps/app/tsconfig.json
+++ b/apps/app/tsconfig.json
@@ -1,11 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2017",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -23,9 +19,8 @@
       }
     ],
     "paths": {
-      "@/*": [
-        "./*"
-      ]
+      "@/*": ["./*"],
+      "collections/*": ["./.source/*"]
     }
   },
   "include": [
@@ -35,7 +30,5 @@
     ".next/types/**/*.ts",
     ".next/dev/types/**/*.ts"
   ],
-  "exclude": [
-    "node_modules"
-  ]
+  "exclude": ["node_modules"]
 }

--- a/apps/app/types/documentation-video.ts
+++ b/apps/app/types/documentation-video.ts
@@ -1,0 +1,22 @@
+export type DocumentationVideoSignedUrlResponse = {
+  message: string;
+  result: {
+    url: string;
+    expiresAt: string;
+  };
+};
+
+export type DocumentationVideoKey =
+  | "department.departments-tab"
+  | "getting-started.welcome-dashboard"
+  | "product.compliance-tab"
+  | "product.label-components"
+  | "product.label-tags"
+  | "product.product-information"
+  | "product.product-plan-review-overview"
+  | "product.product-specifications"
+  | "product.products-intro"
+  | "product.symbols-graphics"
+  | "projects.projects-tab"
+  | "reports-analytics.overview"
+  | "working-with-files.source-files-archive-bookmarks";

--- a/apps/marketing/package.json
+++ b/apps/marketing/package.json
@@ -29,13 +29,13 @@
     "tw-animate-css": "^1.2.5"
   },
   "devDependencies": {
-    "@tailwindcss/postcss": "^4",
+    "@tailwindcss/postcss": "^4.3.0",
     "@types/node": "^20",
     "@types/react": "19.2.7",
     "@types/react-dom": "19.2.3",
     "eslint": "^9",
     "eslint-config-next": "16.0.7",
-    "tailwindcss": "^4",
+    "tailwindcss": "^4.3.0",
     "typescript": "^5"
   },
   "overrides": {

--- a/bun.lock
+++ b/bun.lock
@@ -61,6 +61,7 @@
         "fumadocs-core": "^16.9.1",
         "fumadocs-mdx": "^15.0.8",
         "fumadocs-ui": "^16.9.1",
+        "jose": "^6.2.3",
         "lucide-react": "^0.555.0",
         "motion": "^12.34.0",
         "next": "16.0.10",
@@ -1511,6 +1512,8 @@
     "iterator.prototype": ["iterator.prototype@1.1.5", "", { "dependencies": { "define-data-property": "^1.1.4", "es-object-atoms": "^1.0.0", "get-intrinsic": "^1.2.6", "get-proto": "^1.0.0", "has-symbols": "^1.1.0", "set-function-name": "^2.0.2" } }, "sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g=="],
 
     "jiti": ["jiti@2.6.1", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ=="],
+
+    "jose": ["jose@6.2.3", "", {}, "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw=="],
 
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -48,6 +48,7 @@
         "@tanstack/react-query-devtools": "^5.85.5",
         "@tanstack/react-table": "^8.21.3",
         "@tanstack/react-virtual": "^3.13.16",
+        "@types/mdx": "^2.0.13",
         "@univerjs/presets": "^0.8.1",
         "@univerjs/sheets-zen-editor": "^0.8.3",
         "@uploadthing/react": "^7.3.3",
@@ -57,6 +58,9 @@
         "cmdk": "^1.1.1",
         "country-flag-icons": "^1.6.4",
         "date-fns": "^4.2.1",
+        "fumadocs-core": "^16.9.1",
+        "fumadocs-mdx": "^15.0.8",
+        "fumadocs-ui": "^16.9.1",
         "lucide-react": "^0.555.0",
         "motion": "^12.34.0",
         "next": "16.0.10",
@@ -77,13 +81,13 @@
         "xlsx-js-style": "^1.2.0",
       },
       "devDependencies": {
-        "@tailwindcss/postcss": "^4",
+        "@tailwindcss/postcss": "^4.3.0",
         "@types/node": "^20",
         "@types/react": "19.2.7",
         "@types/react-dom": "19.2.3",
         "eslint": "^9",
         "eslint-config-next": "16.0.7",
-        "tailwindcss": "^4",
+        "tailwindcss": "^4.3.0",
         "typescript": "^5",
       },
     },
@@ -110,13 +114,13 @@
         "tw-animate-css": "^1.2.5",
       },
       "devDependencies": {
-        "@tailwindcss/postcss": "^4",
+        "@tailwindcss/postcss": "^4.3.0",
         "@types/node": "^20",
         "@types/react": "19.2.7",
         "@types/react-dom": "19.2.3",
         "eslint": "^9",
         "eslint-config-next": "16.0.7",
-        "tailwindcss": "^4",
+        "tailwindcss": "^4.3.0",
         "typescript": "^5",
       },
     },
@@ -175,8 +179,10 @@
     },
   },
   "overrides": {
+    "@tailwindcss/postcss": "^4.3.0",
     "date-fns": "^4.2.1",
     "react-day-picker": "^10.0.1",
+    "tailwindcss": "^4.3.0",
   },
   "packages": {
     "@alloc/quick-lru": ["@alloc/quick-lru@5.2.0", "", {}, "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw=="],
@@ -235,6 +241,58 @@
 
     "@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.1.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ=="],
 
+    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.28.0", "", { "os": "aix", "cpu": "ppc64" }, "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA=="],
+
+    "@esbuild/android-arm": ["@esbuild/android-arm@0.28.0", "", { "os": "android", "cpu": "arm" }, "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ=="],
+
+    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.28.0", "", { "os": "android", "cpu": "arm64" }, "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw=="],
+
+    "@esbuild/android-x64": ["@esbuild/android-x64@0.28.0", "", { "os": "android", "cpu": "x64" }, "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA=="],
+
+    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.28.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q=="],
+
+    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.28.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ=="],
+
+    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.28.0", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q=="],
+
+    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.28.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw=="],
+
+    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.28.0", "", { "os": "linux", "cpu": "arm" }, "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw=="],
+
+    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.28.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A=="],
+
+    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.28.0", "", { "os": "linux", "cpu": "ia32" }, "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ=="],
+
+    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.28.0", "", { "os": "linux", "cpu": "none" }, "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg=="],
+
+    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.28.0", "", { "os": "linux", "cpu": "none" }, "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w=="],
+
+    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.28.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg=="],
+
+    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.28.0", "", { "os": "linux", "cpu": "none" }, "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ=="],
+
+    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.28.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q=="],
+
+    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.28.0", "", { "os": "linux", "cpu": "x64" }, "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ=="],
+
+    "@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.28.0", "", { "os": "none", "cpu": "arm64" }, "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw=="],
+
+    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.28.0", "", { "os": "none", "cpu": "x64" }, "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw=="],
+
+    "@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.28.0", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g=="],
+
+    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.28.0", "", { "os": "openbsd", "cpu": "x64" }, "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA=="],
+
+    "@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.28.0", "", { "os": "none", "cpu": "arm64" }, "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w=="],
+
+    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.28.0", "", { "os": "sunos", "cpu": "x64" }, "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw=="],
+
+    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.28.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA=="],
+
+    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.28.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA=="],
+
+    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.28.0", "", { "os": "win32", "cpu": "x64" }, "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw=="],
+
     "@eslint-community/eslint-utils": ["@eslint-community/eslint-utils@4.9.0", "", { "dependencies": { "eslint-visitor-keys": "^3.4.3" }, "peerDependencies": { "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0" } }, "sha512-ayVFHdtZ+hsq1t2Dy24wCmGXGe4q9Gu3smhLYALJrr473ZH27MsnSL+LKUlimp4BWJqMDMLmPpx/Q9R3OAlL4g=="],
 
     "@eslint-community/regexpp": ["@eslint-community/regexpp@4.12.2", "", {}, "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew=="],
@@ -262,6 +320,8 @@
     "@floating-ui/react-dom": ["@floating-ui/react-dom@2.1.6", "", { "dependencies": { "@floating-ui/dom": "^1.7.4" }, "peerDependencies": { "react": ">=16.8.0", "react-dom": ">=16.8.0" } }, "sha512-4JX6rEatQEvlmgU80wZyq9RT96HZJa88q8hp0pBd+LrczeDI4o6uA2M+uvxngVHo4Ihr8uibXxH6+70zhAFrVw=="],
 
     "@floating-ui/utils": ["@floating-ui/utils@0.2.10", "", {}, "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ=="],
+
+    "@fumadocs/tailwind": ["@fumadocs/tailwind@0.0.5", "", { "peerDependencies": { "@tailwindcss/oxide": "^4.0.0", "tailwindcss": "^4.0.0" }, "optionalPeers": ["@tailwindcss/oxide", "tailwindcss"] }, "sha512-ENKPWUDRmriccsrUDE4bDBq3FNr/ms3BP2rWlsAEMV1yP23pcCaan+ceGfeBUsAQjw7sj9Q3R4Kl3g/TCStPzQ=="],
 
     "@grpc/grpc-js": ["@grpc/grpc-js@1.14.1", "", { "dependencies": { "@grpc/proto-loader": "^0.8.0", "@js-sdsl/ordered-map": "^4.4.2" } }, "sha512-sPxgEWtPUR3EnRJCEtbGZG2iX8LQDUls2wUS3o27jg07KqJFMq6YDeWvMo1wfpmy3rqRdS0rivpLwhqQtEyCuQ=="],
 
@@ -339,6 +399,8 @@
 
     "@markerjs/markerjs3": ["@markerjs/markerjs3@3.8.1", "", {}, "sha512-5zD4/eej5uvFPD27e2KrmdDL9mosOJ4U6Hw489zQD+iXSSSA/csbvnXAObql7fh+IJlkp7en19TcvaZthIODQg=="],
 
+    "@mdx-js/mdx": ["@mdx-js/mdx@3.1.1", "", { "dependencies": { "@types/estree": "^1.0.0", "@types/estree-jsx": "^1.0.0", "@types/hast": "^3.0.0", "@types/mdx": "^2.0.0", "acorn": "^8.0.0", "collapse-white-space": "^2.0.0", "devlop": "^1.0.0", "estree-util-is-identifier-name": "^3.0.0", "estree-util-scope": "^1.0.0", "estree-walker": "^3.0.0", "hast-util-to-jsx-runtime": "^2.0.0", "markdown-extensions": "^2.0.0", "recma-build-jsx": "^1.0.0", "recma-jsx": "^1.0.0", "recma-stringify": "^1.0.0", "rehype-recma": "^1.0.0", "remark-mdx": "^3.0.0", "remark-parse": "^11.0.0", "remark-rehype": "^11.0.0", "source-map": "^0.7.0", "unified": "^11.0.0", "unist-util-position-from-estree": "^2.0.0", "unist-util-stringify-position": "^4.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" } }, "sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ=="],
+
     "@msgpackr-extract/msgpackr-extract-darwin-arm64": ["@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-QZHtlVgbAdy2zAqNA9Gu1UpIuI8Xvsd1v8ic6B2pZmeFnFcMWiPLfWXh7TVw4eGEZ/C9TH281KwhVoeQUKbyjw=="],
 
     "@msgpackr-extract/msgpackr-extract-darwin-x64": ["@msgpackr-extract/msgpackr-extract-darwin-x64@3.0.3", "", { "os": "darwin", "cpu": "x64" }, "sha512-mdzd3AVzYKuUmiWOQ8GNhl64/IoFGol569zNRdkLReh6LRLHOXxU4U8eq0JwaD8iFHdVGqSy4IjFL4reoWCDFw=="],
@@ -386,6 +448,8 @@
     "@nolyfill/is-core-module": ["@nolyfill/is-core-module@1.0.39", "", {}, "sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA=="],
 
     "@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.38.0", "", {}, "sha512-kocjix+/sSggfJhwXqClZ3i9Y/MI0fp7b+g7kCRm6psy2dsf8uApTRclwG18h8Avm7C9+fnt+O36PspJ/OzoWg=="],
+
+    "@orama/orama": ["@orama/orama@3.1.18", "", {}, "sha512-a61ljmRVVyG5MC/698C8/FfFDw5a8LOIvyOLW5fztgUXqUpc1jOfQzOitSCbge657OgXXThmY3Tk8fpiDb4UcA=="],
 
     "@protobufjs/aspromise": ["@protobufjs/aspromise@1.1.2", "", {}, "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="],
 
@@ -537,39 +601,55 @@
 
     "@rtsao/scc": ["@rtsao/scc@1.1.0", "", {}, "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g=="],
 
-    "@standard-schema/spec": ["@standard-schema/spec@1.0.0-beta.4", "", {}, "sha512-d3IxtzLo7P1oZ8s8YNvxzBUXRXojSut8pbPrTYtzsc5sn4+53jVqbk66pQerSZbZSJZQux6LkclB/+8IDordHg=="],
+    "@shikijs/core": ["@shikijs/core@4.1.0", "", { "dependencies": { "@shikijs/primitive": "4.1.0", "@shikijs/types": "4.1.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4", "hast-util-to-html": "^9.0.5" } }, "sha512-jLJtSJeuFffqX6/inRE1zqU5aFv2hrszvYgq3OjbAgFRZiWv7abKMDdQzYxuSDfmUPQozZvI/kuy6VMTvnvqTQ=="],
+
+    "@shikijs/engine-javascript": ["@shikijs/engine-javascript@4.1.0", "", { "dependencies": { "@shikijs/types": "4.1.0", "@shikijs/vscode-textmate": "^10.0.2", "oniguruma-to-es": "^4.3.6" } }, "sha512-YquhawCUgaBfhsS72e2Y/dI59gCBNPHu3fEO/tvLaXrTssxZrY5ddjtNLTwndrMgPo8b3IscE+xoICDzpTmlFQ=="],
+
+    "@shikijs/engine-oniguruma": ["@shikijs/engine-oniguruma@4.1.0", "", { "dependencies": { "@shikijs/types": "4.1.0", "@shikijs/vscode-textmate": "^10.0.2" } }, "sha512-axLpjVs45YBvvINa+dJF+NPW+KtFkNXsFr4SDw2BMj9GdeMnGxVB9PQb2xXlJYovslt/nz6giedAyOANkfc7hg=="],
+
+    "@shikijs/langs": ["@shikijs/langs@4.1.0", "", { "dependencies": { "@shikijs/types": "4.1.0" } }, "sha512-nwOMruEkbgdZfQ/b8CgpNBVOpvG1k0N5tbmgiFeqsan401+x3ILqlzZJowSla4Agmq4hG2Uf2wh5jLTEhR8VSg=="],
+
+    "@shikijs/primitive": ["@shikijs/primitive@4.1.0", "", { "dependencies": { "@shikijs/types": "4.1.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-zx2/2Uwj2q9X3KSyYREEhXO23xBw5WUhP4orK2lE4r+t9JGITmEe0JH+wPmJhqHpOT2bRRs6lAL945+LDvOAGw=="],
+
+    "@shikijs/themes": ["@shikijs/themes@4.1.0", "", { "dependencies": { "@shikijs/types": "4.1.0" } }, "sha512-emCcTnUM7yO2wltYbaxm+yLvcCI4+h8XBKc4KmJ7EZUXoSGjcCHifkI//R4OFit9ewpg7H2/9tjOuXrT2v/Knw=="],
+
+    "@shikijs/types": ["@shikijs/types@4.1.0", "", { "dependencies": { "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-3EQWX54fMpniOrDblzAhiwiJwpiTMW6+B9DWyUd9ska483tbayFYuw47UxwuPknI31bKnySfVQ/QW+jFL4rFdA=="],
+
+    "@shikijs/vscode-textmate": ["@shikijs/vscode-textmate@10.0.2", "", {}, "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg=="],
+
+    "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
     "@swc/helpers": ["@swc/helpers@0.5.15", "", { "dependencies": { "tslib": "^2.8.0" } }, "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g=="],
 
-    "@tailwindcss/node": ["@tailwindcss/node@4.1.17", "", { "dependencies": { "@jridgewell/remapping": "^2.3.4", "enhanced-resolve": "^5.18.3", "jiti": "^2.6.1", "lightningcss": "1.30.2", "magic-string": "^0.30.21", "source-map-js": "^1.2.1", "tailwindcss": "4.1.17" } }, "sha512-csIkHIgLb3JisEFQ0vxr2Y57GUNYh447C8xzwj89U/8fdW8LhProdxvnVH6U8M2Y73QKiTIH+LWbK3V2BBZsAg=="],
+    "@tailwindcss/node": ["@tailwindcss/node@4.3.0", "", { "dependencies": { "@jridgewell/remapping": "^2.3.5", "enhanced-resolve": "^5.21.0", "jiti": "^2.6.1", "lightningcss": "1.32.0", "magic-string": "^0.30.21", "source-map-js": "^1.2.1", "tailwindcss": "4.3.0" } }, "sha512-aFb4gUhFOgdh9AXo4IzBEOzBkkAxm9VigwDJnMIYv3lcfXCJVesNfbEaBl4BNgVRyid92AmdviqwBUBRKSeY3g=="],
 
-    "@tailwindcss/oxide": ["@tailwindcss/oxide@4.1.17", "", { "optionalDependencies": { "@tailwindcss/oxide-android-arm64": "4.1.17", "@tailwindcss/oxide-darwin-arm64": "4.1.17", "@tailwindcss/oxide-darwin-x64": "4.1.17", "@tailwindcss/oxide-freebsd-x64": "4.1.17", "@tailwindcss/oxide-linux-arm-gnueabihf": "4.1.17", "@tailwindcss/oxide-linux-arm64-gnu": "4.1.17", "@tailwindcss/oxide-linux-arm64-musl": "4.1.17", "@tailwindcss/oxide-linux-x64-gnu": "4.1.17", "@tailwindcss/oxide-linux-x64-musl": "4.1.17", "@tailwindcss/oxide-wasm32-wasi": "4.1.17", "@tailwindcss/oxide-win32-arm64-msvc": "4.1.17", "@tailwindcss/oxide-win32-x64-msvc": "4.1.17" } }, "sha512-F0F7d01fmkQhsTjXezGBLdrl1KresJTcI3DB8EkScCldyKp3Msz4hub4uyYaVnk88BAS1g5DQjjF6F5qczheLA=="],
+    "@tailwindcss/oxide": ["@tailwindcss/oxide@4.3.0", "", { "optionalDependencies": { "@tailwindcss/oxide-android-arm64": "4.3.0", "@tailwindcss/oxide-darwin-arm64": "4.3.0", "@tailwindcss/oxide-darwin-x64": "4.3.0", "@tailwindcss/oxide-freebsd-x64": "4.3.0", "@tailwindcss/oxide-linux-arm-gnueabihf": "4.3.0", "@tailwindcss/oxide-linux-arm64-gnu": "4.3.0", "@tailwindcss/oxide-linux-arm64-musl": "4.3.0", "@tailwindcss/oxide-linux-x64-gnu": "4.3.0", "@tailwindcss/oxide-linux-x64-musl": "4.3.0", "@tailwindcss/oxide-wasm32-wasi": "4.3.0", "@tailwindcss/oxide-win32-arm64-msvc": "4.3.0", "@tailwindcss/oxide-win32-x64-msvc": "4.3.0" } }, "sha512-F7HZGBeN9I0/AuuJS5PwcD8xayx5ri5GhjYUDBEVYUkexyA/giwbDNjRVrxSezE3T250OU2K/wp/ltWx3UOefg=="],
 
-    "@tailwindcss/oxide-android-arm64": ["@tailwindcss/oxide-android-arm64@4.1.17", "", { "os": "android", "cpu": "arm64" }, "sha512-BMqpkJHgOZ5z78qqiGE6ZIRExyaHyuxjgrJ6eBO5+hfrfGkuya0lYfw8fRHG77gdTjWkNWEEm+qeG2cDMxArLQ=="],
+    "@tailwindcss/oxide-android-arm64": ["@tailwindcss/oxide-android-arm64@4.3.0", "", { "os": "android", "cpu": "arm64" }, "sha512-TJPiq67tKlLuObP6RkwvVGDoxCMBVtDgKkLfa/uyj7/FyxvQwHS+UOnVrXXgbEsfUaMgiVvC4KbJnRr26ho4Ng=="],
 
-    "@tailwindcss/oxide-darwin-arm64": ["@tailwindcss/oxide-darwin-arm64@4.1.17", "", { "os": "darwin", "cpu": "arm64" }, "sha512-EquyumkQweUBNk1zGEU/wfZo2qkp/nQKRZM8bUYO0J+Lums5+wl2CcG1f9BgAjn/u9pJzdYddHWBiFXJTcxmOg=="],
+    "@tailwindcss/oxide-darwin-arm64": ["@tailwindcss/oxide-darwin-arm64@4.3.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-oMN/WZRb+SO37BmUElEgeEWuU8E/HXRkiODxJxLe1UTHVXLrdVSgfaJV7pSlhRGMSOiXLuxTIjfsF3wYvz8cgQ=="],
 
-    "@tailwindcss/oxide-darwin-x64": ["@tailwindcss/oxide-darwin-x64@4.1.17", "", { "os": "darwin", "cpu": "x64" }, "sha512-gdhEPLzke2Pog8s12oADwYu0IAw04Y2tlmgVzIN0+046ytcgx8uZmCzEg4VcQh+AHKiS7xaL8kGo/QTiNEGRog=="],
+    "@tailwindcss/oxide-darwin-x64": ["@tailwindcss/oxide-darwin-x64@4.3.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-N6CUmu4a6bKVADfw77p+iw6Yd9Q3OBhe0veaDX+QazfuVYlQsHfDgxBrsjQ/IW+zywL8mTrNd0SdJT/zgtvMdA=="],
 
-    "@tailwindcss/oxide-freebsd-x64": ["@tailwindcss/oxide-freebsd-x64@4.1.17", "", { "os": "freebsd", "cpu": "x64" }, "sha512-hxGS81KskMxML9DXsaXT1H0DyA+ZBIbyG/sSAjWNe2EDl7TkPOBI42GBV3u38itzGUOmFfCzk1iAjDXds8Oh0g=="],
+    "@tailwindcss/oxide-freebsd-x64": ["@tailwindcss/oxide-freebsd-x64@4.3.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-zDL5hBkQdH5C6MpqbK3gQAgP80tsMwSI26vjOzjJtNCMUo0lFgOItzHKBIupOZNQxt3ouPH7RPhvNhiTfCe5CQ=="],
 
-    "@tailwindcss/oxide-linux-arm-gnueabihf": ["@tailwindcss/oxide-linux-arm-gnueabihf@4.1.17", "", { "os": "linux", "cpu": "arm" }, "sha512-k7jWk5E3ldAdw0cNglhjSgv501u7yrMf8oeZ0cElhxU6Y2o7f8yqelOp3fhf7evjIS6ujTI3U8pKUXV2I4iXHQ=="],
+    "@tailwindcss/oxide-linux-arm-gnueabihf": ["@tailwindcss/oxide-linux-arm-gnueabihf@4.3.0", "", { "os": "linux", "cpu": "arm" }, "sha512-R06HdNi7A7OEoMsf6d4tjZ71RCWnZQPHj2mnotSFURjNLdBC+cIgXQ7l81CqeoiQftjf6OOblxXMInMgN2VzMA=="],
 
-    "@tailwindcss/oxide-linux-arm64-gnu": ["@tailwindcss/oxide-linux-arm64-gnu@4.1.17", "", { "os": "linux", "cpu": "arm64" }, "sha512-HVDOm/mxK6+TbARwdW17WrgDYEGzmoYayrCgmLEw7FxTPLcp/glBisuyWkFz/jb7ZfiAXAXUACfyItn+nTgsdQ=="],
+    "@tailwindcss/oxide-linux-arm64-gnu": ["@tailwindcss/oxide-linux-arm64-gnu@4.3.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-qTJHELX8jetjhRQHCLilkVLmybpzNQAtaI/gaoVoidn/ufbNDbAo8KlK2J+yPoc8wQxvDxCmh/5lr8nC1+lTbg=="],
 
-    "@tailwindcss/oxide-linux-arm64-musl": ["@tailwindcss/oxide-linux-arm64-musl@4.1.17", "", { "os": "linux", "cpu": "arm64" }, "sha512-HvZLfGr42i5anKtIeQzxdkw/wPqIbpeZqe7vd3V9vI3RQxe3xU1fLjss0TjyhxWcBaipk7NYwSrwTwK1hJARMg=="],
+    "@tailwindcss/oxide-linux-arm64-musl": ["@tailwindcss/oxide-linux-arm64-musl@4.3.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-Z6sukiQsngnWO+l39X4pPbiWT81IC+PLKF+PHxIlyZbGNb9MODfYlXEVlFvej5BOZInWX01kVyzeLvHsXhfczQ=="],
 
-    "@tailwindcss/oxide-linux-x64-gnu": ["@tailwindcss/oxide-linux-x64-gnu@4.1.17", "", { "os": "linux", "cpu": "x64" }, "sha512-M3XZuORCGB7VPOEDH+nzpJ21XPvK5PyjlkSFkFziNHGLc5d6g3di2McAAblmaSUNl8IOmzYwLx9NsE7bplNkwQ=="],
+    "@tailwindcss/oxide-linux-x64-gnu": ["@tailwindcss/oxide-linux-x64-gnu@4.3.0", "", { "os": "linux", "cpu": "x64" }, "sha512-DRNdQRpSGzRGfARVuVkxvM8Q12nh19l4BF/G7zGA1oe+9wcC6saFBHTISrpIcKzhiXtSrlSrluCfvMuledoCTQ=="],
 
-    "@tailwindcss/oxide-linux-x64-musl": ["@tailwindcss/oxide-linux-x64-musl@4.1.17", "", { "os": "linux", "cpu": "x64" }, "sha512-k7f+pf9eXLEey4pBlw+8dgfJHY4PZ5qOUFDyNf7SI6lHjQ9Zt7+NcscjpwdCEbYi6FI5c2KDTDWyf2iHcCSyyQ=="],
+    "@tailwindcss/oxide-linux-x64-musl": ["@tailwindcss/oxide-linux-x64-musl@4.3.0", "", { "os": "linux", "cpu": "x64" }, "sha512-Z0IADbDo8bh6I7h2IQMx601AdXBLfFpEdUotft86evd/8ZPflZe9COPO8Q1vw+pfLWIUo9zN/JGZvwuAJqduqg=="],
 
-    "@tailwindcss/oxide-wasm32-wasi": ["@tailwindcss/oxide-wasm32-wasi@4.1.17", "", { "dependencies": { "@emnapi/core": "^1.6.0", "@emnapi/runtime": "^1.6.0", "@emnapi/wasi-threads": "^1.1.0", "@napi-rs/wasm-runtime": "^1.0.7", "@tybys/wasm-util": "^0.10.1", "tslib": "^2.4.0" }, "cpu": "none" }, "sha512-cEytGqSSoy7zK4JRWiTCx43FsKP/zGr0CsuMawhH67ONlH+T79VteQeJQRO/X7L0juEUA8ZyuYikcRBf0vsxhg=="],
+    "@tailwindcss/oxide-wasm32-wasi": ["@tailwindcss/oxide-wasm32-wasi@4.3.0", "", { "dependencies": { "@emnapi/core": "^1.10.0", "@emnapi/runtime": "^1.10.0", "@emnapi/wasi-threads": "^1.2.1", "@napi-rs/wasm-runtime": "^1.1.4", "@tybys/wasm-util": "^0.10.1", "tslib": "^2.8.1" }, "cpu": "none" }, "sha512-HNZGOUxEmElksYR7S6sC5jTeNGpobAsy9u7Gu0AskJ8/20FR9GqebUyB+HBcU/ax6BHuiuJi+Oda4B+YX6H1yA=="],
 
-    "@tailwindcss/oxide-win32-arm64-msvc": ["@tailwindcss/oxide-win32-arm64-msvc@4.1.17", "", { "os": "win32", "cpu": "arm64" }, "sha512-JU5AHr7gKbZlOGvMdb4722/0aYbU+tN6lv1kONx0JK2cGsh7g148zVWLM0IKR3NeKLv+L90chBVYcJ8uJWbC9A=="],
+    "@tailwindcss/oxide-win32-arm64-msvc": ["@tailwindcss/oxide-win32-arm64-msvc@4.3.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-Pe+RPVTi1T+qymuuRpcdvwSVZjnll/f7n8gBxMMh3xLTctMDKqpdfGimbMyioqtLhUYZxdJ9wGNhV7MKHvgZsQ=="],
 
-    "@tailwindcss/oxide-win32-x64-msvc": ["@tailwindcss/oxide-win32-x64-msvc@4.1.17", "", { "os": "win32", "cpu": "x64" }, "sha512-SKWM4waLuqx0IH+FMDUw6R66Hu4OuTALFgnleKbqhgGU30DY20NORZMZUKgLRjQXNN2TLzKvh48QXTig4h4bGw=="],
+    "@tailwindcss/oxide-win32-x64-msvc": ["@tailwindcss/oxide-win32-x64-msvc@4.3.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Mvrf2kXW/yeW/OTezZlCGOirXRcUuLIBx/5Y12BaPM7wJoryG6dfS/NJL8aBPqtTEx/Vm4T4vKzFUcKDT+TKUA=="],
 
-    "@tailwindcss/postcss": ["@tailwindcss/postcss@4.1.17", "", { "dependencies": { "@alloc/quick-lru": "^5.2.0", "@tailwindcss/node": "4.1.17", "@tailwindcss/oxide": "4.1.17", "postcss": "^8.4.41", "tailwindcss": "4.1.17" } }, "sha512-+nKl9N9mN5uJ+M7dBOOCzINw94MPstNR/GtIhz1fpZysxL/4a+No64jCBD6CPN+bIHWFx3KWuu8XJRrj/572Dw=="],
+    "@tailwindcss/postcss": ["@tailwindcss/postcss@4.3.0", "", { "dependencies": { "@alloc/quick-lru": "^5.2.0", "@tailwindcss/node": "4.3.0", "@tailwindcss/oxide": "4.3.0", "postcss": "^8.5.10", "tailwindcss": "4.3.0" } }, "sha512-Jm05Tjx+9yCLGv5qw1c+84Psds8MnyrEQYCB+FFk2lgGiUjlRqdxke4mVTuYrj2xnVZqKim2Apr5ySuQRYAw/w=="],
 
     "@tanstack/query-core": ["@tanstack/query-core@5.90.7", "", {}, "sha512-6PN65csiuTNfBMXqQUxQhCNdtm1rV+9kC9YwWAIKcaxAauq3Wu7p18j3gQY3YIBJU70jT/wzCCZ2uqto/vQgiQ=="],
 
@@ -619,13 +699,25 @@
 
     "@types/d3-timer": ["@types/d3-timer@3.0.2", "", {}, "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw=="],
 
+    "@types/debug": ["@types/debug@4.1.13", "", { "dependencies": { "@types/ms": "*" } }, "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw=="],
+
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
+
+    "@types/estree-jsx": ["@types/estree-jsx@1.0.5", "", { "dependencies": { "@types/estree": "*" } }, "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg=="],
+
+    "@types/hast": ["@types/hast@3.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ=="],
 
     "@types/hoist-non-react-statics": ["@types/hoist-non-react-statics@3.3.7", "", { "dependencies": { "hoist-non-react-statics": "^3.3.0" }, "peerDependencies": { "@types/react": "*" } }, "sha512-PQTyIulDkIDro8P+IHbKCsw7U2xxBYflVzW/FgWdCAePD9xGSidgA76/GeJ6lBKoblyhf9pBY763gbrN+1dI8g=="],
 
     "@types/json-schema": ["@types/json-schema@7.0.15", "", {}, "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="],
 
     "@types/json5": ["@types/json5@0.0.29", "", {}, "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ=="],
+
+    "@types/mdast": ["@types/mdast@4.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA=="],
+
+    "@types/mdx": ["@types/mdx@2.0.13", "", {}, "sha512-+OWZQfAYyio6YkJb3HLxDrvnx6SWWDbC0zVPfBRzUk0/nqoDyf6dNxQi3eArPe8rJ473nobTMQ/8Zk+LxJ+Yuw=="],
+
+    "@types/ms": ["@types/ms@2.1.0", "", {}, "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA=="],
 
     "@types/node": ["@types/node@20.19.24", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-FE5u0ezmi6y9OZEzlJfg37mqqf6ZDSF2V/NLjUyGrR9uTZ7Sb9F7bLNZ03S4XVUNRWGA7Ck4c1kK+YnuWjl+DA=="],
 
@@ -634,6 +726,8 @@
     "@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
 
     "@types/react-redux": ["@types/react-redux@7.1.34", "", { "dependencies": { "@types/hoist-non-react-statics": "^3.3.0", "@types/react": "*", "hoist-non-react-statics": "^3.3.0", "redux": "^4.0.0" } }, "sha512-GdFaVjEbYv4Fthm2ZLvj1VSCedV7TqE5y1kNwnjSdBOTXuRSgowux6J8TAct15T3CKBr63UMk+2CO7ilRhyrAQ=="],
+
+    "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
 
     "@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@8.46.3", "", { "dependencies": { "@eslint-community/regexpp": "^4.10.0", "@typescript-eslint/scope-manager": "8.46.3", "@typescript-eslint/type-utils": "8.46.3", "@typescript-eslint/utils": "8.46.3", "@typescript-eslint/visitor-keys": "8.46.3", "graphemer": "^1.4.0", "ignore": "^7.0.0", "natural-compare": "^1.4.0", "ts-api-utils": "^2.1.0" }, "peerDependencies": { "@typescript-eslint/parser": "^8.46.3", "eslint": "^8.57.0 || ^9.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-sbaQ27XBUopBkRiuY/P9sWGOWUW4rl8fDoHIUmLpZd8uldsTyB4/Zg6bWTegPoTLnKj9Hqgn3QD6cjPNB32Odw=="],
 
@@ -654,6 +748,8 @@
     "@typescript-eslint/utils": ["@typescript-eslint/utils@8.46.3", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.7.0", "@typescript-eslint/scope-manager": "8.46.3", "@typescript-eslint/types": "8.46.3", "@typescript-eslint/typescript-estree": "8.46.3" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-VXw7qmdkucEx9WkmR3ld/u6VhRyKeiF1uxWwCy/iuNfokjJ7VhsgLSOTjsol8BunSw190zABzpwdNsze2Kpo4g=="],
 
     "@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.46.3", "", { "dependencies": { "@typescript-eslint/types": "8.46.3", "eslint-visitor-keys": "^4.2.1" } }, "sha512-uk574k8IU0rOF/AjniX8qbLSGURJVUCeM5e4MIMKBFFi8weeiLrG1fyQejyLXQpRZbU/1BuQasleV/RfHC3hHg=="],
+
+    "@ungap/structured-clone": ["@ungap/structured-clone@1.3.1", "", {}, "sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ=="],
 
     "@univerjs-pro/collaboration": ["@univerjs-pro/collaboration@0.8.3", "", { "dependencies": { "@univerjs-pro/license": "0.8.3", "@univerjs/core": "0.8.3", "@univerjs/data-validation": "0.8.3", "@univerjs/docs": "0.8.3", "@univerjs/engine-formula": "0.8.3", "@univerjs/protocol": "0.1.47-alpha.0", "@univerjs/sheets": "0.8.3", "@univerjs/sheets-conditional-formatting": "0.8.3", "@univerjs/sheets-drawing": "0.8.3", "@univerjs/sheets-filter": "0.8.3", "@univerjs/sheets-hyper-link": "0.8.3", "@univerjs/thread-comment": "0.8.3", "uuid": "^11.1.0" } }, "sha512-//tdxA30wCGSKLPcfAU2BtrM3VWRcVx8gv8Um3s5XENhM0o8OY5jfXjk3CMENQY9aTiTLse+zzkHRRCI/ikhVg=="],
 
@@ -953,6 +1049,8 @@
 
     "ast-types-flow": ["ast-types-flow@0.0.8", "", {}, "sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ=="],
 
+    "astring": ["astring@1.9.0", "", { "bin": { "astring": "bin/astring" } }, "sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg=="],
+
     "async-function": ["async-function@1.0.0", "", {}, "sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA=="],
 
     "async-lock": ["async-lock@1.4.1", "", {}, "sha512-Az2ZTpuytrtqENulXwO3GGv1Bztugx6TT37NIo7imr/Qo0gsYiGtSdBa2B6fsXhTpVZDNfu1Qn3pk531e3q+nQ=="],
@@ -962,6 +1060,8 @@
     "axe-core": ["axe-core@4.11.0", "", {}, "sha512-ilYanEU8vxxBexpJd8cWM4ElSQq4QctCLKih0TSfjIfCQTeyH/6zVrmIJfLPrKTKJRbiG+cfnZbQIjAlJmF1jQ=="],
 
     "axobject-query": ["axobject-query@4.1.0", "", {}, "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ=="],
+
+    "bail": ["bail@2.0.2", "", {}, "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw=="],
 
     "balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 
@@ -983,9 +1083,21 @@
 
     "caniuse-lite": ["caniuse-lite@1.0.30001754", "", {}, "sha512-x6OeBXueoAceOmotzx3PO4Zpt4rzpeIFsSr6AAePTZxSkXiYDUmpypEl7e2+8NCd9bD7bXjqyef8CJYPC1jfxg=="],
 
+    "ccount": ["ccount@2.0.1", "", {}, "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg=="],
+
     "cfb": ["cfb@1.2.2", "", { "dependencies": { "adler-32": "~1.3.0", "crc-32": "~1.2.0" } }, "sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA=="],
 
     "chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
+
+    "character-entities": ["character-entities@2.0.2", "", {}, "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ=="],
+
+    "character-entities-html4": ["character-entities-html4@2.1.0", "", {}, "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA=="],
+
+    "character-entities-legacy": ["character-entities-legacy@3.0.0", "", {}, "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ=="],
+
+    "character-reference-invalid": ["character-reference-invalid@2.0.1", "", {}, "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw=="],
+
+    "chokidar": ["chokidar@5.0.0", "", { "dependencies": { "readdirp": "^5.0.0" } }, "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw=="],
 
     "cjk-regex": ["cjk-regex@3.4.0", "", { "dependencies": { "regexp-util": "^2.0.3", "unicode-regex": "^4.2.0" } }, "sha512-m+gbmlIP6gAG7tDvo2kpeSPAz/uh5wY5/zx10ymjdpbbiTHNTNoYnP2lCiyqtmbLxwhEdq8/lsVbsy4GTc9oUw=="],
 
@@ -1009,7 +1121,11 @@
 
     "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
 
+    "comma-separated-tokens": ["comma-separated-tokens@2.0.3", "", {}, "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg=="],
+
     "commander": ["commander@2.17.1", "", {}, "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg=="],
+
+    "compute-scroll-into-view": ["compute-scroll-into-view@3.1.1", "", {}, "sha512-VRhuHOLoKYOy4UbilLbUzbYg93XLjv2PncJC50EuTWPA3gaja1UjBsUP/D/9/juV3vQFr6XBEzn9KCAHdUvOHw=="],
 
     "concat-map": ["concat-map@0.0.1", "", {}, "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="],
 
@@ -1067,15 +1183,21 @@
 
     "decimal.js-light": ["decimal.js-light@2.5.1", "", {}, "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg=="],
 
+    "decode-named-character-reference": ["decode-named-character-reference@1.3.0", "", { "dependencies": { "character-entities": "^2.0.0" } }, "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q=="],
+
     "deep-is": ["deep-is@0.1.4", "", {}, "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="],
 
     "define-data-property": ["define-data-property@1.1.4", "", { "dependencies": { "es-define-property": "^1.0.0", "es-errors": "^1.3.0", "gopd": "^1.0.1" } }, "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A=="],
 
     "define-properties": ["define-properties@1.2.1", "", { "dependencies": { "define-data-property": "^1.0.1", "has-property-descriptors": "^1.0.0", "object-keys": "^1.1.1" } }, "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg=="],
 
+    "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
+
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
 
     "detect-node-es": ["detect-node-es@1.1.0", "", {}, "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ=="],
+
+    "devlop": ["devlop@1.1.0", "", { "dependencies": { "dequal": "^2.0.0" } }, "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA=="],
 
     "doctrine": ["doctrine@2.1.0", "", { "dependencies": { "esutils": "^2.0.2" } }, "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw=="],
 
@@ -1093,9 +1215,9 @@
 
     "emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
 
-    "enhanced-resolve": ["enhanced-resolve@5.18.3", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.2.0" } }, "sha512-d4lC8xfavMeBjzGr2vECC3fsGXziXZQyJxD868h2M/mBI3PwAuODxAkLkq5HYuvrPYcUtiLzsTo8U3PgX3Ocww=="],
+    "enhanced-resolve": ["enhanced-resolve@5.22.0", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.3" } }, "sha512-xYcDWrpELkFzz9SpZ3PlI6Eu6eD93Yf0WLDRxikGhWJ3MAir2SNZTIVCVZqZ/NUyx8AdMc2gT9C0gPiw18kG+A=="],
 
-    "entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
+    "entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
 
     "es-abstract": ["es-abstract@1.24.0", "", { "dependencies": { "array-buffer-byte-length": "^1.0.2", "arraybuffer.prototype.slice": "^1.0.4", "available-typed-arrays": "^1.0.7", "call-bind": "^1.0.8", "call-bound": "^1.0.4", "data-view-buffer": "^1.0.2", "data-view-byte-length": "^1.0.2", "data-view-byte-offset": "^1.0.1", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "es-set-tostringtag": "^2.1.0", "es-to-primitive": "^1.3.0", "function.prototype.name": "^1.1.8", "get-intrinsic": "^1.3.0", "get-proto": "^1.0.1", "get-symbol-description": "^1.1.0", "globalthis": "^1.0.4", "gopd": "^1.2.0", "has-property-descriptors": "^1.0.2", "has-proto": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "internal-slot": "^1.1.0", "is-array-buffer": "^3.0.5", "is-callable": "^1.2.7", "is-data-view": "^1.0.2", "is-negative-zero": "^2.0.3", "is-regex": "^1.2.1", "is-set": "^2.0.3", "is-shared-array-buffer": "^1.0.4", "is-string": "^1.1.1", "is-typed-array": "^1.1.15", "is-weakref": "^1.1.1", "math-intrinsics": "^1.1.0", "object-inspect": "^1.13.4", "object-keys": "^1.1.1", "object.assign": "^4.1.7", "own-keys": "^1.0.1", "regexp.prototype.flags": "^1.5.4", "safe-array-concat": "^1.1.3", "safe-push-apply": "^1.0.0", "safe-regex-test": "^1.1.0", "set-proto": "^1.0.0", "stop-iteration-iterator": "^1.1.0", "string.prototype.trim": "^1.2.10", "string.prototype.trimend": "^1.0.9", "string.prototype.trimstart": "^1.0.8", "typed-array-buffer": "^1.0.3", "typed-array-byte-length": "^1.0.3", "typed-array-byte-offset": "^1.0.4", "typed-array-length": "^1.0.7", "unbox-primitive": "^1.1.0", "which-typed-array": "^1.1.19" } }, "sha512-WSzPgsdLtTcQwm4CROfS5ju2Wa1QQcVeT37jFjYzdFz1r9ahadC8B8/a4qxJxM+09F18iumCdRmlr96ZYkQvEg=="],
 
@@ -1112,6 +1234,12 @@
     "es-shim-unscopables": ["es-shim-unscopables@1.1.0", "", { "dependencies": { "hasown": "^2.0.2" } }, "sha512-d9T8ucsEhh8Bi1woXCf+TIKDIROLG5WCkxg8geBCbvk22kzwC5G2OnXVMO6FUsvQlgUUXQ2itephWDLqDzbeCw=="],
 
     "es-to-primitive": ["es-to-primitive@1.3.0", "", { "dependencies": { "is-callable": "^1.2.7", "is-date-object": "^1.0.5", "is-symbol": "^1.0.4" } }, "sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g=="],
+
+    "esast-util-from-estree": ["esast-util-from-estree@2.0.0", "", { "dependencies": { "@types/estree-jsx": "^1.0.0", "devlop": "^1.0.0", "estree-util-visit": "^2.0.0", "unist-util-position-from-estree": "^2.0.0" } }, "sha512-4CyanoAudUSBAn5K13H4JhsMH6L9ZP7XbLVe/dKybkxMO7eDyLsT8UHl9TRNrU2Gr9nz+FovfSIjuXWJ81uVwQ=="],
+
+    "esast-util-from-js": ["esast-util-from-js@2.0.1", "", { "dependencies": { "@types/estree-jsx": "^1.0.0", "acorn": "^8.0.0", "esast-util-from-estree": "^2.0.0", "vfile-message": "^4.0.0" } }, "sha512-8Ja+rNJ0Lt56Pcf3TAmpBZjmx8ZcK5Ts4cAzIOjsjevg9oSXJnl6SUQ2EevU8tv3h6ZLWmoKL5H4fgWvdvfETw=="],
+
+    "esbuild": ["esbuild@0.28.0", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.28.0", "@esbuild/android-arm": "0.28.0", "@esbuild/android-arm64": "0.28.0", "@esbuild/android-x64": "0.28.0", "@esbuild/darwin-arm64": "0.28.0", "@esbuild/darwin-x64": "0.28.0", "@esbuild/freebsd-arm64": "0.28.0", "@esbuild/freebsd-x64": "0.28.0", "@esbuild/linux-arm": "0.28.0", "@esbuild/linux-arm64": "0.28.0", "@esbuild/linux-ia32": "0.28.0", "@esbuild/linux-loong64": "0.28.0", "@esbuild/linux-mips64el": "0.28.0", "@esbuild/linux-ppc64": "0.28.0", "@esbuild/linux-riscv64": "0.28.0", "@esbuild/linux-s390x": "0.28.0", "@esbuild/linux-x64": "0.28.0", "@esbuild/netbsd-arm64": "0.28.0", "@esbuild/netbsd-x64": "0.28.0", "@esbuild/openbsd-arm64": "0.28.0", "@esbuild/openbsd-x64": "0.28.0", "@esbuild/openharmony-arm64": "0.28.0", "@esbuild/sunos-x64": "0.28.0", "@esbuild/win32-arm64": "0.28.0", "@esbuild/win32-ia32": "0.28.0", "@esbuild/win32-x64": "0.28.0" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw=="],
 
     "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
 
@@ -1147,13 +1275,29 @@
 
     "estraverse": ["estraverse@5.3.0", "", {}, "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="],
 
-    "estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
+    "estree-util-attach-comments": ["estree-util-attach-comments@3.0.0", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-cKUwm/HUcTDsYh/9FgnuFqpfquUbwIqwKM26BVCGDPVgvaCl/nDCCjUfiLlx6lsEZ3Z4RFxNbOQ60pkaEwFxGw=="],
+
+    "estree-util-build-jsx": ["estree-util-build-jsx@3.0.1", "", { "dependencies": { "@types/estree-jsx": "^1.0.0", "devlop": "^1.0.0", "estree-util-is-identifier-name": "^3.0.0", "estree-walker": "^3.0.0" } }, "sha512-8U5eiL6BTrPxp/CHbs2yMgP8ftMhR5ww1eIKoWRMlqvltHF8fZn5LRDvTKuxD3DUn+shRbLGqXemcP51oFCsGQ=="],
+
+    "estree-util-is-identifier-name": ["estree-util-is-identifier-name@3.0.0", "", {}, "sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg=="],
+
+    "estree-util-scope": ["estree-util-scope@1.0.0", "", { "dependencies": { "@types/estree": "^1.0.0", "devlop": "^1.0.0" } }, "sha512-2CAASclonf+JFWBNJPndcOpA8EMJwa0Q8LUFJEKqXLW6+qBvbFZuF5gItbQOs/umBUkjviCSDCbBwU2cXbmrhQ=="],
+
+    "estree-util-to-js": ["estree-util-to-js@2.0.0", "", { "dependencies": { "@types/estree-jsx": "^1.0.0", "astring": "^1.8.0", "source-map": "^0.7.0" } }, "sha512-WDF+xj5rRWmD5tj6bIqRi6CkLIXbbNQUcxQHzGysQzvHmdYG2G7p/Tf0J0gpxGgkeMZNTIjT/AoSvC9Xehcgdg=="],
+
+    "estree-util-value-to-estree": ["estree-util-value-to-estree@3.5.0", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-aMV56R27Gv3QmfmF1MY12GWkGzzeAezAX+UplqHVASfjc9wNzI/X6hC0S9oxq61WT4aQesLGslWP9tKk6ghRZQ=="],
+
+    "estree-util-visit": ["estree-util-visit@2.0.0", "", { "dependencies": { "@types/estree-jsx": "^1.0.0", "@types/unist": "^3.0.0" } }, "sha512-m5KgiH85xAhhW8Wta0vShLcUvOsh3LLPI2YVwcbio1l7E09NTLL1EyMZFM1OyWowoH0skScNbhOPl4kcBgzTww=="],
+
+    "estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
 
     "esutils": ["esutils@2.0.3", "", {}, "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="],
 
     "eventemitter3": ["eventemitter3@4.0.7", "", {}, "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="],
 
     "exit-on-epipe": ["exit-on-epipe@1.0.1", "", {}, "sha512-h2z5mrROTxce56S+pnvAV890uu7ls7f1kEvVGJbw1OlFH3/mlJ5bkXu0KRyW94v37zzHPiUd55iLn3DA7TjWpw=="],
+
+    "extend": ["extend@3.0.2", "", {}, "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="],
 
     "fast-check": ["fast-check@3.23.2", "", { "dependencies": { "pure-rand": "^6.1.0" } }, "sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A=="],
 
@@ -1193,9 +1337,15 @@
 
     "frac": ["frac@1.1.2", "", {}, "sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA=="],
 
-    "framer-motion": ["framer-motion@12.34.0", "", { "dependencies": { "motion-dom": "^12.34.0", "motion-utils": "^12.29.2", "tslib": "^2.4.0" }, "peerDependencies": { "@emotion/is-prop-valid": "*", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@emotion/is-prop-valid", "react", "react-dom"] }, "sha512-+/H49owhzkzQyxtn7nZeF4kdH++I2FWrESQ184Zbcw5cEqNHYkE5yxWxcTLSj5lNx3NWdbIRy5FHqUvetD8FWg=="],
+    "framer-motion": ["framer-motion@12.40.0", "", { "dependencies": { "motion-dom": "^12.40.0", "motion-utils": "^12.39.0", "tslib": "^2.4.0" }, "peerDependencies": { "@emotion/is-prop-valid": "*", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@emotion/is-prop-valid", "react", "react-dom"] }, "sha512-uaBd3qC1v3KQqBEjwTUd183K6PbS+j0yR9w9VmEOLWA/tnUcSn8Xa3uck7t4dgpDoUss8xQTcj8W2L07lrnLFg=="],
 
     "franc-min": ["franc-min@6.2.0", "", { "dependencies": { "trigram-utils": "^2.0.0" } }, "sha512-1uDIEUSlUZgvJa2AKYR/dmJC66v/PvGQ9mWfI9nOr/kPpMFyvswK0gPXOwpYJYiYD008PpHLkGfG58SPjQJFxw=="],
+
+    "fumadocs-core": ["fumadocs-core@16.9.1", "", { "dependencies": { "@orama/orama": "^3.1.18", "estree-util-value-to-estree": "^3.5.0", "github-slugger": "^2.0.0", "hast-util-to-estree": "^3.1.3", "hast-util-to-jsx-runtime": "^2.3.6", "js-yaml": "^4.1.1", "mdast-util-mdx": "^3.0.0", "mdast-util-to-markdown": "^2.1.2", "remark": "^15.0.1", "remark-gfm": "^4.0.1", "remark-rehype": "^11.1.2", "scroll-into-view-if-needed": "^3.1.0", "shiki": "^4.0.2", "tinyglobby": "^0.2.16", "unified": "^11.0.5", "unist-util-visit": "^5.1.0", "vfile": "^6.0.3" }, "peerDependencies": { "@mdx-js/mdx": "*", "@mixedbread/sdk": "0.x.x", "@orama/core": "1.x.x", "@oramacloud/client": "2.x.x", "@tanstack/react-router": "1.x.x", "@types/estree-jsx": "*", "@types/hast": "*", "@types/mdast": "*", "@types/react": "*", "algoliasearch": "5.x.x", "flexsearch": "*", "lucide-react": "*", "next": "16.x.x", "react": "^19.2.0", "react-dom": "^19.2.0", "react-router": "7.x.x", "waku": "*", "zod": "4.x.x" }, "optionalPeers": ["@mdx-js/mdx", "@mixedbread/sdk", "@orama/core", "@oramacloud/client", "@tanstack/react-router", "@types/estree-jsx", "@types/hast", "@types/mdast", "@types/react", "algoliasearch", "flexsearch", "lucide-react", "next", "react", "react-dom", "react-router", "waku", "zod"] }, "sha512-8VW4aD1iG5SrCChRq84QpNyjKY69i5WfUFFgtx/LSUuX1RewWb0qps7DhKLSjOWraemhZatzsZ7iceivJmYRTg=="],
+
+    "fumadocs-mdx": ["fumadocs-mdx@15.0.8", "", { "dependencies": { "@mdx-js/mdx": "^3.1.1", "@standard-schema/spec": "^1.1.0", "chokidar": "^5.0.0", "esbuild": "^0.28.0", "estree-util-value-to-estree": "^3.5.0", "js-yaml": "^4.1.1", "mdast-util-mdx": "^3.0.0", "picocolors": "^1.1.1", "picomatch": "^4.0.4", "tinyexec": "^1.1.2", "tinyglobby": "^0.2.16", "unified": "^11.0.5", "unist-util-remove-position": "^5.0.0", "unist-util-visit": "^5.1.0", "vfile": "^6.0.3", "zod": "^4.4.3" }, "peerDependencies": { "@types/mdast": "*", "@types/mdx": "*", "@types/react": "*", "fumadocs-core": "^16.7.0", "mdast-util-directive": "*", "next": "^15.3.0 || ^16.0.0", "react": "^19.2.0", "rolldown": "*", "vite": "7.x.x || 8.x.x" }, "optionalPeers": ["@types/mdast", "@types/mdx", "@types/react", "mdast-util-directive", "next", "react", "rolldown", "vite"], "bin": { "fumadocs-mdx": "./bin.js" } }, "sha512-CT9odtkLmpjH/DOTEW8prKY6SYzr7rmHmJj+ZBkvppPMNFstvTLvxxpY0ri8/9RPmCTZQUUMdNBxcPzhsHIcgw=="],
+
+    "fumadocs-ui": ["fumadocs-ui@16.9.1", "", { "dependencies": { "@fumadocs/tailwind": "0.0.5", "@radix-ui/react-accordion": "^1.2.12", "@radix-ui/react-collapsible": "^1.1.12", "@radix-ui/react-dialog": "^1.1.15", "@radix-ui/react-direction": "^1.1.1", "@radix-ui/react-navigation-menu": "^1.2.14", "@radix-ui/react-popover": "^1.1.15", "@radix-ui/react-presence": "^1.1.5", "@radix-ui/react-scroll-area": "^1.2.10", "@radix-ui/react-slot": "^1.2.4", "@radix-ui/react-tabs": "^1.1.13", "class-variance-authority": "^0.7.1", "lucide-react": "^1.16.0", "motion": "^12.38.0", "next-themes": "^0.4.6", "react-remove-scroll": "^2.7.2", "rehype-raw": "^7.0.0", "scroll-into-view-if-needed": "^3.1.0", "shiki": "^4.0.2", "tailwind-merge": "^3.6.0", "unist-util-visit": "^5.1.0" }, "peerDependencies": { "@takumi-rs/image-response": "*", "@types/mdx": "*", "@types/react": "*", "fumadocs-core": "16.9.1", "next": "16.x.x", "react": "^19.2.0", "react-dom": "^19.2.0" }, "optionalPeers": ["@takumi-rs/image-response", "@types/mdx", "@types/react", "next"] }, "sha512-2A8wO/RuoV0eOgabKMlcjBEPQKynbE4wkxoTfAj/E6bYCid/zY3DG+hhSI1Ssen5ws/73mFPacIEBsWhdAAsnw=="],
 
     "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
 
@@ -1218,6 +1368,8 @@
     "get-symbol-description": ["get-symbol-description@1.1.0", "", { "dependencies": { "call-bound": "^1.0.3", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.6" } }, "sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg=="],
 
     "get-tsconfig": ["get-tsconfig@4.13.0", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-1VKTZJCwBrvbd+Wn3AOgQP/2Av+TfTCOlE4AcRJE72W1ksZXbAx8PPBR9RzgTeSPzlPMHrbANMH3LbltH73wxQ=="],
+
+    "github-slugger": ["github-slugger@2.0.0", "", {}, "sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw=="],
 
     "glob-parent": ["glob-parent@6.0.2", "", { "dependencies": { "is-glob": "^4.0.3" } }, "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A=="],
 
@@ -1245,11 +1397,31 @@
 
     "hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
 
+    "hast-util-from-parse5": ["hast-util-from-parse5@8.0.3", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "devlop": "^1.0.0", "hastscript": "^9.0.0", "property-information": "^7.0.0", "vfile": "^6.0.0", "vfile-location": "^5.0.0", "web-namespaces": "^2.0.0" } }, "sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg=="],
+
+    "hast-util-parse-selector": ["hast-util-parse-selector@4.0.0", "", { "dependencies": { "@types/hast": "^3.0.0" } }, "sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A=="],
+
+    "hast-util-raw": ["hast-util-raw@9.1.0", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "@ungap/structured-clone": "^1.0.0", "hast-util-from-parse5": "^8.0.0", "hast-util-to-parse5": "^8.0.0", "html-void-elements": "^3.0.0", "mdast-util-to-hast": "^13.0.0", "parse5": "^7.0.0", "unist-util-position": "^5.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0", "web-namespaces": "^2.0.0", "zwitch": "^2.0.0" } }, "sha512-Y8/SBAHkZGoNkpzqqfCldijcuUKh7/su31kEBp67cFY09Wy0mTRgtsLYsiIxMJxlu0f6AA5SUTbDR8K0rxnbUw=="],
+
+    "hast-util-to-estree": ["hast-util-to-estree@3.1.3", "", { "dependencies": { "@types/estree": "^1.0.0", "@types/estree-jsx": "^1.0.0", "@types/hast": "^3.0.0", "comma-separated-tokens": "^2.0.0", "devlop": "^1.0.0", "estree-util-attach-comments": "^3.0.0", "estree-util-is-identifier-name": "^3.0.0", "hast-util-whitespace": "^3.0.0", "mdast-util-mdx-expression": "^2.0.0", "mdast-util-mdx-jsx": "^3.0.0", "mdast-util-mdxjs-esm": "^2.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0", "style-to-js": "^1.0.0", "unist-util-position": "^5.0.0", "zwitch": "^2.0.0" } }, "sha512-48+B/rJWAp0jamNbAAf9M7Uf//UVqAoMmgXhBdxTDJLGKY+LRnZ99qcG+Qjl5HfMpYNzS5v4EAwVEF34LeAj7w=="],
+
+    "hast-util-to-html": ["hast-util-to-html@9.0.5", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "ccount": "^2.0.0", "comma-separated-tokens": "^2.0.0", "hast-util-whitespace": "^3.0.0", "html-void-elements": "^3.0.0", "mdast-util-to-hast": "^13.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0", "stringify-entities": "^4.0.0", "zwitch": "^2.0.4" } }, "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw=="],
+
+    "hast-util-to-jsx-runtime": ["hast-util-to-jsx-runtime@2.3.6", "", { "dependencies": { "@types/estree": "^1.0.0", "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "comma-separated-tokens": "^2.0.0", "devlop": "^1.0.0", "estree-util-is-identifier-name": "^3.0.0", "hast-util-whitespace": "^3.0.0", "mdast-util-mdx-expression": "^2.0.0", "mdast-util-mdx-jsx": "^3.0.0", "mdast-util-mdxjs-esm": "^2.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0", "style-to-js": "^1.0.0", "unist-util-position": "^5.0.0", "vfile-message": "^4.0.0" } }, "sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg=="],
+
+    "hast-util-to-parse5": ["hast-util-to-parse5@8.0.1", "", { "dependencies": { "@types/hast": "^3.0.0", "comma-separated-tokens": "^2.0.0", "devlop": "^1.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0", "web-namespaces": "^2.0.0", "zwitch": "^2.0.0" } }, "sha512-MlWT6Pjt4CG9lFCjiz4BH7l9wmrMkfkJYCxFwKQic8+RTZgWPuWxwAfjJElsXkex7DJjfSJsQIt931ilUgmwdA=="],
+
+    "hast-util-whitespace": ["hast-util-whitespace@3.0.0", "", { "dependencies": { "@types/hast": "^3.0.0" } }, "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw=="],
+
+    "hastscript": ["hastscript@9.0.1", "", { "dependencies": { "@types/hast": "^3.0.0", "comma-separated-tokens": "^2.0.0", "hast-util-parse-selector": "^4.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0" } }, "sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w=="],
+
     "hermes-estree": ["hermes-estree@0.25.1", "", {}, "sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw=="],
 
     "hermes-parser": ["hermes-parser@0.25.1", "", { "dependencies": { "hermes-estree": "0.25.1" } }, "sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA=="],
 
     "hoist-non-react-statics": ["hoist-non-react-statics@3.3.2", "", { "dependencies": { "react-is": "^16.7.0" } }, "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw=="],
+
+    "html-void-elements": ["html-void-elements@3.0.0", "", {}, "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg=="],
 
     "ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
 
@@ -1259,9 +1431,15 @@
 
     "imurmurhash": ["imurmurhash@0.1.4", "", {}, "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA=="],
 
+    "inline-style-parser": ["inline-style-parser@0.2.7", "", {}, "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA=="],
+
     "internal-slot": ["internal-slot@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "hasown": "^2.0.2", "side-channel": "^1.1.0" } }, "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw=="],
 
     "internmap": ["internmap@2.0.3", "", {}, "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg=="],
+
+    "is-alphabetical": ["is-alphabetical@2.0.1", "", {}, "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ=="],
+
+    "is-alphanumerical": ["is-alphanumerical@2.0.1", "", { "dependencies": { "is-alphabetical": "^2.0.0", "is-decimal": "^2.0.0" } }, "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw=="],
 
     "is-array-buffer": ["is-array-buffer@3.0.5", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.3", "get-intrinsic": "^1.2.6" } }, "sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A=="],
 
@@ -1281,6 +1459,8 @@
 
     "is-date-object": ["is-date-object@1.1.0", "", { "dependencies": { "call-bound": "^1.0.2", "has-tostringtag": "^1.0.2" } }, "sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg=="],
 
+    "is-decimal": ["is-decimal@2.0.1", "", {}, "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A=="],
+
     "is-extglob": ["is-extglob@2.1.1", "", {}, "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="],
 
     "is-finalizationregistry": ["is-finalizationregistry@1.1.1", "", { "dependencies": { "call-bound": "^1.0.3" } }, "sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg=="],
@@ -1291,6 +1471,8 @@
 
     "is-glob": ["is-glob@4.0.3", "", { "dependencies": { "is-extglob": "^2.1.1" } }, "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg=="],
 
+    "is-hexadecimal": ["is-hexadecimal@2.0.1", "", {}, "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg=="],
+
     "is-map": ["is-map@2.0.3", "", {}, "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw=="],
 
     "is-negative-zero": ["is-negative-zero@2.0.3", "", {}, "sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw=="],
@@ -1298,6 +1480,8 @@
     "is-number": ["is-number@7.0.0", "", {}, "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="],
 
     "is-number-object": ["is-number-object@1.1.1", "", { "dependencies": { "call-bound": "^1.0.3", "has-tostringtag": "^1.0.2" } }, "sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw=="],
+
+    "is-plain-obj": ["is-plain-obj@4.1.0", "", {}, "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg=="],
 
     "is-regex": ["is-regex@1.2.1", "", { "dependencies": { "call-bound": "^1.0.2", "gopd": "^1.2.0", "has-tostringtag": "^1.0.2", "hasown": "^2.0.2" } }, "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g=="],
 
@@ -1327,7 +1511,7 @@
 
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
-    "js-yaml": ["js-yaml@4.1.0", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA=="],
+    "js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
 
     "jsesc": ["jsesc@3.1.0", "", { "bin": { "jsesc": "bin/jsesc" } }, "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA=="],
 
@@ -1355,29 +1539,29 @@
 
     "lie": ["lie@3.1.1", "", { "dependencies": { "immediate": "~3.0.5" } }, "sha512-RiNhHysUjhrDQntfYSfY4MU24coXXdEOgw9WGcKHNeEwffDYbF//u87M1EWaMGzuFoSbqW0C9C6lEEhDOAswfw=="],
 
-    "lightningcss": ["lightningcss@1.30.2", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.30.2", "lightningcss-darwin-arm64": "1.30.2", "lightningcss-darwin-x64": "1.30.2", "lightningcss-freebsd-x64": "1.30.2", "lightningcss-linux-arm-gnueabihf": "1.30.2", "lightningcss-linux-arm64-gnu": "1.30.2", "lightningcss-linux-arm64-musl": "1.30.2", "lightningcss-linux-x64-gnu": "1.30.2", "lightningcss-linux-x64-musl": "1.30.2", "lightningcss-win32-arm64-msvc": "1.30.2", "lightningcss-win32-x64-msvc": "1.30.2" } }, "sha512-utfs7Pr5uJyyvDETitgsaqSyjCb2qNRAtuqUeWIAKztsOYdcACf2KtARYXg2pSvhkt+9NfoaNY7fxjl6nuMjIQ=="],
+    "lightningcss": ["lightningcss@1.32.0", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.32.0", "lightningcss-darwin-arm64": "1.32.0", "lightningcss-darwin-x64": "1.32.0", "lightningcss-freebsd-x64": "1.32.0", "lightningcss-linux-arm-gnueabihf": "1.32.0", "lightningcss-linux-arm64-gnu": "1.32.0", "lightningcss-linux-arm64-musl": "1.32.0", "lightningcss-linux-x64-gnu": "1.32.0", "lightningcss-linux-x64-musl": "1.32.0", "lightningcss-win32-arm64-msvc": "1.32.0", "lightningcss-win32-x64-msvc": "1.32.0" } }, "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ=="],
 
-    "lightningcss-android-arm64": ["lightningcss-android-arm64@1.30.2", "", { "os": "android", "cpu": "arm64" }, "sha512-BH9sEdOCahSgmkVhBLeU7Hc9DWeZ1Eb6wNS6Da8igvUwAe0sqROHddIlvU06q3WyXVEOYDZ6ykBZQnjTbmo4+A=="],
+    "lightningcss-android-arm64": ["lightningcss-android-arm64@1.32.0", "", { "os": "android", "cpu": "arm64" }, "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg=="],
 
-    "lightningcss-darwin-arm64": ["lightningcss-darwin-arm64@1.30.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-ylTcDJBN3Hp21TdhRT5zBOIi73P6/W0qwvlFEk22fkdXchtNTOU4Qc37SkzV+EKYxLouZ6M4LG9NfZ1qkhhBWA=="],
+    "lightningcss-darwin-arm64": ["lightningcss-darwin-arm64@1.32.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ=="],
 
-    "lightningcss-darwin-x64": ["lightningcss-darwin-x64@1.30.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-oBZgKchomuDYxr7ilwLcyms6BCyLn0z8J0+ZZmfpjwg9fRVZIR5/GMXd7r9RH94iDhld3UmSjBM6nXWM2TfZTQ=="],
+    "lightningcss-darwin-x64": ["lightningcss-darwin-x64@1.32.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w=="],
 
-    "lightningcss-freebsd-x64": ["lightningcss-freebsd-x64@1.30.2", "", { "os": "freebsd", "cpu": "x64" }, "sha512-c2bH6xTrf4BDpK8MoGG4Bd6zAMZDAXS569UxCAGcA7IKbHNMlhGQ89eRmvpIUGfKWNVdbhSbkQaWhEoMGmGslA=="],
+    "lightningcss-freebsd-x64": ["lightningcss-freebsd-x64@1.32.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig=="],
 
-    "lightningcss-linux-arm-gnueabihf": ["lightningcss-linux-arm-gnueabihf@1.30.2", "", { "os": "linux", "cpu": "arm" }, "sha512-eVdpxh4wYcm0PofJIZVuYuLiqBIakQ9uFZmipf6LF/HRj5Bgm0eb3qL/mr1smyXIS1twwOxNWndd8z0E374hiA=="],
+    "lightningcss-linux-arm-gnueabihf": ["lightningcss-linux-arm-gnueabihf@1.32.0", "", { "os": "linux", "cpu": "arm" }, "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw=="],
 
-    "lightningcss-linux-arm64-gnu": ["lightningcss-linux-arm64-gnu@1.30.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-UK65WJAbwIJbiBFXpxrbTNArtfuznvxAJw4Q2ZGlU8kPeDIWEX1dg3rn2veBVUylA2Ezg89ktszWbaQnxD/e3A=="],
+    "lightningcss-linux-arm64-gnu": ["lightningcss-linux-arm64-gnu@1.32.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ=="],
 
-    "lightningcss-linux-arm64-musl": ["lightningcss-linux-arm64-musl@1.30.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-5Vh9dGeblpTxWHpOx8iauV02popZDsCYMPIgiuw97OJ5uaDsL86cnqSFs5LZkG3ghHoX5isLgWzMs+eD1YzrnA=="],
+    "lightningcss-linux-arm64-musl": ["lightningcss-linux-arm64-musl@1.32.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg=="],
 
-    "lightningcss-linux-x64-gnu": ["lightningcss-linux-x64-gnu@1.30.2", "", { "os": "linux", "cpu": "x64" }, "sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w=="],
+    "lightningcss-linux-x64-gnu": ["lightningcss-linux-x64-gnu@1.32.0", "", { "os": "linux", "cpu": "x64" }, "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA=="],
 
-    "lightningcss-linux-x64-musl": ["lightningcss-linux-x64-musl@1.30.2", "", { "os": "linux", "cpu": "x64" }, "sha512-XJaLUUFXb6/QG2lGIW6aIk6jKdtjtcffUT0NKvIqhSBY3hh9Ch+1LCeH80dR9q9LBjG3ewbDjnumefsLsP6aiA=="],
+    "lightningcss-linux-x64-musl": ["lightningcss-linux-x64-musl@1.32.0", "", { "os": "linux", "cpu": "x64" }, "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg=="],
 
-    "lightningcss-win32-arm64-msvc": ["lightningcss-win32-arm64-msvc@1.30.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-FZn+vaj7zLv//D/192WFFVA0RgHawIcHqLX9xuWiQt7P0PtdFEVaxgF9rjM/IRYHQXNnk61/H/gb2Ei+kUQ4xQ=="],
+    "lightningcss-win32-arm64-msvc": ["lightningcss-win32-arm64-msvc@1.32.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw=="],
 
-    "lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.30.2", "", { "os": "win32", "cpu": "x64" }, "sha512-5g1yc73p+iAkid5phb4oVFMB45417DkRevRbt/El/gKXJk4jid+vPFF/AXbxn05Aky8PapwzZrdJShv5C0avjw=="],
+    "lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.32.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q=="],
 
     "localforage": ["localforage@1.10.0", "", { "dependencies": { "lie": "3.1.1" } }, "sha512-14/H1aX7hzBBmmh7sGPd+AOMkkIrHM3Z1PAyGgZigA1H1p5O5ANnMyWzvpAETtG68/dC4pC0ncy3+PPGzXZHPg=="],
 
@@ -1393,6 +1577,8 @@
 
     "long": ["long@5.3.2", "", {}, "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA=="],
 
+    "longest-streak": ["longest-streak@3.1.0", "", {}, "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g=="],
+
     "loose-envify": ["loose-envify@1.4.0", "", { "dependencies": { "js-tokens": "^3.0.0 || ^4.0.0" }, "bin": { "loose-envify": "cli.js" } }, "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q=="],
 
     "lottie-react": ["lottie-react@2.4.1", "", { "dependencies": { "lottie-web": "^5.10.2" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-LQrH7jlkigIIv++wIyrOYFLHSKQpEY4zehPicL9bQsrt1rnoKRYCYgpCUe5maqylNtacy58/sQDZTkwMcTRxZw=="],
@@ -1405,11 +1591,117 @@
 
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
+    "markdown-extensions": ["markdown-extensions@2.0.0", "", {}, "sha512-o5vL7aDWatOTX8LzaS1WMoaoxIiLRQJuIKKe2wAw6IeULDHaqbiqiggmx+pKvZDb1Sj+pE46Sn1T7lCqfFtg1Q=="],
+
+    "markdown-table": ["markdown-table@3.0.4", "", {}, "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw=="],
+
     "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
+
+    "mdast-util-find-and-replace": ["mdast-util-find-and-replace@3.0.2", "", { "dependencies": { "@types/mdast": "^4.0.0", "escape-string-regexp": "^5.0.0", "unist-util-is": "^6.0.0", "unist-util-visit-parents": "^6.0.0" } }, "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg=="],
+
+    "mdast-util-from-markdown": ["mdast-util-from-markdown@2.0.3", "", { "dependencies": { "@types/mdast": "^4.0.0", "@types/unist": "^3.0.0", "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "mdast-util-to-string": "^4.0.0", "micromark": "^4.0.0", "micromark-util-decode-numeric-character-reference": "^2.0.0", "micromark-util-decode-string": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q=="],
+
+    "mdast-util-gfm": ["mdast-util-gfm@3.1.0", "", { "dependencies": { "mdast-util-from-markdown": "^2.0.0", "mdast-util-gfm-autolink-literal": "^2.0.0", "mdast-util-gfm-footnote": "^2.0.0", "mdast-util-gfm-strikethrough": "^2.0.0", "mdast-util-gfm-table": "^2.0.0", "mdast-util-gfm-task-list-item": "^2.0.0", "mdast-util-to-markdown": "^2.0.0" } }, "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ=="],
+
+    "mdast-util-gfm-autolink-literal": ["mdast-util-gfm-autolink-literal@2.0.1", "", { "dependencies": { "@types/mdast": "^4.0.0", "ccount": "^2.0.0", "devlop": "^1.0.0", "mdast-util-find-and-replace": "^3.0.0", "micromark-util-character": "^2.0.0" } }, "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ=="],
+
+    "mdast-util-gfm-footnote": ["mdast-util-gfm-footnote@2.1.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "devlop": "^1.1.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0" } }, "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ=="],
+
+    "mdast-util-gfm-strikethrough": ["mdast-util-gfm-strikethrough@2.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0" } }, "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg=="],
+
+    "mdast-util-gfm-table": ["mdast-util-gfm-table@2.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "devlop": "^1.0.0", "markdown-table": "^3.0.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0" } }, "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg=="],
+
+    "mdast-util-gfm-task-list-item": ["mdast-util-gfm-task-list-item@2.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "devlop": "^1.0.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0" } }, "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ=="],
+
+    "mdast-util-mdx": ["mdast-util-mdx@3.0.0", "", { "dependencies": { "mdast-util-from-markdown": "^2.0.0", "mdast-util-mdx-expression": "^2.0.0", "mdast-util-mdx-jsx": "^3.0.0", "mdast-util-mdxjs-esm": "^2.0.0", "mdast-util-to-markdown": "^2.0.0" } }, "sha512-JfbYLAW7XnYTTbUsmpu0kdBUVe+yKVJZBItEjwyYJiDJuZ9w4eeaqks4HQO+R7objWgS2ymV60GYpI14Ug554w=="],
+
+    "mdast-util-mdx-expression": ["mdast-util-mdx-expression@2.0.1", "", { "dependencies": { "@types/estree-jsx": "^1.0.0", "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "devlop": "^1.0.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0" } }, "sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ=="],
+
+    "mdast-util-mdx-jsx": ["mdast-util-mdx-jsx@3.2.0", "", { "dependencies": { "@types/estree-jsx": "^1.0.0", "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "@types/unist": "^3.0.0", "ccount": "^2.0.0", "devlop": "^1.1.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0", "parse-entities": "^4.0.0", "stringify-entities": "^4.0.0", "unist-util-stringify-position": "^4.0.0", "vfile-message": "^4.0.0" } }, "sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q=="],
+
+    "mdast-util-mdxjs-esm": ["mdast-util-mdxjs-esm@2.0.1", "", { "dependencies": { "@types/estree-jsx": "^1.0.0", "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "devlop": "^1.0.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0" } }, "sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg=="],
+
+    "mdast-util-phrasing": ["mdast-util-phrasing@4.1.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "unist-util-is": "^6.0.0" } }, "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w=="],
+
+    "mdast-util-to-hast": ["mdast-util-to-hast@13.2.1", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "@ungap/structured-clone": "^1.0.0", "devlop": "^1.0.0", "micromark-util-sanitize-uri": "^2.0.0", "trim-lines": "^3.0.0", "unist-util-position": "^5.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" } }, "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA=="],
+
+    "mdast-util-to-markdown": ["mdast-util-to-markdown@2.1.2", "", { "dependencies": { "@types/mdast": "^4.0.0", "@types/unist": "^3.0.0", "longest-streak": "^3.0.0", "mdast-util-phrasing": "^4.0.0", "mdast-util-to-string": "^4.0.0", "micromark-util-classify-character": "^2.0.0", "micromark-util-decode-string": "^2.0.0", "unist-util-visit": "^5.0.0", "zwitch": "^2.0.0" } }, "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA=="],
+
+    "mdast-util-to-string": ["mdast-util-to-string@4.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0" } }, "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg=="],
 
     "memoize-one": ["memoize-one@5.2.1", "", {}, "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q=="],
 
     "merge2": ["merge2@1.4.1", "", {}, "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="],
+
+    "micromark": ["micromark@4.0.2", "", { "dependencies": { "@types/debug": "^4.0.0", "debug": "^4.0.0", "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "micromark-core-commonmark": "^2.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-combine-extensions": "^2.0.0", "micromark-util-decode-numeric-character-reference": "^2.0.0", "micromark-util-encode": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-resolve-all": "^2.0.0", "micromark-util-sanitize-uri": "^2.0.0", "micromark-util-subtokenize": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA=="],
+
+    "micromark-core-commonmark": ["micromark-core-commonmark@2.0.3", "", { "dependencies": { "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "micromark-factory-destination": "^2.0.0", "micromark-factory-label": "^2.0.0", "micromark-factory-space": "^2.0.0", "micromark-factory-title": "^2.0.0", "micromark-factory-whitespace": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-classify-character": "^2.0.0", "micromark-util-html-tag-name": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-resolve-all": "^2.0.0", "micromark-util-subtokenize": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg=="],
+
+    "micromark-extension-gfm": ["micromark-extension-gfm@3.0.0", "", { "dependencies": { "micromark-extension-gfm-autolink-literal": "^2.0.0", "micromark-extension-gfm-footnote": "^2.0.0", "micromark-extension-gfm-strikethrough": "^2.0.0", "micromark-extension-gfm-table": "^2.0.0", "micromark-extension-gfm-tagfilter": "^2.0.0", "micromark-extension-gfm-task-list-item": "^2.0.0", "micromark-util-combine-extensions": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w=="],
+
+    "micromark-extension-gfm-autolink-literal": ["micromark-extension-gfm-autolink-literal@2.1.0", "", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-sanitize-uri": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw=="],
+
+    "micromark-extension-gfm-footnote": ["micromark-extension-gfm-footnote@2.1.0", "", { "dependencies": { "devlop": "^1.0.0", "micromark-core-commonmark": "^2.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-sanitize-uri": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw=="],
+
+    "micromark-extension-gfm-strikethrough": ["micromark-extension-gfm-strikethrough@2.1.0", "", { "dependencies": { "devlop": "^1.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-classify-character": "^2.0.0", "micromark-util-resolve-all": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw=="],
+
+    "micromark-extension-gfm-table": ["micromark-extension-gfm-table@2.1.1", "", { "dependencies": { "devlop": "^1.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg=="],
+
+    "micromark-extension-gfm-tagfilter": ["micromark-extension-gfm-tagfilter@2.0.0", "", { "dependencies": { "micromark-util-types": "^2.0.0" } }, "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg=="],
+
+    "micromark-extension-gfm-task-list-item": ["micromark-extension-gfm-task-list-item@2.1.0", "", { "dependencies": { "devlop": "^1.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw=="],
+
+    "micromark-extension-mdx-expression": ["micromark-extension-mdx-expression@3.0.1", "", { "dependencies": { "@types/estree": "^1.0.0", "devlop": "^1.0.0", "micromark-factory-mdx-expression": "^2.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-events-to-acorn": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-dD/ADLJ1AeMvSAKBwO22zG22N4ybhe7kFIZ3LsDI0GlsNr2A3KYxb0LdC1u5rj4Nw+CHKY0RVdnHX8vj8ejm4Q=="],
+
+    "micromark-extension-mdx-jsx": ["micromark-extension-mdx-jsx@3.0.2", "", { "dependencies": { "@types/estree": "^1.0.0", "devlop": "^1.0.0", "estree-util-is-identifier-name": "^3.0.0", "micromark-factory-mdx-expression": "^2.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-events-to-acorn": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0", "vfile-message": "^4.0.0" } }, "sha512-e5+q1DjMh62LZAJOnDraSSbDMvGJ8x3cbjygy2qFEi7HCeUT4BDKCvMozPozcD6WmOt6sVvYDNBKhFSz3kjOVQ=="],
+
+    "micromark-extension-mdx-md": ["micromark-extension-mdx-md@2.0.0", "", { "dependencies": { "micromark-util-types": "^2.0.0" } }, "sha512-EpAiszsB3blw4Rpba7xTOUptcFeBFi+6PY8VnJ2hhimH+vCQDirWgsMpz7w1XcZE7LVrSAUGb9VJpG9ghlYvYQ=="],
+
+    "micromark-extension-mdxjs": ["micromark-extension-mdxjs@3.0.0", "", { "dependencies": { "acorn": "^8.0.0", "acorn-jsx": "^5.0.0", "micromark-extension-mdx-expression": "^3.0.0", "micromark-extension-mdx-jsx": "^3.0.0", "micromark-extension-mdx-md": "^2.0.0", "micromark-extension-mdxjs-esm": "^3.0.0", "micromark-util-combine-extensions": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-A873fJfhnJ2siZyUrJ31l34Uqwy4xIFmvPY1oj+Ean5PHcPBYzEsvqvWGaWcfEIr11O5Dlw3p2y0tZWpKHDejQ=="],
+
+    "micromark-extension-mdxjs-esm": ["micromark-extension-mdxjs-esm@3.0.0", "", { "dependencies": { "@types/estree": "^1.0.0", "devlop": "^1.0.0", "micromark-core-commonmark": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-events-to-acorn": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0", "unist-util-position-from-estree": "^2.0.0", "vfile-message": "^4.0.0" } }, "sha512-DJFl4ZqkErRpq/dAPyeWp15tGrcrrJho1hKK5uBS70BCtfrIFg81sqcTVu3Ta+KD1Tk5vAtBNElWxtAa+m8K9A=="],
+
+    "micromark-factory-destination": ["micromark-factory-destination@2.0.1", "", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA=="],
+
+    "micromark-factory-label": ["micromark-factory-label@2.0.1", "", { "dependencies": { "devlop": "^1.0.0", "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg=="],
+
+    "micromark-factory-mdx-expression": ["micromark-factory-mdx-expression@2.0.3", "", { "dependencies": { "@types/estree": "^1.0.0", "devlop": "^1.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-events-to-acorn": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0", "unist-util-position-from-estree": "^2.0.0", "vfile-message": "^4.0.0" } }, "sha512-kQnEtA3vzucU2BkrIa8/VaSAsP+EJ3CKOvhMuJgOEGg9KDC6OAY6nSnNDVRiVNRqj7Y4SlSzcStaH/5jge8JdQ=="],
+
+    "micromark-factory-space": ["micromark-factory-space@2.0.1", "", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg=="],
+
+    "micromark-factory-title": ["micromark-factory-title@2.0.1", "", { "dependencies": { "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw=="],
+
+    "micromark-factory-whitespace": ["micromark-factory-whitespace@2.0.1", "", { "dependencies": { "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ=="],
+
+    "micromark-util-character": ["micromark-util-character@2.1.1", "", { "dependencies": { "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q=="],
+
+    "micromark-util-chunked": ["micromark-util-chunked@2.0.1", "", { "dependencies": { "micromark-util-symbol": "^2.0.0" } }, "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA=="],
+
+    "micromark-util-classify-character": ["micromark-util-classify-character@2.0.1", "", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q=="],
+
+    "micromark-util-combine-extensions": ["micromark-util-combine-extensions@2.0.1", "", { "dependencies": { "micromark-util-chunked": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg=="],
+
+    "micromark-util-decode-numeric-character-reference": ["micromark-util-decode-numeric-character-reference@2.0.2", "", { "dependencies": { "micromark-util-symbol": "^2.0.0" } }, "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw=="],
+
+    "micromark-util-decode-string": ["micromark-util-decode-string@2.0.1", "", { "dependencies": { "decode-named-character-reference": "^1.0.0", "micromark-util-character": "^2.0.0", "micromark-util-decode-numeric-character-reference": "^2.0.0", "micromark-util-symbol": "^2.0.0" } }, "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ=="],
+
+    "micromark-util-encode": ["micromark-util-encode@2.0.1", "", {}, "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw=="],
+
+    "micromark-util-events-to-acorn": ["micromark-util-events-to-acorn@2.0.3", "", { "dependencies": { "@types/estree": "^1.0.0", "@types/unist": "^3.0.0", "devlop": "^1.0.0", "estree-util-visit": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0", "vfile-message": "^4.0.0" } }, "sha512-jmsiEIiZ1n7X1Rr5k8wVExBQCg5jy4UXVADItHmNk1zkwEVhBuIUKRu3fqv+hs4nxLISi2DQGlqIOGiFxgbfHg=="],
+
+    "micromark-util-html-tag-name": ["micromark-util-html-tag-name@2.0.1", "", {}, "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA=="],
+
+    "micromark-util-normalize-identifier": ["micromark-util-normalize-identifier@2.0.1", "", { "dependencies": { "micromark-util-symbol": "^2.0.0" } }, "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q=="],
+
+    "micromark-util-resolve-all": ["micromark-util-resolve-all@2.0.1", "", { "dependencies": { "micromark-util-types": "^2.0.0" } }, "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg=="],
+
+    "micromark-util-sanitize-uri": ["micromark-util-sanitize-uri@2.0.1", "", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-encode": "^2.0.0", "micromark-util-symbol": "^2.0.0" } }, "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ=="],
+
+    "micromark-util-subtokenize": ["micromark-util-subtokenize@2.1.0", "", { "dependencies": { "devlop": "^1.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA=="],
+
+    "micromark-util-symbol": ["micromark-util-symbol@2.0.1", "", {}, "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q=="],
+
+    "micromark-util-types": ["micromark-util-types@2.0.2", "", {}, "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA=="],
 
     "micromatch": ["micromatch@4.0.8", "", { "dependencies": { "braces": "^3.0.3", "picomatch": "^2.3.1" } }, "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA=="],
 
@@ -1417,11 +1709,11 @@
 
     "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
 
-    "motion": ["motion@12.34.0", "", { "dependencies": { "framer-motion": "^12.34.0", "tslib": "^2.4.0" }, "peerDependencies": { "@emotion/is-prop-valid": "*", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@emotion/is-prop-valid", "react", "react-dom"] }, "sha512-01Sfa/zgsD/di8zA/uFW5Eb7/SPXoGyUfy+uMRMW5Spa8j0z/UbfQewAYvPMYFCXRlyD6e5aLHh76TxeeJD+RA=="],
+    "motion": ["motion@12.40.0", "", { "dependencies": { "framer-motion": "^12.40.0", "tslib": "^2.4.0" }, "peerDependencies": { "@emotion/is-prop-valid": "*", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@emotion/is-prop-valid", "react", "react-dom"] }, "sha512-yjrHUrBFW6kQvjJwRsoiPSAhC5tRwRqNGJWmiJ4CrGnbKp0V88AdzkhBmDoqIsIPfarOe0Uddd37Xq43/gIocA=="],
 
-    "motion-dom": ["motion-dom@12.34.0", "", { "dependencies": { "motion-utils": "^12.29.2" } }, "sha512-Lql3NuEcScRDxTAO6GgUsRHBZOWI/3fnMlkMcH5NftzcN37zJta+bpbMAV9px4Nj057TuvRooMK7QrzMCgtz6Q=="],
+    "motion-dom": ["motion-dom@12.40.0", "", { "dependencies": { "motion-utils": "^12.39.0" } }, "sha512-HxU3ZaBwNPVQUBQf1xxgq+7JrPNZvjLVxgbpEZL7RrWJnsxOf0/OM+yrHG9ogLQ31Do/r57Oz2gQWPK+6q62mg=="],
 
-    "motion-utils": ["motion-utils@12.29.2", "", {}, "sha512-G3kc34H2cX2gI63RqU+cZq+zWRRPSsNIOjpdl9TN4AQwC4sgwYPl/Q/Obf/d53nOm569T0fYK+tcoSV50BWx8A=="],
+    "motion-utils": ["motion-utils@12.39.0", "", {}, "sha512-8nadJAJjTtqRkmRF36FoJTrywK9nnFmnPwnSMyxaOCU7GDjN9RTMJIxx9De8ErM+vpPhMccr/6fo5WciyQLnMQ=="],
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
@@ -1433,7 +1725,7 @@
 
     "n-gram": ["n-gram@2.0.2", "", {}, "sha512-S24aGsn+HLBxUGVAUFOwGpKs7LBcG4RudKU//eWzt/mQ97/NMKQxDWHyHx63UNWk/OOdihgmzoETn1tf5nQDzQ=="],
 
-    "nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
+    "nanoid": ["nanoid@3.3.12", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ=="],
 
     "napi-postinstall": ["napi-postinstall@0.3.4", "", { "bin": { "napi-postinstall": "lib/cli.js" } }, "sha512-PHI5f1O0EP5xJ9gQmFGMS6IZcrVvTjpXjz7Na41gTE7eE2hK11lg04CECCYEEjdc17EV4DO+fkGEtt7TpTaTiQ=="],
 
@@ -1467,6 +1759,10 @@
 
     "oidc-client-ts": ["oidc-client-ts@3.3.0", "", { "dependencies": { "jwt-decode": "^4.0.0" } }, "sha512-t13S540ZwFOEZKLYHJwSfITugupW4uYLwuQSSXyKH/wHwZ+7FvgHE7gnNJh1YQIZ1Yd1hKSRjqeXGSUtS0r9JA=="],
 
+    "oniguruma-parser": ["oniguruma-parser@0.12.2", "", {}, "sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw=="],
+
+    "oniguruma-to-es": ["oniguruma-to-es@4.3.6", "", { "dependencies": { "oniguruma-parser": "^0.12.2", "regex": "^6.1.0", "regex-recursion": "^6.0.2" } }, "sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA=="],
+
     "opentype.js": ["opentype.js@1.3.4", "", { "dependencies": { "string.prototype.codepointat": "^0.2.1", "tiny-inflate": "^1.0.3" }, "bin": { "ot": "bin/ot" } }, "sha512-d2JE9RP/6uagpQAVtJoF0pJJA/fgai89Cc50Yp0EJHk+eLp6QQ7gBoblsnubRULNY132I0J1QKMJ+JTbMqz4sw=="],
 
     "optionator": ["optionator@0.9.4", "", { "dependencies": { "deep-is": "^0.1.3", "fast-levenshtein": "^2.0.6", "levn": "^0.4.1", "prelude-ls": "^1.2.1", "type-check": "^0.4.0", "word-wrap": "^1.2.5" } }, "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g=="],
@@ -1485,6 +1781,10 @@
 
     "parent-module": ["parent-module@1.0.1", "", { "dependencies": { "callsites": "^3.0.0" } }, "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g=="],
 
+    "parse-entities": ["parse-entities@4.0.2", "", { "dependencies": { "@types/unist": "^2.0.0", "character-entities-legacy": "^3.0.0", "character-reference-invalid": "^2.0.0", "decode-named-character-reference": "^1.0.0", "is-alphanumerical": "^2.0.0", "is-decimal": "^2.0.0", "is-hexadecimal": "^2.0.0" } }, "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw=="],
+
+    "parse5": ["parse5@7.3.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
+
     "path-exists": ["path-exists@4.0.0", "", {}, "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="],
 
     "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
@@ -1497,17 +1797,19 @@
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
-    "picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
+    "picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
 
     "possible-typed-array-names": ["possible-typed-array-names@1.1.0", "", {}, "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg=="],
 
-    "postcss": ["postcss@8.5.6", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg=="],
+    "postcss": ["postcss@8.5.15", "", { "dependencies": { "nanoid": "^3.3.12", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A=="],
 
     "prelude-ls": ["prelude-ls@1.2.1", "", {}, "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="],
 
     "printj": ["printj@1.1.2", "", { "bin": { "printj": "./bin/printj.njs" } }, "sha512-zA2SmoLaxZyArQTOPj5LXecR+RagfPSU5Kw1qP+jkWeNlrq+eJZyY2oS68SU1Z/7/myXM4lo9716laOFAVStCQ=="],
 
     "prop-types": ["prop-types@15.8.1", "", { "dependencies": { "loose-envify": "^1.4.0", "object-assign": "^4.1.1", "react-is": "^16.13.1" } }, "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg=="],
+
+    "property-information": ["property-information@7.1.0", "", {}, "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ=="],
 
     "protobufjs": ["protobufjs@7.5.4", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.4", "@protobufjs/eventemitter": "^1.1.0", "@protobufjs/fetch": "^1.1.0", "@protobufjs/float": "^1.0.2", "@protobufjs/inquire": "^1.1.0", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.0", "@types/node": ">=13.7.0", "long": "^5.0.0" } }, "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg=="],
 
@@ -1577,17 +1879,49 @@
 
     "react-use-measure": ["react-use-measure@2.1.7", "", { "peerDependencies": { "react": ">=16.13", "react-dom": ">=16.13" }, "optionalPeers": ["react-dom"] }, "sha512-KrvcAo13I/60HpwGO5jpW7E9DfusKyLPLvuHlUyP5zqnmAPhNc6qTRjUQrdTADl0lpPpDVU2/Gg51UlOGHXbdg=="],
 
+    "readdirp": ["readdirp@5.0.0", "", {}, "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ=="],
+
     "recharts": ["recharts@2.15.4", "", { "dependencies": { "clsx": "^2.0.0", "eventemitter3": "^4.0.1", "lodash": "^4.17.21", "react-is": "^18.3.1", "react-smooth": "^4.0.4", "recharts-scale": "^0.4.4", "tiny-invariant": "^1.3.1", "victory-vendor": "^36.6.8" }, "peerDependencies": { "react": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-UT/q6fwS3c1dHbXv2uFgYJ9BMFHu3fwnd7AYZaEQhXuYQ4hgsxLvsUXzGdKeZrW5xopzDCvuA2N41WJ88I7zIw=="],
 
     "recharts-scale": ["recharts-scale@0.4.5", "", { "dependencies": { "decimal.js-light": "^2.4.1" } }, "sha512-kivNFO+0OcUNu7jQquLXAxz1FIwZj8nrj+YkOKc5694NbjCvcT6aSZiIzNzd2Kul4o4rTto8QVR9lMNtxD4G1w=="],
+
+    "recma-build-jsx": ["recma-build-jsx@1.0.0", "", { "dependencies": { "@types/estree": "^1.0.0", "estree-util-build-jsx": "^3.0.0", "vfile": "^6.0.0" } }, "sha512-8GtdyqaBcDfva+GUKDr3nev3VpKAhup1+RvkMvUxURHpW7QyIvk9F5wz7Vzo06CEMSilw6uArgRqhpiUcWp8ew=="],
+
+    "recma-jsx": ["recma-jsx@1.0.1", "", { "dependencies": { "acorn-jsx": "^5.0.0", "estree-util-to-js": "^2.0.0", "recma-parse": "^1.0.0", "recma-stringify": "^1.0.0", "unified": "^11.0.0" }, "peerDependencies": { "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-huSIy7VU2Z5OLv6oFLosQGGDqPqdO1iq6bWNAdhzMxSJP7RAso4fCZ1cKu8j9YHCZf3TPrq4dw3okhrylgcd7w=="],
+
+    "recma-parse": ["recma-parse@1.0.0", "", { "dependencies": { "@types/estree": "^1.0.0", "esast-util-from-js": "^2.0.0", "unified": "^11.0.0", "vfile": "^6.0.0" } }, "sha512-OYLsIGBB5Y5wjnSnQW6t3Xg7q3fQ7FWbw/vcXtORTnyaSFscOtABg+7Pnz6YZ6c27fG1/aN8CjfwoUEUIdwqWQ=="],
+
+    "recma-stringify": ["recma-stringify@1.0.0", "", { "dependencies": { "@types/estree": "^1.0.0", "estree-util-to-js": "^2.0.0", "unified": "^11.0.0", "vfile": "^6.0.0" } }, "sha512-cjwII1MdIIVloKvC9ErQ+OgAtwHBmcZ0Bg4ciz78FtbT8In39aAYbaA7zvxQ61xVMSPE8WxhLwLbhif4Js2C+g=="],
 
     "redux": ["redux@4.2.1", "", { "dependencies": { "@babel/runtime": "^7.9.2" } }, "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w=="],
 
     "reflect.getprototypeof": ["reflect.getprototypeof@1.0.10", "", { "dependencies": { "call-bind": "^1.0.8", "define-properties": "^1.2.1", "es-abstract": "^1.23.9", "es-errors": "^1.3.0", "es-object-atoms": "^1.0.0", "get-intrinsic": "^1.2.7", "get-proto": "^1.0.1", "which-builtin-type": "^1.2.1" } }, "sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw=="],
 
+    "regex": ["regex@6.1.0", "", { "dependencies": { "regex-utilities": "^2.3.0" } }, "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg=="],
+
+    "regex-recursion": ["regex-recursion@6.0.2", "", { "dependencies": { "regex-utilities": "^2.3.0" } }, "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg=="],
+
+    "regex-utilities": ["regex-utilities@2.3.0", "", {}, "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng=="],
+
     "regexp-util": ["regexp-util@2.0.3", "", {}, "sha512-GP6h9OgJmhAZpb3dbNbXTfRWVnGcoMhWRZv/HxgM4/qCVqs1P9ukQdYxaUhjWBSAs9oJ/uPXUUvGT1VMe0Bs0Q=="],
 
     "regexp.prototype.flags": ["regexp.prototype.flags@1.5.4", "", { "dependencies": { "call-bind": "^1.0.8", "define-properties": "^1.2.1", "es-errors": "^1.3.0", "get-proto": "^1.0.1", "gopd": "^1.2.0", "set-function-name": "^2.0.2" } }, "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA=="],
+
+    "rehype-raw": ["rehype-raw@7.0.0", "", { "dependencies": { "@types/hast": "^3.0.0", "hast-util-raw": "^9.0.0", "vfile": "^6.0.0" } }, "sha512-/aE8hCfKlQeA8LmyeyQvQF3eBiLRGNlfBJEvWH7ivp9sBqs7TNqBL5X3v157rM4IFETqDnIOO+z5M/biZbo9Ww=="],
+
+    "rehype-recma": ["rehype-recma@1.0.0", "", { "dependencies": { "@types/estree": "^1.0.0", "@types/hast": "^3.0.0", "hast-util-to-estree": "^3.0.0" } }, "sha512-lqA4rGUf1JmacCNWWZx0Wv1dHqMwxzsDWYMTowuplHF3xH0N/MmrZ/G3BDZnzAkRmxDadujCjaKM2hqYdCBOGw=="],
+
+    "remark": ["remark@15.0.1", "", { "dependencies": { "@types/mdast": "^4.0.0", "remark-parse": "^11.0.0", "remark-stringify": "^11.0.0", "unified": "^11.0.0" } }, "sha512-Eht5w30ruCXgFmxVUSlNWQ9iiimq07URKeFS3hNc8cUWy1llX4KDWfyEDZRycMc+znsN9Ux5/tJ/BFdgdOwA3A=="],
+
+    "remark-gfm": ["remark-gfm@4.0.1", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-gfm": "^3.0.0", "micromark-extension-gfm": "^3.0.0", "remark-parse": "^11.0.0", "remark-stringify": "^11.0.0", "unified": "^11.0.0" } }, "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg=="],
+
+    "remark-mdx": ["remark-mdx@3.1.1", "", { "dependencies": { "mdast-util-mdx": "^3.0.0", "micromark-extension-mdxjs": "^3.0.0" } }, "sha512-Pjj2IYlUY3+D8x00UJsIOg5BEvfMyeI+2uLPn9VO9Wg4MEtN/VTIq2NEJQfde9PnX15KgtHyl9S0BcTnWrIuWg=="],
+
+    "remark-parse": ["remark-parse@11.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-from-markdown": "^2.0.0", "micromark-util-types": "^2.0.0", "unified": "^11.0.0" } }, "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA=="],
+
+    "remark-rehype": ["remark-rehype@11.1.2", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "mdast-util-to-hast": "^13.0.0", "unified": "^11.0.0", "vfile": "^6.0.0" } }, "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw=="],
+
+    "remark-stringify": ["remark-stringify@11.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-to-markdown": "^2.0.0", "unified": "^11.0.0" } }, "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw=="],
 
     "require-directory": ["require-directory@2.1.1", "", {}, "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="],
 
@@ -1613,6 +1947,8 @@
 
     "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
 
+    "scroll-into-view-if-needed": ["scroll-into-view-if-needed@3.1.0", "", { "dependencies": { "compute-scroll-into-view": "^3.0.2" } }, "sha512-49oNpRjWRvnU8NyGVmUaYG4jtTkNonFZI86MmGRDqBphEK2EXT9gdEUoQPZhuBM8yWHxCWbobltqYO5M4XrUvQ=="],
+
     "semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
     "set-function-length": ["set-function-length@1.2.2", "", { "dependencies": { "define-data-property": "^1.1.4", "es-errors": "^1.3.0", "function-bind": "^1.1.2", "get-intrinsic": "^1.2.4", "gopd": "^1.0.1", "has-property-descriptors": "^1.0.2" } }, "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg=="],
@@ -1627,6 +1963,8 @@
 
     "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
 
+    "shiki": ["shiki@4.1.0", "", { "dependencies": { "@shikijs/core": "4.1.0", "@shikijs/engine-javascript": "4.1.0", "@shikijs/engine-oniguruma": "4.1.0", "@shikijs/langs": "4.1.0", "@shikijs/themes": "4.1.0", "@shikijs/types": "4.1.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-l/ABZPUR5v70jI10EzqfMS/I96vjSGv2y0ihUV+WYFzv0EfvW4s54m0Lg8wCrrL+2IkwBzFTuxkZjPf8b2NX9Q=="],
+
     "side-channel": ["side-channel@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.3", "side-channel-list": "^1.0.0", "side-channel-map": "^1.0.1", "side-channel-weakmap": "^1.0.2" } }, "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw=="],
 
     "side-channel-list": ["side-channel-list@1.0.0", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.3" } }, "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA=="],
@@ -1637,7 +1975,11 @@
 
     "sonner": ["sonner@2.0.7", "", { "peerDependencies": { "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc", "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc" } }, "sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w=="],
 
+    "source-map": ["source-map@0.7.6", "", {}, "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ=="],
+
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
+
+    "space-separated-tokens": ["space-separated-tokens@2.0.2", "", {}, "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q=="],
 
     "sqids": ["sqids@0.3.0", "", {}, "sha512-lOQK1ucVg+W6n3FhRwwSeUijxe93b51Bfz5PMRMihVf1iVkl82ePQG7V5vwrhzB11v0NtsR25PSZRGiSomJaJw=="],
 
@@ -1663,11 +2005,17 @@
 
     "string.prototype.trimstart": ["string.prototype.trimstart@1.0.8", "", { "dependencies": { "call-bind": "^1.0.7", "define-properties": "^1.2.1", "es-object-atoms": "^1.0.0" } }, "sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg=="],
 
+    "stringify-entities": ["stringify-entities@4.0.4", "", { "dependencies": { "character-entities-html4": "^2.0.0", "character-entities-legacy": "^3.0.0" } }, "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg=="],
+
     "strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "strip-bom": ["strip-bom@3.0.0", "", {}, "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA=="],
 
     "strip-json-comments": ["strip-json-comments@3.1.1", "", {}, "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="],
+
+    "style-to-js": ["style-to-js@1.1.21", "", { "dependencies": { "style-to-object": "1.0.14" } }, "sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ=="],
+
+    "style-to-object": ["style-to-object@1.0.14", "", { "dependencies": { "inline-style-parser": "0.2.7" } }, "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw=="],
 
     "styled-jsx": ["styled-jsx@5.1.6", "", { "dependencies": { "client-only": "0.0.1" }, "peerDependencies": { "react": ">= 16.8.0 || 17.x.x || ^18.0.0-0 || ^19.0.0-0" } }, "sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA=="],
 
@@ -1675,21 +2023,27 @@
 
     "supports-preserve-symlinks-flag": ["supports-preserve-symlinks-flag@1.0.0", "", {}, "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="],
 
-    "tailwind-merge": ["tailwind-merge@3.3.1", "", {}, "sha512-gBXpgUm/3rp1lMZZrM/w7D8GKqshif0zAymAhbCyIt8KMe+0v9DQ7cdYLR4FHH/cKpdTXb+A/tKKU3eolfsI+g=="],
+    "tailwind-merge": ["tailwind-merge@3.6.0", "", {}, "sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w=="],
 
-    "tailwindcss": ["tailwindcss@4.1.17", "", {}, "sha512-j9Ee2YjuQqYT9bbRTfTZht9W/ytp5H+jJpZKiYdP/bpnXARAuELt9ofP0lPnmHjbga7SNQIxdTAXCmtKVYjN+Q=="],
+    "tailwindcss": ["tailwindcss@4.3.0", "", {}, "sha512-y6nxMGB1nMW9R6k96e5gdIFzcfL/gTJRNaqGes1YvkLnPVXzWgbqFF2yLC0T8G774n24cx3Pe8XrKoniCOAH+Q=="],
 
-    "tapable": ["tapable@2.3.0", "", {}, "sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg=="],
+    "tapable": ["tapable@2.3.3", "", {}, "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A=="],
 
     "tiny-inflate": ["tiny-inflate@1.0.3", "", {}, "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw=="],
 
     "tiny-invariant": ["tiny-invariant@1.3.3", "", {}, "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg=="],
 
-    "tinyglobby": ["tinyglobby@0.2.15", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.3" } }, "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ=="],
+    "tinyexec": ["tinyexec@1.2.2", "", {}, "sha512-M/Q0B2cp4K7kynaT/vnED1j8TlLY+Pp7C6Wl2bl/7u/F0mUVwdyOpwomQb8JpYLitHUssAJRmLZdMCGsrx7i+g=="],
+
+    "tinyglobby": ["tinyglobby@0.2.16", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg=="],
 
     "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
 
     "trigram-utils": ["trigram-utils@2.0.1", "", { "dependencies": { "collapse-white-space": "^2.0.0", "n-gram": "^2.0.0" } }, "sha512-nfWIXHEaB+HdyslAfMxSqWKDdmqY9I32jS7GnqpdWQnLH89r6A5sdk3fDVYqGAZ0CrT8ovAFSAo6HRiWcWNIGQ=="],
+
+    "trim-lines": ["trim-lines@3.0.1", "", {}, "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg=="],
+
+    "trough": ["trough@2.2.0", "", {}, "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw=="],
 
     "ts-api-utils": ["ts-api-utils@2.1.0", "", { "peerDependencies": { "typescript": ">=4.8.4" } }, "sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ=="],
 
@@ -1723,6 +2077,22 @@
 
     "unicount": ["unicount@1.1.0", "", {}, "sha512-RlwWt1ywVW4WErPGAVHw/rIuJ2+MxvTME0siJ6lk9zBhpDfExDbspe6SRlWT3qU6AucNjotPl9qAJRVjP7guCQ=="],
 
+    "unified": ["unified@11.0.5", "", { "dependencies": { "@types/unist": "^3.0.0", "bail": "^2.0.0", "devlop": "^1.0.0", "extend": "^3.0.0", "is-plain-obj": "^4.0.0", "trough": "^2.0.0", "vfile": "^6.0.0" } }, "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA=="],
+
+    "unist-util-is": ["unist-util-is@6.0.1", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g=="],
+
+    "unist-util-position": ["unist-util-position@5.0.0", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA=="],
+
+    "unist-util-position-from-estree": ["unist-util-position-from-estree@2.0.0", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-KaFVRjoqLyF6YXCbVLNad/eS4+OfPQQn2yOd7zF/h5T/CSL2v8NpN6a5TPvtbXthAGw5nG+PuTtq+DdIZr+cRQ=="],
+
+    "unist-util-remove-position": ["unist-util-remove-position@5.0.0", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-visit": "^5.0.0" } }, "sha512-Hp5Kh3wLxv0PHj9m2yZhhLt58KzPtEYKQQ4yxfYFEO7EvHwzyDYnduhHnY1mDxoqr7VUwVuHXk9RXKIiYS1N8Q=="],
+
+    "unist-util-stringify-position": ["unist-util-stringify-position@4.0.0", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ=="],
+
+    "unist-util-visit": ["unist-util-visit@5.1.0", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-is": "^6.0.0", "unist-util-visit-parents": "^6.0.0" } }, "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg=="],
+
+    "unist-util-visit-parents": ["unist-util-visit-parents@6.0.2", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-is": "^6.0.0" } }, "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ=="],
+
     "unrs-resolver": ["unrs-resolver@1.11.1", "", { "dependencies": { "napi-postinstall": "^0.3.0" }, "optionalDependencies": { "@unrs/resolver-binding-android-arm-eabi": "1.11.1", "@unrs/resolver-binding-android-arm64": "1.11.1", "@unrs/resolver-binding-darwin-arm64": "1.11.1", "@unrs/resolver-binding-darwin-x64": "1.11.1", "@unrs/resolver-binding-freebsd-x64": "1.11.1", "@unrs/resolver-binding-linux-arm-gnueabihf": "1.11.1", "@unrs/resolver-binding-linux-arm-musleabihf": "1.11.1", "@unrs/resolver-binding-linux-arm64-gnu": "1.11.1", "@unrs/resolver-binding-linux-arm64-musl": "1.11.1", "@unrs/resolver-binding-linux-ppc64-gnu": "1.11.1", "@unrs/resolver-binding-linux-riscv64-gnu": "1.11.1", "@unrs/resolver-binding-linux-riscv64-musl": "1.11.1", "@unrs/resolver-binding-linux-s390x-gnu": "1.11.1", "@unrs/resolver-binding-linux-x64-gnu": "1.11.1", "@unrs/resolver-binding-linux-x64-musl": "1.11.1", "@unrs/resolver-binding-wasm32-wasi": "1.11.1", "@unrs/resolver-binding-win32-arm64-msvc": "1.11.1", "@unrs/resolver-binding-win32-ia32-msvc": "1.11.1", "@unrs/resolver-binding-win32-x64-msvc": "1.11.1" } }, "sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg=="],
 
     "update-browserslist-db": ["update-browserslist-db@1.1.4", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": { "update-browserslist-db": "cli.js" } }, "sha512-q0SPT4xyU84saUX+tomz1WLkxUbuaJnR1xWt17M7fJtEJigJeWUNGUqrauFXsHnqev9y9JTRGwk13tFBuKby4A=="],
@@ -1741,9 +2111,17 @@
 
     "uuid": ["uuid@11.1.0", "", { "bin": { "uuid": "dist/esm/bin/uuid" } }, "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A=="],
 
+    "vfile": ["vfile@6.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "vfile-message": "^4.0.0" } }, "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q=="],
+
+    "vfile-location": ["vfile-location@5.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "vfile": "^6.0.0" } }, "sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg=="],
+
+    "vfile-message": ["vfile-message@4.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw=="],
+
     "victory-vendor": ["victory-vendor@36.9.2", "", { "dependencies": { "@types/d3-array": "^3.0.3", "@types/d3-ease": "^3.0.0", "@types/d3-interpolate": "^3.0.1", "@types/d3-scale": "^4.0.2", "@types/d3-shape": "^3.1.0", "@types/d3-time": "^3.0.0", "@types/d3-timer": "^3.0.0", "d3-array": "^3.1.6", "d3-ease": "^3.0.1", "d3-interpolate": "^3.0.1", "d3-scale": "^4.0.2", "d3-shape": "^3.1.0", "d3-time": "^3.0.0", "d3-timer": "^3.0.1" } }, "sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ=="],
 
     "vue": ["vue@3.5.24", "", { "dependencies": { "@vue/compiler-dom": "3.5.24", "@vue/compiler-sfc": "3.5.24", "@vue/runtime-dom": "3.5.24", "@vue/server-renderer": "3.5.24", "@vue/shared": "3.5.24" }, "peerDependencies": { "typescript": "*" }, "optionalPeers": ["typescript"] }, "sha512-uTHDOpVQTMjcGgrqFPSb8iO2m1DUvo+WbGqoXQz8Y1CeBYQ0FXf2z1gLRaBtHjlRz7zZUBHxjVB5VTLzYkvftg=="],
+
+    "web-namespaces": ["web-namespaces@2.0.1", "", {}, "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ=="],
 
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
@@ -1775,17 +2153,21 @@
 
     "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
 
-    "zod": ["zod@4.1.12", "", {}, "sha512-JInaHOamG8pt5+Ey8kGmdcAcg3OL9reK8ltczgHTAwNhMys/6ThXHityHxVV2p3fkw/c+MAvBHFVYHFZDmjMCQ=="],
+    "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 
     "zod-validation-error": ["zod-validation-error@4.0.2", "", { "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ=="],
 
     "zrender": ["zrender@5.6.1", "", { "dependencies": { "tslib": "2.3.0" } }, "sha512-OFXkDJKcrlx5su2XbzJvj/34Q3m6PvyCZkVPHGYpcCJ52ek4U/ymZyfuV1nKE23AyBJ51E/6Yr0mhZ7xGTO4ag=="],
+
+    "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
 
     "@babel/core/json5": ["json5@2.2.3", "", { "bin": { "json5": "lib/cli.js" } }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
 
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
 
     "@eslint/eslintrc/globals": ["globals@14.0.0", "", {}, "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ=="],
+
+    "@eslint/eslintrc/js-yaml": ["js-yaml@4.1.0", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA=="],
 
     "@radix-ui/react-alert-dialog/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
 
@@ -1819,13 +2201,13 @@
 
     "@radix-ui/react-tooltip/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
 
-    "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.7.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.1.0", "tslib": "^2.4.0" }, "bundled": true }, "sha512-pJdKGq/1iquWYtv1RRSljZklxHCOCAJFJrImO5ZLKPJVJlVUcs8yFwNQlqS0Lo8xT1VAXXTCZocF9n26FWEKsw=="],
+    "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.10.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" }, "bundled": true }, "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw=="],
 
-    "@tailwindcss/oxide-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.7.0", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-oAYoQnCYaQZKVS53Fq23ceWMRxq5EhQsE0x0RdQ55jT7wagMu5k+fS39v1fiSLrtrLQlXwVINenqhLMtTrV/1Q=="],
+    "@tailwindcss/oxide-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.10.0", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA=="],
 
-    "@tailwindcss/oxide-wasm32-wasi/@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.1.0", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ=="],
+    "@tailwindcss/oxide-wasm32-wasi/@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.1", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w=="],
 
-    "@tailwindcss/oxide-wasm32-wasi/@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.0.7", "", { "dependencies": { "@emnapi/core": "^1.5.0", "@emnapi/runtime": "^1.5.0", "@tybys/wasm-util": "^0.10.1" }, "bundled": true }, "sha512-SeDnOO0Tk7Okiq6DbXmmBODgOAb9dp9gjlphokTUxmt8U3liIP1ZsozBahH69j/RJv+Rfs6IwUKHTgQYJ/HBAw=="],
+    "@tailwindcss/oxide-wasm32-wasi/@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.4", "", { "dependencies": { "@tybys/wasm-util": "^0.10.1" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" }, "bundled": true }, "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow=="],
 
     "@tailwindcss/oxide-wasm32-wasi/@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
 
@@ -1853,6 +2235,16 @@
 
     "@univerjs/core/nanoid": ["nanoid@5.1.5", "", { "bin": { "nanoid": "bin/nanoid.js" } }, "sha512-Ir/+ZpE9fDsNH0hQ3C68uyThDXzYcim2EqcZ8zn8Chtt1iylPT9xXJB0kPCnqzgcEGikO9RxSrh63MsmVCU7Fw=="],
 
+    "@univerjs/design/tailwind-merge": ["tailwind-merge@3.3.1", "", {}, "sha512-gBXpgUm/3rp1lMZZrM/w7D8GKqshif0zAymAhbCyIt8KMe+0v9DQ7cdYLR4FHH/cKpdTXb+A/tKKU3eolfsI+g=="],
+
+    "@vue/compiler-core/entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
+
+    "@vue/compiler-core/estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
+
+    "@vue/compiler-sfc/estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
+
+    "@vue/compiler-sfc/postcss": ["postcss@8.5.6", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg=="],
+
     "@vue/runtime-dom/csstype": ["csstype@3.1.3", "", {}, "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="],
 
     "cfb/adler-32": ["adler-32@1.3.1", "", {}, "sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A=="],
@@ -1869,21 +2261,33 @@
 
     "eslint-import-resolver-node/debug": ["debug@3.2.7", "", { "dependencies": { "ms": "^2.1.1" } }, "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ=="],
 
+    "eslint-import-resolver-typescript/tinyglobby": ["tinyglobby@0.2.15", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.3" } }, "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ=="],
+
     "eslint-module-utils/debug": ["debug@3.2.7", "", { "dependencies": { "ms": "^2.1.1" } }, "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ=="],
 
     "eslint-plugin-import/debug": ["debug@3.2.7", "", { "dependencies": { "ms": "^2.1.1" } }, "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ=="],
 
     "eslint-plugin-react/resolve": ["resolve@2.0.0-next.5", "", { "dependencies": { "is-core-module": "^2.13.0", "path-parse": "^1.0.7", "supports-preserve-symlinks-flag": "^1.0.0" }, "bin": { "resolve": "bin/resolve" } }, "sha512-U7WjGVG9sH8tvjW5SmGbQuui75FiyjAX72HX15DwBBwF9dNiQZRQAg9nnPhYy+TUnE0+VcrttuvNI8oSxZcocA=="],
 
+    "eslint-plugin-react-hooks/zod": ["zod@4.1.12", "", {}, "sha512-JInaHOamG8pt5+Ey8kGmdcAcg3OL9reK8ltczgHTAwNhMys/6ThXHityHxVV2p3fkw/c+MAvBHFVYHFZDmjMCQ=="],
+
     "fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
+
+    "fumadocs-ui/lucide-react": ["lucide-react@1.16.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-dYwyPzb4MEKpGUmNYk3WKWPnMrHs3FKM+q94kAnJrcDIqqn1hq2xY8scaS2ovsOCM5D51ey2gaRG3PBb1vgoYQ=="],
+
+    "fumadocs-ui/react-remove-scroll": ["react-remove-scroll@2.7.2", "", { "dependencies": { "react-remove-scroll-bar": "^2.3.7", "react-style-singleton": "^2.2.3", "tslib": "^2.1.0", "use-callback-ref": "^1.3.3", "use-sidecar": "^1.1.3" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q=="],
 
     "hoist-non-react-statics/react-is": ["react-is@16.13.1", "", {}, "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="],
 
     "is-bun-module/semver": ["semver@7.7.3", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q=="],
 
+    "mdast-util-find-and-replace/escape-string-regexp": ["escape-string-regexp@5.0.0", "", {}, "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="],
+
     "micromatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
     "next/postcss": ["postcss@8.4.31", "", { "dependencies": { "nanoid": "^3.3.6", "picocolors": "^1.0.0", "source-map-js": "^1.0.2" } }, "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ=="],
+
+    "parse-entities/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
 
     "prop-types/react-is": ["react-is@16.13.1", "", {}, "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="],
 
@@ -1905,10 +2309,18 @@
 
     "string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
+    "uploadthing/@standard-schema/spec": ["@standard-schema/spec@1.0.0-beta.4", "", {}, "sha512-d3IxtzLo7P1oZ8s8YNvxzBUXRXojSut8pbPrTYtzsc5sn4+53jVqbk66pQerSZbZSJZQux6LkclB/+8IDordHg=="],
+
     "zrender/tslib": ["tslib@2.3.0", "", {}, "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="],
 
     "@typescript-eslint/typescript-estree/fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
     "@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
+
+    "@vue/compiler-sfc/postcss/nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
+
+    "eslint-import-resolver-typescript/tinyglobby/picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
+
+    "next/postcss/nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
   }
 }

--- a/bun.lock
+++ b/bun.lock
@@ -155,6 +155,7 @@
         "cmdk": "^1.1.1",
         "date-fns": "^4.2.1",
         "lucide-react": "^0.555.0",
+        "media-chrome": "^4.19.0",
         "motion": "^12.34.0",
         "radix-ui": "^1.4.3",
         "react-day-picker": "^10.0.1",
@@ -1085,6 +1086,8 @@
 
     "ccount": ["ccount@2.0.1", "", {}, "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg=="],
 
+    "ce-la-react": ["ce-la-react@0.3.2", "", { "peerDependencies": { "react": ">=17.0.0" } }, "sha512-QJ6k4lOD/btI08xG8jBPxRCGXvCnusGGkTsiXk0u3NqUu/W+BXRnFD4PYjwtqh8AWmGa5LDbGk0fLQsqr0nSMA=="],
+
     "cfb": ["cfb@1.2.2", "", { "dependencies": { "adler-32": "~1.3.0", "crc-32": "~1.2.0" } }, "sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA=="],
 
     "chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
@@ -1628,6 +1631,8 @@
     "mdast-util-to-markdown": ["mdast-util-to-markdown@2.1.2", "", { "dependencies": { "@types/mdast": "^4.0.0", "@types/unist": "^3.0.0", "longest-streak": "^3.0.0", "mdast-util-phrasing": "^4.0.0", "mdast-util-to-string": "^4.0.0", "micromark-util-classify-character": "^2.0.0", "micromark-util-decode-string": "^2.0.0", "unist-util-visit": "^5.0.0", "zwitch": "^2.0.0" } }, "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA=="],
 
     "mdast-util-to-string": ["mdast-util-to-string@4.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0" } }, "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg=="],
+
+    "media-chrome": ["media-chrome@4.19.0", "", { "dependencies": { "ce-la-react": "^0.3.2" } }, "sha512-HWhDTwts+BSbdPkkB1VsJXp5kvL0IxY7xFT5tBwliM2+89kTPVTnHnev+9it2f9PweANjT/C8/C/S0PW9oyZbA=="],
 
     "memoize-one": ["memoize-one@5.2.1", "", {}, "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q=="],
 

--- a/package.json
+++ b/package.json
@@ -31,6 +31,8 @@
   },
   "overrides": {
     "date-fns": "^4.2.1",
-    "react-day-picker": "^10.0.1"
+    "react-day-picker": "^10.0.1",
+    "tailwindcss": "^4.3.0",
+    "@tailwindcss/postcss": "^4.3.0"
   }
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -10,6 +10,7 @@
     "./components/ui/*": "./src/components/ui/*.tsx",
     "./components/common/ThemeToggle": "./src/components/common/ThemeToggle.tsx",
     "./components/common/SlidingNumber": "./src/components/common/SlidingNumber.tsx",
+    "./components/kibo-ui/video-player": "./src/components/kibo-ui/video-player/index.tsx",
     "./hooks/general/use-mobile": "./src/hooks/general/use-mobile.ts",
     "./lib/utils": "./src/lib/utils.ts",
     "./lib/theme-provider": "./src/lib/theme-provider.tsx"
@@ -48,6 +49,7 @@
     "cmdk": "^1.1.1",
     "date-fns": "^4.2.1",
     "lucide-react": "^0.555.0",
+    "media-chrome": "^4.19.0",
     "motion": "^12.34.0",
     "radix-ui": "^1.4.3",
     "react-day-picker": "^10.0.1",

--- a/packages/ui/src/components/kibo-ui/video-player/index.tsx
+++ b/packages/ui/src/components/kibo-ui/video-player/index.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+import {
+  MediaControlBar,
+  MediaController,
+  MediaMuteButton,
+  MediaPlayButton,
+  MediaSeekBackwardButton,
+  MediaSeekForwardButton,
+  MediaTimeDisplay,
+  MediaTimeRange,
+  MediaVolumeRange,
+} from "media-chrome/react";
+import type { ComponentProps, CSSProperties } from "react";
+import { cn } from "@uprevit/ui/lib/utils";
+
+export type VideoPlayerProps = ComponentProps<typeof MediaController>;
+
+const variables = {
+  "--media-primary-color": "var(--primary)",
+  "--media-secondary-color": "var(--background)",
+  "--media-text-color": "var(--foreground)",
+  "--media-background-color": "var(--background)",
+  "--media-control-hover-background": "var(--accent)",
+  "--media-font-family": "var(--font-sans)",
+  "--media-live-button-icon-color": "var(--muted-foreground)",
+  "--media-live-button-indicator-color": "var(--destructive)",
+  "--media-range-track-background": "var(--border)",
+} as CSSProperties;
+
+export const VideoPlayer = ({ style, ...props }: VideoPlayerProps) => (
+  <MediaController
+    style={{
+      ...variables,
+      ...style,
+    }}
+    {...props}
+  />
+);
+
+export type VideoPlayerControlBarProps = ComponentProps<typeof MediaControlBar>;
+
+export const VideoPlayerControlBar = (props: VideoPlayerControlBarProps) => (
+  <MediaControlBar {...props} />
+);
+
+export type VideoPlayerTimeRangeProps = ComponentProps<typeof MediaTimeRange>;
+
+export const VideoPlayerTimeRange = ({
+  className,
+  ...props
+}: VideoPlayerTimeRangeProps) => (
+  <MediaTimeRange className={cn("p-2.5", className)} {...props} />
+);
+
+export type VideoPlayerTimeDisplayProps = ComponentProps<
+  typeof MediaTimeDisplay
+>;
+
+export const VideoPlayerTimeDisplay = ({
+  className,
+  ...props
+}: VideoPlayerTimeDisplayProps) => (
+  <MediaTimeDisplay className={cn("p-2.5", className)} {...props} />
+);
+
+export type VideoPlayerVolumeRangeProps = ComponentProps<
+  typeof MediaVolumeRange
+>;
+
+export const VideoPlayerVolumeRange = ({
+  className,
+  ...props
+}: VideoPlayerVolumeRangeProps) => (
+  <MediaVolumeRange className={cn("p-2.5", className)} {...props} />
+);
+
+export type VideoPlayerPlayButtonProps = ComponentProps<typeof MediaPlayButton>;
+
+export const VideoPlayerPlayButton = ({
+  className,
+  ...props
+}: VideoPlayerPlayButtonProps) => (
+  <MediaPlayButton className={cn("p-2.5", className)} {...props} />
+);
+
+export type VideoPlayerSeekBackwardButtonProps = ComponentProps<
+  typeof MediaSeekBackwardButton
+>;
+
+export const VideoPlayerSeekBackwardButton = ({
+  className,
+  ...props
+}: VideoPlayerSeekBackwardButtonProps) => (
+  <MediaSeekBackwardButton className={cn("p-2.5", className)} {...props} />
+);
+
+export type VideoPlayerSeekForwardButtonProps = ComponentProps<
+  typeof MediaSeekForwardButton
+>;
+
+export const VideoPlayerSeekForwardButton = ({
+  className,
+  ...props
+}: VideoPlayerSeekForwardButtonProps) => (
+  <MediaSeekForwardButton className={cn("p-2.5", className)} {...props} />
+);
+
+export type VideoPlayerMuteButtonProps = ComponentProps<typeof MediaMuteButton>;
+
+export const VideoPlayerMuteButton = ({
+  className,
+  ...props
+}: VideoPlayerMuteButtonProps) => (
+  <MediaMuteButton className={cn("p-2.5", className)} {...props} />
+);
+
+export type VideoPlayerContentProps = ComponentProps<"video">;
+
+export const VideoPlayerContent = ({
+  className,
+  ...props
+}: VideoPlayerContentProps) => (
+  <video className={cn("mt-0 mb-0", className)} {...props} />
+);


### PR DESCRIPTION
- Extract `AccessEligibilityGuard` from the main app layout so auth, onboarding, and workspace eligibility checks can wrap other authenticated surfaces
- Add in-app documentation at `/docs` with Fumadocs, MDX content, full-text search, and sidebar navigation from the app shell
- Add a shared `VideoPlayer` component (kibo-ui with media-chrome) for consistent, accessible playback controls
- Embed walkthrough videos in documentation pages via `DocsVideo` with signed-URL fetching from the backend API
- Publish MDX guides for getting started, product documentation tabs, review outputs, and source files/bookmarks