### PR TITLE
Fix TypeScript errors blocking develop Amplify builds

### DIFF
--- a/apps/app/features/workspace/products/product/label-tags/labelTagsTabs.tsx
+++ b/apps/app/features/workspace/products/product/label-tags/labelTagsTabs.tsx
@@ -332,7 +332,8 @@ export default function LabelTagsTabs({
   const persistAnnotation = useCallback(
     (itemId: string, annotation: AnnotationState): Promise<void> => {
       const item = labelTagsData.find((labelTag) => labelTag._id === itemId);
-      if (!item?.image) {
+      const itemImage = item?.image;
+      if (!itemImage) {
         return Promise.reject(new Error("No image available for this label tag"));
       }
 
@@ -345,7 +346,6 @@ export default function LabelTagsTabs({
 
         setIsSaving(true);
         setAnnotations((prev) => ({ ...prev, [itemId]: annotation }));
-        const itemImage = item.image;
         setPendingSave({
           itemId,
           itemImage,
@@ -361,7 +361,7 @@ export default function LabelTagsTabs({
   );
 
   const saveDirtyItemIds = useCallback(
-    async (itemIds: string[]) => {
+    async (itemIds?: string[]) => {
       const dirtyIds = getDirtyItemIds(itemIds);
       for (const itemId of dirtyIds) {
         const annotation = currentEditorState[itemId];

--- a/apps/app/utils/product/label-tag-annotation.ts
+++ b/apps/app/utils/product/label-tag-annotation.ts
@@ -2,8 +2,8 @@ import type { AnnotationState } from "@markerjs/markerjs3";
 
 function normalizeMarkers(
   markers: AnnotationState["markers"] | undefined,
-): AnnotationState["markers"] | undefined {
-  if (!markers) return markers;
+): AnnotationState["markers"] {
+  if (!markers) return [];
 
   return markers.map((marker) => {
     const typeName = marker.typeName;


### PR DESCRIPTION
- Narrow optional label tag image before pending save so `itemImage` is typed as `string`
- Make `saveDirtyItemIds` accept optional `itemIds` so save-all dirty flow compiles
- Return an empty array from `normalizeMarkers` when markers are missing so annotation normalization matches `AnnotationState`