### PR TITLE
Fix platform admin workspace detail TypeScript build error

### DIFF
--- a/apps/app/app/(app)/platform-admin/workspaces/[workspaceId]/page.tsx
+++ b/apps/app/app/(app)/platform-admin/workspaces/[workspaceId]/page.tsx
@@ -59,7 +59,7 @@ export default function PlatformAdminWorkspaceDetailPage() {
                     Platform workspace detail
                   </p>
                 </>
-              ) : (
+              ) : data ? (
                 <>
                   <h1 className="text-base font-semibold">
                     {data.workspace.workspaceName}
@@ -68,7 +68,7 @@ export default function PlatformAdminWorkspaceDetailPage() {
                     {data.workspace.companyName}
                   </p>
                 </>
-              )}
+              ) : null}
               <div className="mt-3">
                 <PlatformAdminNav />
               </div>


### PR DESCRIPTION
- Guard workspace header rendering with an explicit `data` check so TypeScript narrows before accessing `data.workspace`
- Resolves Amplify build failure on `platform-admin/workspaces/[workspaceId]/page.tsx`