### PR TITLE
Fix dark mode colors for redline views and product workbook cells

### DIFF
--- a/apps/app/app/(app)/products/[productId]/compliance-information/page.tsx
+++ b/apps/app/app/(app)/products/[productId]/compliance-information/page.tsx
@@ -16,6 +16,18 @@ import type { DiffItem } from "@/utils/deepDiff";
 import { countChangedRedlineItems } from "@/utils/redlineCounts";
 import { buildRedlineArray, type RedlineStatus } from "@/utils/redlineArray";
 import {
+  cnRedlineBadge,
+  redlineBannerText,
+  redlineCardAdded,
+  redlineCardModified,
+  redlineCardRemoved,
+  redlineFieldHighlightAdded,
+  redlineFieldHighlightModified,
+  redlineFieldHighlightRemoved,
+  redlineNewValue,
+  redlineOldValue,
+} from "@/utils/redlineStyles";
+import {
   PiArrowRightBold,
   PiCaretRightDuotone,
   PiCertificateDuotone,
@@ -111,7 +123,12 @@ export default function Page() {
     return (
       <span className="inline-flex max-w-full flex-wrap items-center gap-2 whitespace-normal break-words">
         {(diff.old_value !== null || isRemoved) && hasOldValue && (
-          <span className="max-w-full whitespace-pre-wrap break-words text-sm text-red-600/70 line-through">
+          <span
+            className={cn(
+              "max-w-full whitespace-pre-wrap break-words",
+              redlineOldValue,
+            )}
+          >
             {oldValue}
           </span>
         )}
@@ -126,7 +143,12 @@ export default function Page() {
           )}
 
         {(diff.new_value !== null || isAdded) && !isRemoved && hasNewValue && (
-          <span className="max-w-full whitespace-pre-wrap break-words text-sm font-semibold text-blue-700">
+          <span
+            className={cn(
+              "max-w-full whitespace-pre-wrap break-words",
+              redlineNewValue,
+            )}
+          >
             {newValue}
           </span>
         )}
@@ -326,7 +348,7 @@ export default function Page() {
     <div className="flex h-full flex-col gap-2 p-2">
       {isRedlineView && (
         <div className="flex items-center gap-2 rounded-lg border border-amber-500/30 bg-amber-500/10 px-2 py-2 text-sm">
-          <span className="font-medium text-amber-600">
+          <span className={cn("font-medium", redlineBannerText)}>
             {diffRedlineLoading
               ? "Loading changes..."
               : `Redline View: ${complianceChangeCount} changes in Compliance Information`}
@@ -424,30 +446,39 @@ export default function Page() {
                       key={item._redlineId ?? item._id}
                       className={cn(
                         "group relative flex flex-col gap-3 rounded-xl border bg-card p-4 transition-all duration-200 hover:bg-accent/5",
-                        isRedlineView &&
-                          isRemoved &&
-                          "border-red-500/50 bg-red-100/5 opacity-60",
-                        isRedlineView &&
-                          isAdded &&
-                          "border-blue-500/50 bg-blue-100/5",
-                        isRedlineView &&
-                          isModified &&
-                          "border-amber-500/50 bg-amber-100/10",
+                        isRedlineView && isRemoved && redlineCardRemoved,
+                        isRedlineView && isAdded && redlineCardAdded,
+                        isRedlineView && isModified && redlineCardModified,
                         (!isRedlineView || !hasAnyDiff) && "border-border",
                       )}
                     >
                       {isRedlineView && isAdded && (
-                        <span className="absolute -top-2 -right-2 z-10 rounded-full border border-blue-200 bg-blue-100 px-2 py-0.5 text-[10px] font-bold tracking-wider text-blue-700 shadow-sm">
+                        <span
+                          className={cn(
+                            "absolute -top-2 -right-2 z-10 rounded-full px-2 py-0.5 text-[10px]",
+                            cnRedlineBadge("added"),
+                          )}
+                        >
                           NEW
                         </span>
                       )}
                       {isRedlineView && isRemoved && (
-                        <span className="absolute -top-2 -right-2 z-10 rounded-full border border-red-200 bg-red-100 px-2 py-0.5 text-[10px] font-bold tracking-wider text-red-700 shadow-sm">
+                        <span
+                          className={cn(
+                            "absolute -top-2 -right-2 z-10 rounded-full px-2 py-0.5 text-[10px]",
+                            cnRedlineBadge("removed"),
+                          )}
+                        >
                           DEL
                         </span>
                       )}
                       {isRedlineView && isModified && (
-                        <span className="absolute -top-2 -right-2 z-10 rounded-full border border-amber-200 bg-amber-100 px-2 py-0.5 text-[10px] font-bold tracking-wider text-amber-700 shadow-sm">
+                        <span
+                          className={cn(
+                            "absolute -top-2 -right-2 z-10 rounded-full px-2 py-0.5 text-[10px]",
+                            cnRedlineBadge("modified"),
+                          )}
+                        >
                           MOD
                         </span>
                       )}
@@ -458,13 +489,13 @@ export default function Page() {
                               "rounded-lg bg-green-500/10 p-2 text-green-600",
                               isRedlineView &&
                                 isRemoved &&
-                                "bg-red-200/40 text-destructive",
+                                redlineFieldHighlightRemoved,
                               isRedlineView &&
                                 isAdded &&
-                                "bg-blue-200/40 text-blue-500",
+                                redlineFieldHighlightAdded,
                               isRedlineView &&
                                 isModified &&
-                                "bg-amber-200/40 text-amber-500",
+                                redlineFieldHighlightModified,
                             )}
                           >
                             <PiShieldCheckDuotone className="h-4 w-4" />
@@ -476,7 +507,7 @@ export default function Page() {
                                   "min-w-0 break-words text-base font-semibold text-foreground",
                                   isRedlineView &&
                                     isRemoved &&
-                                    "text-red-500/70 line-through",
+                                    "text-red-500/70 line-through dark:text-red-400/80",
                                 )}
                               >
                                 <RedlineValue
@@ -508,7 +539,7 @@ export default function Page() {
                           "line-clamp-3 break-words text-sm leading-relaxed text-muted-foreground",
                           isRedlineView &&
                             isRemoved &&
-                            "text-red-500/70 line-through",
+                            "text-red-500/70 line-through dark:text-red-400/80",
                         )}
                       >
                         <RedlineValue
@@ -656,9 +687,9 @@ export default function Page() {
                         !isInLastDesktopRow && "lg:border-b lg:border-border",
                         hasDesktopItemToTheRight &&
                           "lg:border-r lg:border-border",
-                        isRedlineView && isRemoved && "bg-red-100/5 opacity-60",
-                        isRedlineView && isAdded && "bg-blue-100/5",
-                        isRedlineView && isModified && "bg-amber-100/10",
+                        isRedlineView && isRemoved && redlineCardRemoved,
+                        isRedlineView && isAdded && redlineCardAdded,
+                        isRedlineView && isModified && redlineCardModified,
                         (!isRedlineView || !hasAnyDiff) && "hover:bg-accent/30",
                       )}
                     >
@@ -674,7 +705,7 @@ export default function Page() {
                                 "text-sm font-medium text-foreground",
                                 isRedlineView &&
                                   isRemoved &&
-                                  "text-red-500/70 line-through",
+                                  "text-red-500/70 line-through dark:text-red-400/80",
                               )}
                             >
                               <RedlineValue value={item.name} diff={nameDiff} />
@@ -685,7 +716,7 @@ export default function Page() {
                                   "mt-0.5 text-xs text-muted-foreground",
                                   isRedlineView &&
                                     isRemoved &&
-                                    "text-red-500/70 line-through",
+                                    "text-red-500/70 line-through dark:text-red-400/80",
                                 )}
                               >
                                 <RedlineValue
@@ -701,13 +732,10 @@ export default function Page() {
                       {statusLabel && (
                         <span
                           className={cn(
-                            "absolute right-1 top-1 z-10 rounded-full border px-2 py-0.5 text-[10px] font-bold tracking-wider shadow-sm",
-                            isAdded &&
-                              "border-blue-200 bg-blue-100 text-blue-700",
-                            isRemoved &&
-                              "border-red-200 bg-red-100 text-red-700",
-                            isModified &&
-                              "border-amber-200 bg-amber-100 text-amber-700",
+                            "absolute right-1 top-1 z-10 rounded-full px-2 py-0.5 text-[10px]",
+                            isAdded && cnRedlineBadge("added"),
+                            isRemoved && cnRedlineBadge("removed"),
+                            isModified && cnRedlineBadge("modified"),
                           )}
                         >
                           {statusLabel}

--- a/apps/app/app/(app)/products/[productId]/label-components/page.tsx
+++ b/apps/app/app/(app)/products/[productId]/label-components/page.tsx
@@ -137,7 +137,7 @@ export default function Page() {
       {/* Redline Mode Banner */}
       {isRedlineView && (
         <div className="px-2 py-2 bg-amber-500/10 border border-amber-500/30 rounded-lg flex items-center gap-2 text-sm">
-          <span className="text-amber-600 font-medium">
+          <span className="text-amber-600 dark:text-amber-400 font-medium">
             {isLoadingDiff
               ? "Loading changes..."
               : `Redline View: ${labelComponentChangeCount} changes in Label Components`}

--- a/apps/app/app/(app)/products/[productId]/product-information/page.tsx
+++ b/apps/app/app/(app)/products/[productId]/product-information/page.tsx
@@ -29,6 +29,18 @@ import {
 import type { DiffItem } from "@/utils/deepDiff";
 import { hasChangedRedlineStatus } from "@/utils/redlineCounts";
 import { buildRedlineArray, type RedlineStatus } from "@/utils/redlineArray";
+import {
+  cnRedlineBadge,
+  redlineBannerText,
+  redlineCardAdded,
+  redlineCardModified,
+  redlineCardRemoved,
+  redlineFieldHighlightAdded,
+  redlineFieldHighlightModified,
+  redlineFieldHighlightRemoved,
+  redlineNewValue,
+  redlineOldValue,
+} from "@/utils/redlineStyles";
 import Link from "next/link";
 import { notFound, useParams, useSearchParams } from "next/navigation";
 import { useMemo } from "react";
@@ -139,12 +151,7 @@ function RedlineValue({
   return (
     <span className="inline-flex flex-wrap items-center gap-2">
       {(diff.old_value !== null || isRemoved) && (
-        <span
-          className={cn(
-            "line-through text-sm text-red-600/70",
-            oldValueClassName,
-          )}
-        >
+        <span className={cn(redlineOldValue, oldValueClassName)}>
           {format(diff.old_value) || ""}
         </span>
       )}
@@ -157,12 +164,7 @@ function RedlineValue({
         )}
 
       {(diff.new_value !== null || isAdded) && !isRemoved && (
-        <span
-          className={cn(
-            "text-sm font-semibold text-blue-700",
-            newValueClassName,
-          )}
-        >
+        <span className={cn(redlineNewValue, newValueClassName)}>
           {format(diff.new_value) || ""}
         </span>
       )}
@@ -502,7 +504,7 @@ export default function Page() {
       {/* Redline Mode Banner */}
       {isRedlineView && (
         <div className=" px-2 py-2 bg-amber-500/10 border border-amber-500/30 rounded-lg flex items-center gap-2 text-sm">
-          <span className="text-amber-600 font-medium">
+          <span className={cn("font-medium", redlineBannerText)}>
             {diffRedlineLoading
               ? "Loading changes..."
               : `Redline View: ${productInfoChangeCount} changes in Product Information`}
@@ -776,30 +778,39 @@ export default function Page() {
                   key={idx}
                   className={cn(
                     "relative flex flex-col gap-3 p-4 border rounded-xl bg-card hover:bg-accent/5 transition-all duration-200 group",
-                    isRedlineView &&
-                      isRemoved &&
-                      "border-red-500/50 bg-red-100/5 opacity-60",
-                    isRedlineView &&
-                      isAdded &&
-                      "border-blue-500/50 bg-blue-100/5",
-                    isRedlineView &&
-                      isModified &&
-                      "border-amber-500/50 bg-amber-100/10",
+                    isRedlineView && isRemoved && redlineCardRemoved,
+                    isRedlineView && isAdded && redlineCardAdded,
+                    isRedlineView && isModified && redlineCardModified,
                     !isRedlineView || !fieldStatus ? "border-border" : "",
                   )}
                 >
                   {isRedlineView && isAdded && (
-                    <span className="absolute -top-1 -right-1 text-[10px] font-bold tracking-wider text-blue-700 bg-blue-100 border border-blue-200 px-2 py-0.5 rounded-full shadow-sm">
+                    <span
+                      className={cn(
+                        "absolute -top-1 -right-1 rounded-full px-2 py-0.5 text-[10px]",
+                        cnRedlineBadge("added"),
+                      )}
+                    >
                       NEW
                     </span>
                   )}
                   {isRedlineView && isRemoved && (
-                    <span className="absolute -top-1 -right-1 text-[10px] font-bold tracking-wider text-red-700 bg-red-100 border border-red-200 px-2 py-0.5 rounded-full shadow-sm">
+                    <span
+                      className={cn(
+                        "absolute -top-1 -right-1 rounded-full px-2 py-0.5 text-[10px]",
+                        cnRedlineBadge("removed"),
+                      )}
+                    >
                       DEL
                     </span>
                   )}
                   {isRedlineView && isModified && (
-                    <span className="absolute -top-1 -right-1 text-[10px] font-bold tracking-wider text-amber-700 bg-amber-100 border border-amber-200 px-2 py-0.5 rounded-full shadow-sm">
+                    <span
+                      className={cn(
+                        "absolute -top-1 -right-1 rounded-full px-2 py-0.5 text-[10px]",
+                        cnRedlineBadge("modified"),
+                      )}
+                    >
                       MOD
                     </span>
                   )}
@@ -809,13 +820,11 @@ export default function Page() {
                         "p-2 rounded-lg bg-accent text-foreground group-hover:bg-accent/60 transition-colors",
                         isRedlineView &&
                           isRemoved &&
-                          "bg-red-200/40 text-destructive",
-                        isRedlineView &&
-                          isAdded &&
-                          "bg-blue-200/40 text-blue-500",
+                          redlineFieldHighlightRemoved,
+                        isRedlineView && isAdded && redlineFieldHighlightAdded,
                         isRedlineView &&
                           isModified &&
-                          "bg-amber-200/40 text-amber-500",
+                          redlineFieldHighlightModified,
                         !isRedlineView || !fieldStatus ? "border-border" : "",
                       )}
                     >
@@ -826,7 +835,7 @@ export default function Page() {
                         "text-sm font-medium text-muted-foreground truncate",
                         isRedlineView &&
                           isRemoved &&
-                          "line-through text-red-500/70",
+                          "line-through text-red-500/70 dark:text-red-400/80",
                       )}
                     >
                       {labelDiff ? (
@@ -845,7 +854,7 @@ export default function Page() {
                       "font-semibold text-lg text-foreground pl-1",
                       isRedlineView &&
                         isRemoved &&
-                        "line-through text-red-500/70",
+                        "line-through text-red-500/70 dark:text-red-400/80",
                     )}
                     title={field.value}
                   >

--- a/apps/app/features/workspace/products/product/component-details/ProductComponentDetailsTable.tsx
+++ b/apps/app/features/workspace/products/product/component-details/ProductComponentDetailsTable.tsx
@@ -17,6 +17,7 @@ import {
   useReactTable,
   VisibilityState,
 } from "@tanstack/react-table";
+import { cn } from "@uprevit/ui/lib/utils";
 import { usePathname } from "next/navigation";
 import { Fragment, useState, type ElementType } from "react";
 import {
@@ -66,6 +67,13 @@ import { advancedFilterFn } from "@/lib/table-filters";
 import DeleteComponentDialog from "./DeleteComponentDialog";
 import EditComponentDialog from "./EditComponentDialog";
 import type { DiffItem } from "@/utils/deepDiff";
+import {
+  cnRedlineBadge,
+  redlineChipAdded,
+  redlineChipRemoved,
+  redlineNewValueCompact,
+  redlineOldValueCompact,
+} from "@/utils/redlineStyles";
 import { ProductImageFrame } from "../ProductImageFrame";
 
 type ComponentItem = {
@@ -127,13 +135,13 @@ const RedlineCell = ({
     <div className="flex flex-col gap-0.5">
       {/* Old value - show for modified and removed */}
       {(isModified || isRemoved) && diff.old_value !== null && (
-        <div className="text-sm text-red-600/70">
+        <div className={redlineOldValueCompact}>
           {format(diff.old_value, "old")}
         </div>
       )}
       {/* New value - show for modified and added */}
       {(isModified || isAdded) && !isRemoved && (
-        <div className="text-sm text-blue-700">
+        <div className={redlineNewValueCompact}>
           {format(diff.new_value, "new")}
         </div>
       )}
@@ -406,13 +414,11 @@ const columns: ColumnDef<ComponentItem>[] = [
                 <Badge
                   key={index}
                   variant="outline"
-                  className={`text-xs ${
-                    isNewlyAdded
-                      ? "border-blue-400 text-blue-700 bg-blue-50 dark:bg-blue-900/20 dark:text-blue-400 dark:border-blue-500"
-                      : isRemoved
-                        ? "border-red-400 text-red-700 bg-red-50 line-through dark:bg-red-900/20 dark:text-red-400 dark:border-red-500"
-                        : ""
-                  }`}
+                  className={cn(
+                    "text-xs",
+                    isNewlyAdded && redlineChipAdded,
+                    isRemoved && redlineChipRemoved,
+                  )}
                 >
                   {type}
                 </Badge>
@@ -720,11 +726,12 @@ export default function ProductComponentDetailsTable({
                   <Fragment key={componentId}>
                     <TableRow
                       data-state={row.getIsSelected() && "selected"}
-                      className={`hover:bg-muted/50 ${
-                        isAdded ? "bg-blue-50/30 " : ""
-                      } ${isRemoved ? "bg-red-50/30" : ""} ${
-                        isModified ? "bg-amber-50/30" : ""
-                      }`}
+                      className={cn(
+                        "hover:bg-muted/50",
+                        isAdded && "bg-blue-50/30 dark:bg-blue-950/20",
+                        isRemoved && "bg-red-50/30 dark:bg-red-950/20",
+                        isModified && "bg-amber-50/30 dark:bg-amber-950/20",
+                      )}
                     >
                       {row.getVisibleCells().map((cell, cellIdx) => (
                         <TableCell
@@ -735,13 +742,12 @@ export default function ProductComponentDetailsTable({
                             {/* Status badge in expander column */}
                             {cellIdx === 0 && isRedlineView && rowStatus && (
                               <span
-                                className={`text-[9px] font-bold tracking-wider px-1.5 py-0.5 rounded-full border shadow-sm whitespace-nowrap ${
-                                  isAdded
-                                    ? "text-blue-700 bg-blue-100 border-blue-200"
-                                    : isRemoved
-                                      ? "text-red-700 bg-red-100 border-red-200"
-                                      : "text-amber-700 bg-amber-100 border-amber-200"
-                                }`}
+                                className={cn(
+                                  "whitespace-nowrap rounded-full px-1.5 py-0.5 text-[9px]",
+                                  isAdded && cnRedlineBadge("added"),
+                                  isRemoved && cnRedlineBadge("removed"),
+                                  isModified && cnRedlineBadge("modified"),
+                                )}
                               >
                                 {isAdded ? "NEW" : isRemoved ? "DEL" : "MOD"}
                               </span>

--- a/apps/app/features/workspace/products/product/graphics-other-components/SymbolsGraphicsPageBarcodesTable.tsx
+++ b/apps/app/features/workspace/products/product/graphics-other-components/SymbolsGraphicsPageBarcodesTable.tsx
@@ -66,6 +66,14 @@ import {
 import EditBarcodesDialog from "./EditBarcodesDialog";
 import DeleteSymbolsSchematicsDialog from "./DeleteSymbolsSchematicsDialog";
 import type { DiffItem } from "@/utils/deepDiff";
+import { cn } from "@uprevit/ui/lib/utils";
+import {
+  cnRedlineBadge,
+  redlineChipAdded,
+  redlineChipRemoved,
+  redlineNewValueCompact,
+  redlineOldValueCompact,
+} from "@/utils/redlineStyles";
 
 type Item = {
   id: string;
@@ -186,22 +194,20 @@ const RedlineCell = ({
     <div className="flex flex-col gap-1">
       {(isModified || isRemoved) && diff.old_value !== null && (
         <div
-          className={`line-through text-sm ${
-            showBadgeStyle
-              ? "text-red-700 px-1.5 py-0.5"
-              : "text-red-600/70 px-1.5 py-0.5"
-          }`}
+          className={cn(
+            redlineOldValueCompact,
+            showBadgeStyle && "px-1.5 py-0.5",
+          )}
         >
           {format(diff.old_value, true, false)}
         </div>
       )}
       {(isModified || isAdded) && !isRemoved && (
         <div
-          className={`text-sm ${
-            showBadgeStyle
-              ? "text-blue-700 px-1.5 py-0.5"
-              : "text-blue-700 px-1.5 py-0.5"
-          }`}
+          className={cn(
+            redlineNewValueCompact,
+            showBadgeStyle && "px-1.5 py-0.5",
+          )}
         >
           {format(diff.new_value, false, true)}
         </div>
@@ -451,13 +457,11 @@ const columns: ColumnDef<Item>[] = [
                 <Badge
                   key={index}
                   variant="outline"
-                  className={`text-xs ${
-                    isNewlyAdded
-                      ? "border-blue-400 text-blue-700 bg-blue-50 dark:bg-blue-900/20 dark:text-blue-400 dark:border-blue-500"
-                      : isRemoved
-                        ? "border-red-400 text-red-700 bg-red-50 line-through dark:bg-red-900/20 dark:text-red-400 dark:border-red-500"
-                        : ""
-                  }`}
+                  className={cn(
+                    "text-xs",
+                    isNewlyAdded && redlineChipAdded,
+                    isRemoved && redlineChipRemoved,
+                  )}
                 >
                   {label}
                 </Badge>
@@ -643,11 +647,12 @@ export default function SymbolsGraphicsPageBarcodesTable({
                   <Fragment key={itemId}>
                     <TableRow
                       data-state={row.getIsSelected() && "selected"}
-                      className={`hover:bg-muted/50 ${
-                        isAdded ? "bg-blue-50/30" : ""
-                      } ${isRemoved ? "bg-red-50/30" : ""} ${
-                        isModified ? "bg-amber-50/30" : ""
-                      }`}
+                      className={cn(
+                        "hover:bg-muted/50",
+                        isAdded && "bg-blue-50/30 dark:bg-blue-950/20",
+                        isRemoved && "bg-red-50/30 dark:bg-red-950/20",
+                        isModified && "bg-amber-50/30 dark:bg-amber-950/20",
+                      )}
                     >
                       {row.getVisibleCells().map((cell, cellIdx) => (
                         <TableCell
@@ -657,13 +662,12 @@ export default function SymbolsGraphicsPageBarcodesTable({
                           <div className="flex items-center gap-2">
                             {cellIdx === 0 && isRedlineView && rowStatus && (
                               <span
-                                className={`text-[9px] font-bold tracking-wider px-1.5 py-0.5 rounded-full border shadow-sm whitespace-nowrap ${
-                                  isAdded
-                                    ? "text-blue-700 bg-blue-100 border-blue-200"
-                                    : isRemoved
-                                      ? "text-red-700 bg-red-100 border-red-200"
-                                      : "text-amber-700 bg-amber-100 border-amber-200"
-                                }`}
+                                className={cn(
+                                  "whitespace-nowrap rounded-full px-1.5 py-0.5 text-[9px]",
+                                  isAdded && cnRedlineBadge("added"),
+                                  isRemoved && cnRedlineBadge("removed"),
+                                  isModified && cnRedlineBadge("modified"),
+                                )}
                               >
                                 {isAdded ? "NEW" : isRemoved ? "DEL" : "MOD"}
                               </span>

--- a/apps/app/features/workspace/products/product/graphics-other-components/SymbolsGraphicsPageBarcodesTable.tsx
+++ b/apps/app/features/workspace/products/product/graphics-other-components/SymbolsGraphicsPageBarcodesTable.tsx
@@ -174,12 +174,10 @@ const RedlineCell = ({
   value,
   diff,
   formatFn,
-  showBadgeStyle = false,
 }: {
   value: unknown;
   diff: DiffItem | null;
   formatFn?: (v: unknown, isOld?: boolean, isNew?: boolean) => React.ReactNode;
-  showBadgeStyle?: boolean;
 }) => {
   const format =
     formatFn ||
@@ -194,20 +192,14 @@ const RedlineCell = ({
     <div className="flex flex-col gap-1">
       {(isModified || isRemoved) && diff.old_value !== null && (
         <div
-          className={cn(
-            redlineOldValueCompact,
-            showBadgeStyle && "px-1.5 py-0.5",
-          )}
+          className={cn(redlineOldValueCompact, "px-1.5 py-0.5")}
         >
           {format(diff.old_value, true, false)}
         </div>
       )}
       {(isModified || isAdded) && !isRemoved && (
         <div
-          className={cn(
-            redlineNewValueCompact,
-            showBadgeStyle && "px-1.5 py-0.5",
-          )}
+          className={cn(redlineNewValueCompact, "px-1.5 py-0.5")}
         >
           {format(diff.new_value, false, true)}
         </div>

--- a/apps/app/features/workspace/products/product/graphics-other-components/SymbolsGraphicsPageOtherComponentsTable.tsx
+++ b/apps/app/features/workspace/products/product/graphics-other-components/SymbolsGraphicsPageOtherComponentsTable.tsx
@@ -172,12 +172,10 @@ const RedlineCell = ({
   value,
   diff,
   formatFn,
-  showBadgeStyle = false,
 }: {
   value: unknown;
   diff: DiffItem | null;
   formatFn?: (v: unknown, isOld?: boolean, isNew?: boolean) => React.ReactNode;
-  showBadgeStyle?: boolean;
 }) => {
   const format =
     formatFn ||
@@ -192,20 +190,14 @@ const RedlineCell = ({
     <div className="flex flex-col gap-1">
       {(isModified || isRemoved) && diff.old_value !== null && (
         <div
-          className={cn(
-            redlineOldValueCompact,
-            showBadgeStyle && "px-1.5 py-0.5",
-          )}
+          className={cn(redlineOldValueCompact, "px-1.5 py-0.5")}
         >
           {format(diff.old_value, true, false)}
         </div>
       )}
       {(isModified || isAdded) && !isRemoved && (
         <div
-          className={cn(
-            redlineNewValueCompact,
-            showBadgeStyle && "px-1.5 py-0.5",
-          )}
+          className={cn(redlineNewValueCompact, "px-1.5 py-0.5")}
         >
           {format(diff.new_value, false, true)}
         </div>

--- a/apps/app/features/workspace/products/product/graphics-other-components/SymbolsGraphicsPageOtherComponentsTable.tsx
+++ b/apps/app/features/workspace/products/product/graphics-other-components/SymbolsGraphicsPageOtherComponentsTable.tsx
@@ -65,6 +65,14 @@ import {
 import EditOtherComponentsDialog from "./EditOtherComponentsDialog";
 import DeleteSymbolsSchematicsDialog from "./DeleteSymbolsSchematicsDialog";
 import type { DiffItem } from "@/utils/deepDiff";
+import { cn } from "@uprevit/ui/lib/utils";
+import {
+  cnRedlineBadge,
+  redlineChipAdded,
+  redlineChipRemoved,
+  redlineNewValueCompact,
+  redlineOldValueCompact,
+} from "@/utils/redlineStyles";
 
 type Item = {
   id: string;
@@ -184,22 +192,20 @@ const RedlineCell = ({
     <div className="flex flex-col gap-1">
       {(isModified || isRemoved) && diff.old_value !== null && (
         <div
-          className={`line-through text-sm ${
-            showBadgeStyle
-              ? "text-red-700 px-1.5 py-0.5"
-              : "text-red-600/70 px-1.5 py-0.5"
-          }`}
+          className={cn(
+            redlineOldValueCompact,
+            showBadgeStyle && "px-1.5 py-0.5",
+          )}
         >
           {format(diff.old_value, true, false)}
         </div>
       )}
       {(isModified || isAdded) && !isRemoved && (
         <div
-          className={`text-sm ${
-            showBadgeStyle
-              ? "text-blue-700 px-1.5 py-0.5"
-              : "text-blue-700 px-1.5 py-0.5"
-          }`}
+          className={cn(
+            redlineNewValueCompact,
+            showBadgeStyle && "px-1.5 py-0.5",
+          )}
         >
           {format(diff.new_value, false, true)}
         </div>
@@ -449,13 +455,11 @@ const columns: ColumnDef<Item>[] = [
                 <Badge
                   key={index}
                   variant="outline"
-                  className={`text-xs ${
-                    isNewlyAdded
-                      ? "border-blue-400 text-blue-700 bg-blue-50 dark:bg-blue-900/20 dark:text-blue-400 dark:border-blue-500"
-                      : isRemoved
-                        ? "border-red-400 text-red-700 bg-red-50 line-through dark:bg-red-900/20 dark:text-red-400 dark:border-red-500"
-                        : ""
-                  }`}
+                  className={cn(
+                    "text-xs",
+                    isNewlyAdded && redlineChipAdded,
+                    isRemoved && redlineChipRemoved,
+                  )}
                 >
                   {label}
                 </Badge>
@@ -609,11 +613,12 @@ export default function SymbolsGraphicsPageOtherComponentsTable({
                   <Fragment key={itemId}>
                     <TableRow
                       data-state={row.getIsSelected() && "selected"}
-                      className={`hover:bg-muted/50 ${
-                        isAdded ? "bg-blue-50/30" : ""
-                      } ${isRemoved ? "bg-red-50/30" : ""} ${
-                        isModified ? "bg-amber-50/30" : ""
-                      }`}
+                      className={cn(
+                        "hover:bg-muted/50",
+                        isAdded && "bg-blue-50/30 dark:bg-blue-950/20",
+                        isRemoved && "bg-red-50/30 dark:bg-red-950/20",
+                        isModified && "bg-amber-50/30 dark:bg-amber-950/20",
+                      )}
                     >
                       {row.getVisibleCells().map((cell, cellIdx) => (
                         <TableCell
@@ -623,13 +628,12 @@ export default function SymbolsGraphicsPageOtherComponentsTable({
                           <div className="flex items-center gap-2">
                             {cellIdx === 0 && isRedlineView && rowStatus && (
                               <span
-                                className={`text-[9px] font-bold tracking-wider px-1.5 py-0.5 rounded-full border shadow-sm whitespace-nowrap ${
-                                  isAdded
-                                    ? "text-blue-700 bg-blue-100 border-blue-200"
-                                    : isRemoved
-                                      ? "text-red-700 bg-red-100 border-red-200"
-                                      : "text-amber-700 bg-amber-100 border-amber-200"
-                                }`}
+                                className={cn(
+                                  "whitespace-nowrap rounded-full px-1.5 py-0.5 text-[9px]",
+                                  isAdded && cnRedlineBadge("added"),
+                                  isRemoved && cnRedlineBadge("removed"),
+                                  isModified && cnRedlineBadge("modified"),
+                                )}
                               >
                                 {isAdded ? "NEW" : isRemoved ? "DEL" : "MOD"}
                               </span>

--- a/apps/app/features/workspace/products/product/graphics-other-components/SymbolsGraphicsPageSchematicsTable.tsx
+++ b/apps/app/features/workspace/products/product/graphics-other-components/SymbolsGraphicsPageSchematicsTable.tsx
@@ -171,12 +171,10 @@ const RedlineCell = ({
   value,
   diff,
   formatFn,
-  showBadgeStyle = false,
 }: {
   value: unknown;
   diff: DiffItem | null;
   formatFn?: (v: unknown, isOld?: boolean, isNew?: boolean) => React.ReactNode;
-  showBadgeStyle?: boolean;
 }) => {
   const format =
     formatFn ||
@@ -191,20 +189,14 @@ const RedlineCell = ({
     <div className="flex flex-col gap-1">
       {(isModified || isRemoved) && diff.old_value !== null && (
         <div
-          className={cn(
-            redlineOldValueCompact,
-            showBadgeStyle && "px-1.5 py-0.5",
-          )}
+          className={cn(redlineOldValueCompact, "px-1.5 py-0.5")}
         >
           {format(diff.old_value, true, false)}
         </div>
       )}
       {(isModified || isAdded) && !isRemoved && (
         <div
-          className={cn(
-            redlineNewValueCompact,
-            showBadgeStyle && "px-1.5 py-0.5",
-          )}
+          className={cn(redlineNewValueCompact, "px-1.5 py-0.5")}
         >
           {format(diff.new_value, false, true)}
         </div>

--- a/apps/app/features/workspace/products/product/graphics-other-components/SymbolsGraphicsPageSchematicsTable.tsx
+++ b/apps/app/features/workspace/products/product/graphics-other-components/SymbolsGraphicsPageSchematicsTable.tsx
@@ -65,6 +65,14 @@ import {
 import EditSchematicsDialog from "./EditSchematicsDialog";
 import DeleteSymbolsSchematicsDialog from "./DeleteSymbolsSchematicsDialog";
 import type { DiffItem } from "@/utils/deepDiff";
+import { cn } from "@uprevit/ui/lib/utils";
+import {
+  cnRedlineBadge,
+  redlineChipAdded,
+  redlineChipRemoved,
+  redlineNewValueCompact,
+  redlineOldValueCompact,
+} from "@/utils/redlineStyles";
 
 type Item = {
   id: string;
@@ -183,22 +191,20 @@ const RedlineCell = ({
     <div className="flex flex-col gap-1">
       {(isModified || isRemoved) && diff.old_value !== null && (
         <div
-          className={`line-through text-sm ${
-            showBadgeStyle
-              ? "text-red-700 px-1.5 py-0.5"
-              : "text-red-600/70 px-1.5 py-0.5"
-          }`}
+          className={cn(
+            redlineOldValueCompact,
+            showBadgeStyle && "px-1.5 py-0.5",
+          )}
         >
           {format(diff.old_value, true, false)}
         </div>
       )}
       {(isModified || isAdded) && !isRemoved && (
         <div
-          className={`text-sm ${
-            showBadgeStyle
-              ? "text-blue-700 px-1.5 py-0.5"
-              : "text-blue-700 px-1.5 py-0.5"
-          }`}
+          className={cn(
+            redlineNewValueCompact,
+            showBadgeStyle && "px-1.5 py-0.5",
+          )}
         >
           {format(diff.new_value, false, true)}
         </div>
@@ -462,13 +468,11 @@ const columns: ColumnDef<Item>[] = [
                 <Badge
                   key={index}
                   variant="outline"
-                  className={`text-xs ${
-                    isNewlyAdded
-                      ? "border-blue-400 text-blue-700 bg-blue-50 dark:bg-blue-900/20 dark:text-blue-400 dark:border-blue-500"
-                      : isRemoved
-                        ? "border-red-400 text-red-700 bg-red-50 line-through dark:bg-red-900/20 dark:text-red-400 dark:border-red-500"
-                        : ""
-                  }`}
+                  className={cn(
+                    "text-xs",
+                    isNewlyAdded && redlineChipAdded,
+                    isRemoved && redlineChipRemoved,
+                  )}
                 >
                   {label}
                 </Badge>
@@ -629,11 +633,12 @@ export default function SymbolsGraphicsPageSchematicsTable({
                   <Fragment key={itemId}>
                     <TableRow
                       data-state={row.getIsSelected() && "selected"}
-                      className={`hover:bg-muted/50 ${
-                        isAdded ? "bg-blue-50/30" : ""
-                      } ${isRemoved ? "bg-red-50/30" : ""} ${
-                        isModified ? "bg-amber-50/30" : ""
-                      }`}
+                      className={cn(
+                        "hover:bg-muted/50",
+                        isAdded && "bg-blue-50/30 dark:bg-blue-950/20",
+                        isRemoved && "bg-red-50/30 dark:bg-red-950/20",
+                        isModified && "bg-amber-50/30 dark:bg-amber-950/20",
+                      )}
                     >
                       {row.getVisibleCells().map((cell, cellIdx) => (
                         <TableCell
@@ -643,13 +648,12 @@ export default function SymbolsGraphicsPageSchematicsTable({
                           <div className="flex items-center gap-2">
                             {cellIdx === 0 && isRedlineView && rowStatus && (
                               <span
-                                className={`text-[9px] font-bold tracking-wider px-1.5 py-0.5 rounded-full border shadow-sm whitespace-nowrap ${
-                                  isAdded
-                                    ? "text-blue-700 bg-blue-100 border-blue-200"
-                                    : isRemoved
-                                      ? "text-red-700 bg-red-100 border-red-200"
-                                      : "text-amber-700 bg-amber-100 border-amber-200"
-                                }`}
+                                className={cn(
+                                  "whitespace-nowrap rounded-full px-1.5 py-0.5 text-[9px]",
+                                  isAdded && cnRedlineBadge("added"),
+                                  isRemoved && cnRedlineBadge("removed"),
+                                  isModified && cnRedlineBadge("modified"),
+                                )}
                               >
                                 {isAdded ? "NEW" : isRemoved ? "DEL" : "MOD"}
                               </span>

--- a/apps/app/features/workspace/products/product/graphics-other-components/SymbolsGraphicsPageSymbolsTable.tsx
+++ b/apps/app/features/workspace/products/product/graphics-other-components/SymbolsGraphicsPageSymbolsTable.tsx
@@ -173,12 +173,10 @@ const RedlineCell = ({
   value,
   diff,
   formatFn,
-  showBadgeStyle = false,
 }: {
   value: unknown;
   diff: DiffItem | null;
   formatFn?: (v: unknown, isOld?: boolean, isNew?: boolean) => React.ReactNode;
-  showBadgeStyle?: boolean;
 }) => {
   const format =
     formatFn ||
@@ -195,10 +193,7 @@ const RedlineCell = ({
       {/* Old value - show for modified and removed */}
       {(isModified || isRemoved) && diff.old_value !== null && (
         <div
-          className={cn(
-            redlineOldValueCompact,
-            showBadgeStyle && "px-1.5 py-0.5",
-          )}
+          className={cn(redlineOldValueCompact, "px-1.5 py-0.5")}
         >
           {format(diff.old_value, true, false)}
         </div>
@@ -206,10 +201,7 @@ const RedlineCell = ({
       {/* New value - show for modified and added */}
       {(isModified || isAdded) && !isRemoved && (
         <div
-          className={cn(
-            redlineNewValueCompact,
-            showBadgeStyle && "px-1.5 py-0.5",
-          )}
+          className={cn(redlineNewValueCompact, "px-1.5 py-0.5")}
         >
           {format(diff.new_value, false, true)}
         </div>
@@ -399,7 +391,6 @@ const columns: ColumnDef<Item>[] = [
           <RedlineCell
             value={row.getValue("textPresent")}
             diff={diff}
-            showBadgeStyle={true}
             formatFn={(v, isOld, isNew) => (
               <Badge
                 variant={

--- a/apps/app/features/workspace/products/product/graphics-other-components/SymbolsGraphicsPageSymbolsTable.tsx
+++ b/apps/app/features/workspace/products/product/graphics-other-components/SymbolsGraphicsPageSymbolsTable.tsx
@@ -65,6 +65,14 @@ import {
 import EditSymbolsDialog from "./EditSymbolsDialog";
 import DeleteSymbolsSchematicsDialog from "./DeleteSymbolsSchematicsDialog";
 import type { DiffItem } from "@/utils/deepDiff";
+import { cn } from "@uprevit/ui/lib/utils";
+import {
+  cnRedlineBadge,
+  redlineChipAdded,
+  redlineChipRemoved,
+  redlineNewValueCompact,
+  redlineOldValueCompact,
+} from "@/utils/redlineStyles";
 
 type Item = {
   id: string;
@@ -187,9 +195,10 @@ const RedlineCell = ({
       {/* Old value - show for modified and removed */}
       {(isModified || isRemoved) && diff.old_value !== null && (
         <div
-          className={`line-through text-sm ${
-            showBadgeStyle ? "text-red-700" : "text-red-600/70"
-          }`}
+          className={cn(
+            redlineOldValueCompact,
+            showBadgeStyle && "px-1.5 py-0.5",
+          )}
         >
           {format(diff.old_value, true, false)}
         </div>
@@ -197,9 +206,10 @@ const RedlineCell = ({
       {/* New value - show for modified and added */}
       {(isModified || isAdded) && !isRemoved && (
         <div
-          className={`text-sm ${
-            showBadgeStyle ? "text-blue-700" : "text-blue-700"
-          }`}
+          className={cn(
+            redlineNewValueCompact,
+            showBadgeStyle && "px-1.5 py-0.5",
+          )}
         >
           {format(diff.new_value, false, true)}
         </div>
@@ -401,13 +411,11 @@ const columns: ColumnDef<Item>[] = [
                         ? "default"
                         : "secondary"
                 }
-                className={`${
-                  isNew
-                    ? "bg-blue-600 hover:bg-blue-700 text-white border-blue-500"
-                    : isOld
-                      ? "bg-red-100 text-red-700 border-red-300 dark:bg-red-900/30 dark:text-red-400 line-through"
-                      : ""
-                }`}
+                className={cn(
+                  isNew &&
+                    "border-blue-500 bg-blue-600 text-white hover:bg-blue-700 dark:bg-blue-700 dark:hover:bg-blue-600",
+                  isOld && redlineChipRemoved,
+                )}
               >
                 {v ? "Yes" : "No"}
               </Badge>
@@ -487,13 +495,11 @@ const columns: ColumnDef<Item>[] = [
                 <Badge
                   key={index}
                   variant="outline"
-                  className={`text-xs ${
-                    isNewlyAdded
-                      ? "border-blue-400 text-blue-700 bg-blue-50 dark:bg-blue-900/20 dark:text-blue-400 dark:border-blue-500"
-                      : isRemoved
-                        ? "border-red-400 text-red-700 bg-red-50 line-through dark:bg-red-900/20 dark:text-red-400 dark:border-red-500"
-                        : ""
-                  }`}
+                  className={cn(
+                    "text-xs",
+                    isNewlyAdded && redlineChipAdded,
+                    isRemoved && redlineChipRemoved,
+                  )}
                 >
                   {symbol}
                 </Badge>
@@ -650,11 +656,12 @@ export default function SymbolsGraphicsPageSymbolsTable({
                   <Fragment key={itemId}>
                     <TableRow
                       data-state={row.getIsSelected() && "selected"}
-                      className={`hover:bg-muted/50 ${
-                        isAdded ? "bg-blue-50/30" : ""
-                      } ${isRemoved ? "bg-red-50/30" : ""} ${
-                        isModified ? "bg-amber-50/30" : ""
-                      }`}
+                      className={cn(
+                        "hover:bg-muted/50",
+                        isAdded && "bg-blue-50/30 dark:bg-blue-950/20",
+                        isRemoved && "bg-red-50/30 dark:bg-red-950/20",
+                        isModified && "bg-amber-50/30 dark:bg-amber-950/20",
+                      )}
                     >
                       {row.getVisibleCells().map((cell, cellIdx) => (
                         <TableCell
@@ -665,13 +672,12 @@ export default function SymbolsGraphicsPageSymbolsTable({
                             {/* Status badge in expander column */}
                             {cellIdx === 0 && isRedlineView && rowStatus && (
                               <span
-                                className={`text-[9px] font-bold tracking-wider px-1.5 py-0.5 rounded-full border shadow-sm whitespace-nowrap ${
-                                  isAdded
-                                    ? "text-blue-700 bg-blue-100 border-blue-200"
-                                    : isRemoved
-                                      ? "text-red-700 bg-red-100 border-red-200"
-                                      : "text-amber-700 bg-amber-100 border-amber-200"
-                                }`}
+                                className={cn(
+                                  "whitespace-nowrap rounded-full px-1.5 py-0.5 text-[9px]",
+                                  isAdded && cnRedlineBadge("added"),
+                                  isRemoved && cnRedlineBadge("removed"),
+                                  isModified && cnRedlineBadge("modified"),
+                                )}
                               >
                                 {isAdded ? "NEW" : isRemoved ? "DEL" : "MOD"}
                               </span>

--- a/apps/app/features/workspace/products/product/label-tags/labelTagsTabs.tsx
+++ b/apps/app/features/workspace/products/product/label-tags/labelTagsTabs.tsx
@@ -33,6 +33,14 @@ import { LegendPanel } from "./LegendPanel";
 import { LegendItem } from "./legendTypes";
 import type { DiffItem } from "@/utils/deepDiff";
 import { annotationsMatchForComparison } from "@/utils/product/label-tag-annotation";
+import {
+  cnRedlineBadge,
+  redlineCardAdded,
+  redlineCardModified,
+  redlineCardRemoved,
+  redlineNewValue,
+  redlineOldValue,
+} from "@/utils/redlineStyles";
 
 interface LabelTagItem {
   _id: string;
@@ -627,11 +635,16 @@ export default function LabelTagsTabs({
         <div className="flex flex-col gap-2">
           {(oldValue || isRemoved) && (
             <div className="relative">
-              <span className="absolute top-2 left-2 z-10 text-[10px] font-bold tracking-wider text-red-700 bg-red-100 border border-red-200 px-2 py-0.5 rounded-full shadow-sm">
+              <span
+                className={cn(
+                  "absolute top-2 left-2 z-10 rounded-full px-2 py-0.5 text-[10px]",
+                  cnRedlineBadge("removed"),
+                )}
+              >
                 OLD
               </span>
               {oldValue ? (
-                <div className="aspect-square relative overflow-hidden rounded-lg border-2 border-red-300 bg-red-50/30 opacity-60">
+                <div className="aspect-square relative overflow-hidden rounded-lg border-2 border-red-300 bg-red-50/30 opacity-60 dark:border-red-700/50 dark:bg-red-950/20">
                   <Image
                     src={oldValue}
                     alt="Previous image"
@@ -641,7 +654,7 @@ export default function LabelTagsTabs({
                   />
                 </div>
               ) : (
-                <div className="flex flex-col items-center justify-center p-6 text-muted-foreground bg-red-50/30 rounded-lg border-2 border-red-300 border-dashed opacity-60">
+                <div className="flex flex-col items-center justify-center p-6 text-muted-foreground bg-red-50/30 rounded-lg border-2 border-red-300 border-dashed opacity-60 dark:border-red-700/50 dark:bg-red-950/20">
                   <PiImageDuotone className="w-8 h-8 mb-2 opacity-50" />
                   <p className="text-xs">No image</p>
                 </div>
@@ -655,11 +668,16 @@ export default function LabelTagsTabs({
           )}
           {(newValue || isAdded) && !isRemoved && (
             <div className="relative">
-              <span className="absolute top-2 left-2 z-10 text-[10px] font-bold tracking-wider text-blue-700 bg-blue-100 border border-blue-200 px-2 py-0.5 rounded-full shadow-sm">
+              <span
+                className={cn(
+                  "absolute top-2 left-2 z-10 rounded-full px-2 py-0.5 text-[10px]",
+                  cnRedlineBadge("added"),
+                )}
+              >
                 NEW
               </span>
               {newValue ? (
-                <div className="aspect-square relative overflow-hidden rounded-lg border-2 border-blue-300 bg-blue-50/30">
+                <div className="aspect-square relative overflow-hidden rounded-lg border-2 border-blue-300 bg-blue-50/30 dark:border-blue-700/50 dark:bg-blue-950/20">
                   <Image
                     src={newValue}
                     alt="New image"
@@ -669,7 +687,7 @@ export default function LabelTagsTabs({
                   />
                 </div>
               ) : (
-                <div className="flex flex-col items-center justify-center p-6 text-muted-foreground bg-blue-50/30 rounded-lg border-2 border-blue-300 border-dashed">
+                <div className="flex flex-col items-center justify-center p-6 text-muted-foreground bg-blue-50/30 rounded-lg border-2 border-blue-300 border-dashed dark:border-blue-700/50 dark:bg-blue-950/20">
                   <PiImageDuotone className="w-8 h-8 mb-2 opacity-50" />
                   <p className="text-xs">No image</p>
                 </div>
@@ -687,7 +705,7 @@ export default function LabelTagsTabs({
             {/* <span className="text-[9px] font-bold tracking-wider text-red-700 bg-red-100 border border-red-200 px-1.5 py-0.5 rounded-full shadow-sm">
               OLD
             </span> */}
-            <span className="line-through text-sm text-red-600/70 ">
+            <span className={redlineOldValue}>
               {format(diff.old_value) || ""}
             </span>
           </span>
@@ -705,7 +723,7 @@ export default function LabelTagsTabs({
             {/* <span className="text-[9px] font-bold tracking-wider text-blue-700 bg-blue-100 border border-blue-200 px-1.5 py-0.5 rounded-full shadow-sm">
               NEW
             </span> */}
-            <span className="text-sm text-blue-700 ">
+            <span className={redlineNewValue}>
               {format(diff.new_value) ||
                 (emptyLabel ? (
                   <span className="text-muted-foreground/35 italic">
@@ -812,11 +830,11 @@ export default function LabelTagsTabs({
                     className={cn(
                       "gap-2",
                       isTypeAdded &&
-                        "text-blue-700 data-[state=active]:bg-blue-50 data-[state=active]:text-blue-800",
+                        "text-blue-700 data-[state=active]:bg-blue-50 data-[state=active]:text-blue-800 dark:text-blue-400 dark:data-[state=active]:bg-blue-950/30 dark:data-[state=active]:text-blue-300",
                       isTypeRemoved &&
-                        "text-red-700 data-[state=active]:bg-red-50 data-[state=active]:text-red-800",
+                        "text-red-700 data-[state=active]:bg-red-50 data-[state=active]:text-red-800 dark:text-red-400 dark:data-[state=active]:bg-red-950/30 dark:data-[state=active]:text-red-300",
                       isTypeModified &&
-                        "text-amber-700 data-[state=active]:bg-amber-50 data-[state=active]:text-amber-800",
+                        "text-amber-700 data-[state=active]:bg-amber-50 data-[state=active]:text-amber-800 dark:text-amber-400 dark:data-[state=active]:bg-amber-950/30 dark:data-[state=active]:text-amber-300",
                     )}
                   >
                     {isTypeModified && typeDiff ? (
@@ -825,17 +843,32 @@ export default function LabelTagsTabs({
                       <span>{type}</span>
                     )}
                     {isTypeAdded && (
-                      <span className="text-[9px] font-bold tracking-wider text-blue-700 bg-blue-100 border border-blue-200 px-2 py-0.5 rounded-full shadow-sm">
+                      <span
+                        className={cn(
+                          "rounded-full px-2 py-0.5 text-[9px]",
+                          cnRedlineBadge("added"),
+                        )}
+                      >
                         NEW
                       </span>
                     )}
                     {isTypeRemoved && (
-                      <span className="text-[9px] font-bold tracking-wider text-red-700 bg-red-100 border border-red-200 px-2 py-0.5 rounded-full shadow-sm">
+                      <span
+                        className={cn(
+                          "rounded-full px-2 py-0.5 text-[9px]",
+                          cnRedlineBadge("removed"),
+                        )}
+                      >
                         DEL
                       </span>
                     )}
                     {isTypeModified && (
-                      <span className="text-[9px] font-bold tracking-wider text-amber-700 bg-amber-100 border border-amber-200 px-2 py-0.5 rounded-full shadow-sm">
+                      <span
+                        className={cn(
+                          "rounded-full px-2 py-0.5 text-[9px]",
+                          cnRedlineBadge("modified"),
+                        )}
+                      >
                         MOD
                       </span>
                     )}
@@ -868,13 +901,13 @@ export default function LabelTagsTabs({
                         "w-full shadow-none transition-all duration-200 mb-4 last:mb-0",
                         isRedlineView &&
                           isRemoved &&
-                          "border-red-500/50 bg-red-100/5 opacity-60",
+                          redlineCardRemoved,
                         isRedlineView &&
                           isAdded &&
-                          "border-blue-500/50 bg-blue-100/5",
+                          redlineCardAdded,
                         isRedlineView &&
                           isModified &&
-                          "border-amber-500/50 bg-amber-100/10",
+                          redlineCardModified,
                         !isRedlineView || !itemStatus ? "border-border" : "",
                       )}
                     >
@@ -883,17 +916,32 @@ export default function LabelTagsTabs({
                           <div className="space-y-1">
                             <div className="flex items-center gap-2">
                               {isRedlineView && isAdded && (
-                                <span className="text-[10px] font-bold tracking-wider text-blue-700 bg-blue-100 border border-blue-200 px-2 py-0.5 rounded-full shadow-sm">
+                                <span
+                                  className={cn(
+                                    "rounded-full px-2 py-0.5 text-[10px]",
+                                    cnRedlineBadge("added"),
+                                  )}
+                                >
                                   NEW
                                 </span>
                               )}
                               {isRedlineView && isRemoved && (
-                                <span className="text-[10px] font-bold tracking-wider text-red-700 bg-red-100 border border-red-200 px-2 py-0.5 rounded-full shadow-sm">
+                                <span
+                                  className={cn(
+                                    "rounded-full px-2 py-0.5 text-[10px]",
+                                    cnRedlineBadge("removed"),
+                                  )}
+                                >
                                   DEL
                                 </span>
                               )}
                               {isRedlineView && isModified && (
-                                <span className="text-[10px] font-bold tracking-wider text-amber-700 bg-amber-100 border border-amber-200 px-2 py-0.5 rounded-full shadow-sm">
+                                <span
+                                  className={cn(
+                                    "rounded-full px-2 py-0.5 text-[10px]",
+                                    cnRedlineBadge("modified"),
+                                  )}
+                                >
                                   MOD
                                 </span>
                               )}
@@ -903,7 +951,7 @@ export default function LabelTagsTabs({
                                 "text-sm font-semibold flex items-center gap-2",
                                 isRedlineView &&
                                   isRemoved &&
-                                  "line-through text-red-500/70",
+                                  "line-through text-red-500/70 dark:text-red-400/80",
                               )}
                             >
                               <span className="text-[10px] font-semibold uppercase tracking-wide text-muted-foreground bg-muted/60 border border-border/60 px-2 py-0.5 rounded-full">
@@ -927,7 +975,7 @@ export default function LabelTagsTabs({
                                   "text-sm font-normal text-muted-foreground",
                                   isRedlineView &&
                                     isRemoved &&
-                                    "line-through text-red-500/70",
+                                    "line-through text-red-500/70 dark:text-red-400/80",
                                 )}
                               >
                                 {isRedlineView && descriptionDiff ? (
@@ -998,9 +1046,9 @@ export default function LabelTagsTabs({
                                 className={cn(
                                   "flex flex-col items-center justify-center p-12 text-muted-foreground rounded-lg border border-dashed w-full max-w-md",
                                   isRedlineView && isRemoved
-                                    ? "border-red-300 bg-red-50/30 opacity-60"
+                                    ? "border-red-300 bg-red-50/30 opacity-60 dark:border-red-700/50 dark:bg-red-950/20"
                                     : isRedlineView && isAdded
-                                      ? "border-blue-300 bg-blue-50/30"
+                                      ? "border-blue-300 bg-blue-50/30 dark:border-blue-700/50 dark:bg-blue-950/20"
                                       : "bg-muted/50 border-border",
                                 )}
                               >

--- a/apps/app/features/workspace/products/product/product-data-table/ProductSpecificationDataTable.tsx
+++ b/apps/app/features/workspace/products/product/product-data-table/ProductSpecificationDataTable.tsx
@@ -30,6 +30,23 @@ import {
 } from "@/types/product-data-table";
 import { sparseProductSpecDataForDatabase } from "@/utils/product/product-spec";
 import {
+  getRedlineHighlightInsetShadow,
+  redlineHighlightBorder,
+  redlineHighlightRing,
+  redlineOldValueCompact,
+  redlineNewValueCompact,
+} from "@/utils/redlineStyles";
+import {
+  getWorkbookFillPalette,
+  getWorkbookTextPalette,
+  getWorkbookTheme,
+  isDefaultWorkbookTextColor,
+  NO_FILL_COLOR,
+  resolveWorkbookFillColor,
+  resolveWorkbookTextColor,
+  type WorkbookTheme,
+} from "@/utils/product/workbook-cell-colors";
+import {
   closestCenter,
   DndContext,
   KeyboardSensor,
@@ -83,6 +100,7 @@ import {
   PiMagnifyingGlassDuotone,
   PiUploadSimpleDuotone,
 } from "react-icons/pi";
+import { cn } from "@uprevit/ui/lib/utils";
 import { toast } from "sonner";
 import { applyFilter, detectColumnDataType } from "./column-filter-utils";
 import { ColumnFilterPopover } from "./ColumnFilterPopover";
@@ -168,41 +186,6 @@ const ROW_NUMBER_WIDTH = 60;
 const MIN_COL_WIDTH = 50;
 const MAX_COL_WIDTH = 500;
 
-const NO_FILL_COLOR = "transparent";
-
-const LIGHT_FILL_COLORS = [
-  NO_FILL_COLOR,
-  "#f9fafb",
-  "#fffbeb",
-  "#f0fdf4",
-  "#eff6ff",
-  "#fdf2f8",
-  "#fef2f2",
-  "#eef2ff",
-];
-
-const DARK_FILL_COLORS = [
-  NO_FILL_COLOR,
-  "#27272a",
-  "#422006",
-  "#052e16",
-  "#172554",
-  "#4a044e",
-  "#450a0a",
-  "#312e81",
-];
-
-const DEFAULT_TEXT_COLORS = [
-  "#000000",
-  "#4b5563",
-  "#d97706",
-  "#16a34a",
-  "#2563eb",
-  "#db2777",
-  "#dc2626",
-  "#4f46e5",
-];
-
 // Row data type for the table
 type RowData = { rowIndex: number };
 
@@ -225,6 +208,7 @@ interface TableMeta {
     React.SetStateAction<Record<number, ColumnFilter>>
   >;
   isReadOnly?: boolean;
+  workbookTheme: WorkbookTheme;
 }
 
 function DiffValueDisplay<T extends string>({
@@ -237,12 +221,12 @@ function DiffValueDisplay<T extends string>({
   return (
     <div className="flex flex-col gap-0.5">
       {diff.status !== "added" && (
-        <span className="truncate text-red-600/80 line-through">
+        <span className={cn("truncate", redlineOldValueCompact)}>
           {formatValue(diff.oldValue)}
         </span>
       )}
       {diff.status !== "removed" && (
-        <span className="truncate text-blue-700 font-semibold">
+        <span className={cn("truncate font-semibold", redlineNewValueCompact)}>
           {formatValue(diff.newValue)}
         </span>
       )}
@@ -277,12 +261,14 @@ const EditableHeaderContent = ({
   const headerInput = (
     <div className="relative flex-1 min-w-0 h-full">
       <input
-        className={`h-full w-full bg-transparent outline-none text-xs font-medium placeholder:text-muted-foreground ${
-          showHighlightDiff ? "ring-1 ring-amber-400/60 ring-inset" : ""
-        } ${showInlineDiff ? "caret-transparent" : ""}`}
+        className={cn(
+          "h-full w-full bg-transparent outline-none text-xs font-medium placeholder:text-muted-foreground",
+          showHighlightDiff && redlineHighlightRing,
+          showInlineDiff && "caret-transparent",
+        )}
         style={{
           boxShadow: showHighlightDiff
-            ? "inset 0 0 0 9999px rgba(251, 191, 36, 0.12)"
+            ? getRedlineHighlightInsetShadow(meta.workbookTheme)
             : undefined,
           color: showInlineDiff ? "transparent" : undefined,
           caretColor: showInlineDiff ? "transparent" : undefined,
@@ -498,8 +484,9 @@ export function ProductSpecificationDataTable({
   const fileInputRef = useRef<HTMLInputElement>(null);
   const hasLoadedData = useRef(false);
   const dndContextId = useId();
-  const fillColors =
-    resolvedTheme === "dark" ? DARK_FILL_COLORS : LIGHT_FILL_COLORS;
+  const workbookTheme = getWorkbookTheme(resolvedTheme);
+  const fillColors = getWorkbookFillPalette(workbookTheme);
+  const textColors = getWorkbookTextPalette(workbookTheme);
 
   useEffect(() => {
     if (!hasLoadedData.current && initialData) {
@@ -986,7 +973,7 @@ export function ProductSpecificationDataTable({
         const prev = cellFormats[key];
         const next = {
           ...prev,
-          textColor: color === "#000000" ? undefined : color,
+          textColor: isDefaultWorkbookTextColor(color) ? undefined : color,
         };
         changes.push({ key, prev, next });
         setCellFormats((f) => ({ ...f, [key]: next }));
@@ -995,7 +982,7 @@ export function ProductSpecificationDataTable({
           const prev = cellFormats[key];
           const next = {
             ...prev,
-            textColor: color === "#000000" ? undefined : color,
+            textColor: isDefaultWorkbookTextColor(color) ? undefined : color,
           };
           changes.push({ key, prev, next });
         });
@@ -1004,7 +991,7 @@ export function ProductSpecificationDataTable({
           selectedCells.forEach((key) => {
             updated[key] = {
               ...updated[key],
-              textColor: color === "#000000" ? undefined : color,
+              textColor: isDefaultWorkbookTextColor(color) ? undefined : color,
             };
           });
           return updated;
@@ -1106,6 +1093,7 @@ export function ProductSpecificationDataTable({
       columnFilters,
       setColumnFilters,
       isReadOnly,
+      workbookTheme,
     },
     state: {
       columnSizing,
@@ -1461,13 +1449,13 @@ export function ProductSpecificationDataTable({
         <div className="flex items-center gap-1.5">
           <span className="text-xs text-muted-foreground">Text:</span>
           <div className="flex gap-0.5">
-            {DEFAULT_TEXT_COLORS.map((color) => (
+            {textColors.map((color) => (
               <button
                 key={`text-${color}`}
                 onClick={() => applyTextColor(color)}
                 disabled={isReadOnly}
                 className="size-5 rounded border border-border hover:ring-2 hover:ring-primary/50 transition-all flex items-center justify-center"
-                title={color === "#000000" ? "Default" : color}
+                title={isDefaultWorkbookTextColor(color) ? "Default" : color}
               >
                 <span className="text-xs font-bold" style={{ color }}>
                   A
@@ -1668,18 +1656,17 @@ export function ProductSpecificationDataTable({
                     const select = (
                       <div
                         key={`type-${column.id}`}
-                        className={`border-r border-b border-border flex items-center bg-muted ${
-                          showHighlightDiff
-                            ? "ring-1 ring-amber-400/60 ring-inset"
-                            : ""
-                        }`}
+                        className={cn(
+                          "border-r border-b border-border flex items-center bg-muted",
+                          showHighlightDiff && redlineHighlightRing,
+                        )}
                         style={{
                           position: "absolute",
                           left: virtualCol.start,
                           width: virtualCol.size,
                           height: ROW_HEIGHT,
                           boxShadow: showHighlightDiff
-                            ? "inset 0 0 0 9999px rgba(251, 191, 36, 0.12)"
+                            ? getRedlineHighlightInsetShadow(workbookTheme)
                             : undefined,
                         }}
                       >
@@ -1794,28 +1781,36 @@ export function ProductSpecificationDataTable({
                       const showHighlightDiff =
                         isRedlineView && redlineMode === "highlight" && diff;
 
+                      const resolvedBg = resolveWorkbookFillColor(
+                        format?.bgColor,
+                        workbookTheme,
+                      );
+                      const resolvedText = resolveWorkbookTextColor(
+                        format?.textColor,
+                        workbookTheme,
+                      );
+
                       const input = (
                         <input
                           data-cell-key={cellKey}
                           readOnly={isReadOnly}
-                          className={`h-full w-full border border-border/60 outline-none px-2 text-sm ${
+                          className={cn(
+                            "h-full w-full border border-border/60 outline-none px-2 text-sm",
                             isSelected
                               ? "ring-1 ring-primary ring-inset border-foreground/60"
-                              : "border-border"
-                          } ${
-                            showHighlightDiff
-                              ? "ring-1 ring-amber-400/60 border-amber-400/70"
-                              : ""
-                          } ${showInlineDiff ? "caret-transparent" : ""}`}
+                              : "border-border",
+                            showHighlightDiff && redlineHighlightBorder,
+                            showInlineDiff && "caret-transparent",
+                          )}
                           style={{
                             backgroundColor:
-                              format?.bgColor || "var(--background)",
+                              resolvedBg || "var(--background)",
                             boxShadow: showHighlightDiff
-                              ? "inset 0 0 0 9999px rgba(251, 191, 36, 0.12)"
+                              ? getRedlineHighlightInsetShadow(workbookTheme)
                               : undefined,
                             color: showInlineDiff
                               ? "transparent"
-                              : format?.textColor || "inherit",
+                              : resolvedText || "inherit",
                             caretColor: showInlineDiff
                               ? "transparent"
                               : undefined,

--- a/apps/app/features/workspace/products/product/product-data-table/ProductWorkbookTabPage.tsx
+++ b/apps/app/features/workspace/products/product/product-data-table/ProductWorkbookTabPage.tsx
@@ -169,7 +169,7 @@ export function ProductWorkbookTabPage({
     <div className="flex flex-1 flex-col gap-2 p-2 min-h-0 overflow-hidden">
       {isRedlineView && (
         <div className="px-2 py-2 bg-amber-500/10 border border-amber-500/30 rounded-lg flex items-center gap-2 text-sm">
-          <span className="text-amber-600 font-medium">
+          <span className="text-amber-600 dark:text-amber-400 font-medium">
             {isLoadingDiff ? "Loading changes..." : redlineBannerLabel}
           </span>
         </div>
@@ -217,7 +217,9 @@ export function ProductWorkbookTabPage({
                 <span className="text-xs">Saving</span>
               </div>
             ) : editor.hasEditableUnsavedChanges ? (
-              <span className="text-xs text-amber-600">Unsaved changes</span>
+              <span className="text-xs text-amber-600 dark:text-amber-400">
+                Unsaved changes
+              </span>
             ) : editor.lastSavedAt ? (
               <div className="flex items-center gap-1.5 text-muted-foreground">
                 <PiCloudCheckDuotone className="w-4 h-4 text-green-600" />

--- a/apps/app/features/workspace/products/product/product-specifications/UniverReadOnlyViewer.tsx
+++ b/apps/app/features/workspace/products/product/product-specifications/UniverReadOnlyViewer.tsx
@@ -8,6 +8,8 @@ import {
   merge,
 } from "@univerjs/presets";
 import { IWorkbookData } from "@univerjs/core";
+import { cn } from "@uprevit/ui/lib/utils";
+import { redlineBadgeAdded, redlineBadgeRemoved } from "@/utils/redlineStyles";
 import { UniverSheetsCorePreset } from "@univerjs/presets/preset-sheets-core";
 import UniverPresetSheetsCoreEnUS from "@univerjs/presets/preset-sheets-core/locales/en-US";
 
@@ -74,9 +76,9 @@ export default function UniverReadOnlyViewer({
   const getBorderColor = () => {
     switch (variant) {
       case "old":
-        return "border-red-300/50";
+        return "border-red-300/50 dark:border-red-700/50";
       case "new":
-        return "border-blue-300/50";
+        return "border-blue-300/50 dark:border-blue-700/50";
       default:
         return "border-border";
     }
@@ -85,9 +87,9 @@ export default function UniverReadOnlyViewer({
   const getLabelColor = () => {
     switch (variant) {
       case "old":
-        return "text-red-700 bg-red-100 border-red-200";
+        return cn(redlineBadgeRemoved, "border");
       case "new":
-        return "text-blue-700 bg-blue-100 border-blue-200";
+        return cn(redlineBadgeAdded, "border");
       default:
         return "text-muted-foreground bg-muted border-border";
     }

--- a/apps/app/utils/product/workbook-cell-colors.ts
+++ b/apps/app/utils/product/workbook-cell-colors.ts
@@ -1,0 +1,115 @@
+export const NO_FILL_COLOR = "transparent";
+
+export const LIGHT_FILL_COLORS = [
+  NO_FILL_COLOR,
+  "#f9fafb",
+  "#fffbeb",
+  "#f0fdf4",
+  "#eff6ff",
+  "#fdf2f8",
+  "#fef2f2",
+  "#eef2ff",
+] as const;
+
+export const DARK_FILL_COLORS = [
+  NO_FILL_COLOR,
+  "#27272a",
+  "#422006",
+  "#052e16",
+  "#172554",
+  "#4a044e",
+  "#450a0a",
+  "#312e81",
+] as const;
+
+export const LIGHT_TEXT_COLORS = [
+  "#000000",
+  "#4b5563",
+  "#d97706",
+  "#16a34a",
+  "#2563eb",
+  "#db2777",
+  "#dc2626",
+  "#4f46e5",
+] as const;
+
+export const DARK_TEXT_COLORS = [
+  "#fafafa",
+  "#a1a1aa",
+  "#fbbf24",
+  "#4ade80",
+  "#60a5fa",
+  "#f472b6",
+  "#f87171",
+  "#a78bfa",
+] as const;
+
+export type WorkbookTheme = "light" | "dark";
+
+export function isDefaultWorkbookTextColor(color: string | undefined): boolean {
+  if (!color) return true;
+  return (
+    color === LIGHT_TEXT_COLORS[0] ||
+    color === DARK_TEXT_COLORS[0]
+  );
+}
+
+function resolvePaletteColor(
+  stored: string | undefined,
+  theme: WorkbookTheme,
+  lightPalette: readonly string[],
+  darkPalette: readonly string[],
+): string | undefined {
+  if (!stored || stored === NO_FILL_COLOR) return stored;
+
+  const lightIndex = lightPalette.indexOf(stored);
+  if (lightIndex >= 0) {
+    return theme === "dark" ? darkPalette[lightIndex] : stored;
+  }
+
+  const darkIndex = darkPalette.indexOf(stored);
+  if (darkIndex >= 0) {
+    return theme === "light" ? lightPalette[darkIndex] : stored;
+  }
+
+  return stored;
+}
+
+export function resolveWorkbookFillColor(
+  stored: string | undefined,
+  theme: WorkbookTheme,
+): string | undefined {
+  return resolvePaletteColor(
+    stored,
+    theme,
+    LIGHT_FILL_COLORS,
+    DARK_FILL_COLORS,
+  );
+}
+
+export function resolveWorkbookTextColor(
+  stored: string | undefined,
+  theme: WorkbookTheme,
+): string | undefined {
+  if (!stored || isDefaultWorkbookTextColor(stored)) return undefined;
+  return resolvePaletteColor(
+    stored,
+    theme,
+    LIGHT_TEXT_COLORS,
+    DARK_TEXT_COLORS,
+  );
+}
+
+export function getWorkbookFillPalette(theme: WorkbookTheme): readonly string[] {
+  return theme === "dark" ? DARK_FILL_COLORS : LIGHT_FILL_COLORS;
+}
+
+export function getWorkbookTextPalette(
+  theme: WorkbookTheme,
+): readonly string[] {
+  return theme === "dark" ? DARK_TEXT_COLORS : LIGHT_TEXT_COLORS;
+}
+
+export function getWorkbookTheme(resolvedTheme: string | undefined): WorkbookTheme {
+  return resolvedTheme === "dark" ? "dark" : "light";
+}

--- a/apps/app/utils/redlineStyles.ts
+++ b/apps/app/utils/redlineStyles.ts
@@ -1,0 +1,81 @@
+import { cn } from "@uprevit/ui/lib/utils";
+
+/** Strikethrough old / removed value in inline redline text */
+export const redlineOldValue =
+  "line-through text-sm text-red-600/70 dark:text-red-400/80";
+
+/** New / added value in inline redline text */
+export const redlineNewValue =
+  "text-sm font-semibold text-blue-700 dark:text-blue-400";
+
+/** Compact old value (tables) */
+export const redlineOldValueCompact =
+  "text-sm text-red-600/70 dark:text-red-400/80 line-through";
+
+/** Compact new value (tables) */
+export const redlineNewValueCompact = "text-sm text-blue-700 dark:text-blue-400";
+
+export const redlineBadgeAdded =
+  "text-blue-700 bg-blue-100 border-blue-200 dark:bg-blue-950/40 dark:text-blue-300 dark:border-blue-800";
+
+export const redlineBadgeRemoved =
+  "text-red-700 bg-red-100 border-red-200 dark:bg-red-950/40 dark:text-red-300 dark:border-red-800";
+
+export const redlineBadgeModified =
+  "text-amber-700 bg-amber-100 border-amber-200 dark:bg-amber-950/40 dark:text-amber-300 dark:border-amber-800";
+
+/** Shared badge shell (tracking, padding) — pair with badge* tokens above */
+export const redlineBadgeBase =
+  "font-bold tracking-wider border shadow-sm";
+
+export const redlineCardAdded =
+  "border-blue-500/50 bg-blue-100/5 dark:bg-blue-950/15";
+
+export const redlineCardRemoved =
+  "border-red-500/50 bg-red-100/5 opacity-60 dark:bg-red-950/15";
+
+export const redlineCardModified =
+  "border-amber-500/50 bg-amber-100/10 dark:bg-amber-950/20";
+
+export const redlineFieldHighlightRemoved =
+  "bg-red-200/40 text-destructive dark:bg-red-500/15";
+
+export const redlineFieldHighlightAdded =
+  "bg-blue-200/40 text-blue-500 dark:bg-blue-500/15";
+
+export const redlineFieldHighlightModified =
+  "bg-amber-200/40 text-amber-500 dark:bg-amber-500/15";
+
+export const redlineHighlightRing =
+  "ring-1 ring-amber-400/60 ring-inset dark:ring-amber-500/50";
+
+export const redlineHighlightBorder =
+  "ring-1 ring-amber-400/60 border-amber-400/70 dark:ring-amber-500/50 dark:border-amber-500/60";
+
+export function getRedlineHighlightInsetShadow(theme: "light" | "dark"): string {
+  return theme === "dark"
+    ? "inset 0 0 0 9999px rgba(251, 191, 36, 0.18)"
+    : "inset 0 0 0 9999px rgba(251, 191, 36, 0.12)";
+}
+
+export function cnRedlineBadge(
+  variant: "added" | "removed" | "modified",
+  className?: string,
+) {
+  const variantClass =
+    variant === "added"
+      ? redlineBadgeAdded
+      : variant === "removed"
+        ? redlineBadgeRemoved
+        : redlineBadgeModified;
+  return cn(redlineBadgeBase, variantClass, className);
+}
+
+/** Label chip styles for array field diffs (symbols tables) */
+export const redlineChipAdded =
+  "border-blue-400 text-blue-700 bg-blue-50 dark:bg-blue-900/20 dark:text-blue-400 dark:border-blue-500";
+
+export const redlineChipRemoved =
+  "border-red-400 text-red-700 bg-red-50 line-through dark:bg-red-900/20 dark:text-red-400 dark:border-red-500";
+
+export const redlineBannerText = "text-amber-600 dark:text-amber-400";


### PR DESCRIPTION
- Add shared `redlineStyles` utilities with dark-mode-safe tokens for badges, cards, chips, banners, and inline old/new values
- Apply consolidated redline styling across compliance information, product information, label components, component details, symbols/graphics tables, label tags, and Univer read-only viewer
- Extract workbook fill and text color palettes into `workbook-cell-colors` with theme-aware resolution when switching light/dark mode
- Update product specification data table to use theme palettes for color pickers and resolved cell background/text colors in redline highlight mode
- Improve amber status and redline banner text contrast on workbook tab pages in dark mode