### PR TITLE
Release v0.5.1

### DIFF
--- a/.cursor/plans/billing_simplification_0d96b20b.plan.md
+++ b/.cursor/plans/billing_simplification_0d96b20b.plan.md
@@ -1,0 +1,259 @@
+---
+name: Billing Simplification
+overview: Revamp the three-phase billing plan so Phase 1 stays intact, Phase 2 becomes a small internal usage/limits domain, and Phase 3 uses Chargebee live Usage Events plus a single workspace billing profile instead of snapshots, reconciliation, provider outbox, and snapshot approval flows.
+todos:
+  - id: rewrite-plan-doc
+    content: Rewrite `/Users/amit/Downloads/Updated 3 Phased Plan.md` with Phase 1 unchanged and simplified Phase 2/3 decisions.
+    status: pending
+  - id: remove-stale-snapshot-language
+    content: Remove snapshot approval, provider sync, reconciliation, provider outbox, and provider events language from the plan.
+    status: pending
+  - id: define-new-model
+    content: Define `usageEvents` with embedded Chargebee sync status and one workspace billing profile with Chargebee mirror plus internal limits.
+    status: pending
+  - id: define-ui-split
+    content: Document Usage tab versus Billing tab responsibilities and platform-admin UI removals.
+    status: pending
+  - id: define-validation
+    content: Update backend, UI, and manual E2E acceptance criteria around live usage ingestion, retries, and manual correction fallback.
+    status: pending
+isProject: false
+---
+
+# Simplified Chargebee Billing Plan
+
+## Scope
+
+Update `/Users/amit/Downloads/Updated 3 Phased Plan.md` into a new three-phase plan that reflects the simplified model:
+
+- Phase 1 remains the platform-operator control plane and should stay mostly unchanged.
+- Phase 2 becomes internal usage capture, limits, freezes, and workspace usage UI only.
+- Phase 3 becomes Chargebee linkage, mirrored billing profile data, live usage-event ingestion, and webhook updates.
+
+## Architecture Direction
+
+```mermaid
+flowchart LR
+  exportOrUpload["Export or Upload Completes"] --> usageEvent["Write usageEvents Row"]
+  usageEvent --> immediateSend["Attempt Chargebee Usage Event Send"]
+  immediateSend --> synced["Mark chargebeeSync Synced"]
+  immediateSend --> failed["Mark chargebeeSync Failed"]
+  failed --> retryWorker["Retry Within 12 Hour Window"]
+  retryWorker --> synced
+  retryWorker --> manualFallback["Manual CSV Correction If Aged Out"]
+  chargebeeWebhook["Chargebee Webhook"] --> billingProfile["WorkspaceBillingProfile"]
+  billingProfile --> billingTab["Workspace Billing Tab"]
+  usageEvent --> usageTab["Workspace Usage Tab"]
+```
+
+
+
+## Phase 1 Updates
+
+Keep the existing Phase 1 content from `/Users/amit/Downloads/Updated 3 Phased Plan.md`:
+
+- Platform-operator access remains `platform-admin` Cognito group plus active platform-admin registry plus active user row.
+- Platform APIs continue to use platform-operator auth, not tenant auth.
+- Audit behavior remains scoped to failures, workspace detail views, and mutations.
+- No billing-specific complexity should be added to Phase 1.
+
+## Phase 2 Rewrite
+
+Replace the current Phase 2 snapshot/reconciliation-heavy wording with a smaller internal domain:
+
+- Keep `usageEvents` as the internal usage ledger for exports and uploads.
+- Keep a single workspace billing profile document. Prefer using the existing physical `billingAccounts` collection to avoid unnecessary migration churn, but describe the domain as `WorkspaceBillingProfile`.
+- Store internal limits on that profile:
+  - `limits.enabled`
+  - `limits.enforcementMode: 'block' | 'overage'`
+  - `limits.seats`
+  - `limits.exports`
+  - `limits.uploadMb` or `limits.uploadBytes`
+  - `limits.ssoAllowed`
+- Remove `usageSnapshots`, snapshot approval, snapshot recompute, reconciliation runs, and period-anchor correction from the plan.
+- Keep internal limit enforcement because Chargebee cannot block app actions at export/upload/invite time.
+- Keep active-seat enforcement locally against purchased/allowed seat count.
+- Keep `usage freeze` and `access freeze` behavior if still wanted for platform-admin operations.
+- Workspace admins can view usage and limits; decide later whether they can change `enforcementMode`, but default plan should make platform admin own limits.
+
+Key backend areas to keep/adapt:
+
+- `[/Users/amit/Developer/Startup/uprevit-backend/src/models/billing.ts](/Users/amit/Developer/Startup/uprevit-backend/src/models/billing.ts)`
+- `[/Users/amit/Developer/Startup/uprevit-backend/src/utils/billing/usageRecording.ts](/Users/amit/Developer/Startup/uprevit-backend/src/utils/billing/usageRecording.ts)`
+- `[/Users/amit/Developer/Startup/uprevit-backend/src/utils/billing/uploadCommit.ts](/Users/amit/Developer/Startup/uprevit-backend/src/utils/billing/uploadCommit.ts)`
+- `[/Users/amit/Developer/Startup/uprevit-backend/src/utils/billing/enforcement.ts](/Users/amit/Developer/Startup/uprevit-backend/src/utils/billing/enforcement.ts)`
+- `[/Users/amit/Developer/Startup/uprevit-backend/src/controllers/billing/getSummary.ts](/Users/amit/Developer/Startup/uprevit-backend/src/controllers/billing/getSummary.ts)`
+
+Key Phase 2 removals from the plan:
+
+- `UsageSnapshot`
+- `USAGE_SNAPSHOTS_COLLECTION`
+- `approvedForBillingAt`
+- `approvedByPlatformAdminId`
+- `reconciliationStatus`
+- reconciliation-run APIs
+- snapshot recompute APIs
+- snapshot acceptance criteria
+
+## Phase 3 Rewrite
+
+Replace provider sync with live usage-event ingestion:
+
+- Chargebee owns billing calculations, invoice generation, proration, subscription status, invoices, add-ons, and paid/unpaid state.
+- Uprevit mirrors the important Chargebee data into the workspace billing profile for display and access decisions.
+- Chargebee customer/subscription linking remains platform-admin-only.
+- Seat increases/decreases are sent to Chargebee as subscription/add-on quantity changes and Chargebee handles proration.
+- Seats are not usage events.
+- Exports and uploads are Chargebee Usage Events.
+- The app writes the local `usageEvents` row first, then attempts to send the Chargebee Usage Event in the same product flow.
+- If Chargebee send fails, the usage event remains local with `chargebeeSync.status = 'failed'` or `pending` and retry metadata.
+- A retry worker/manual trigger retries failed events inside the documented Usage Events timestamp window. The plan should state the stricter documented window is 12 hours, even if we previously assumed 24 hours.
+- If an event ages out of the live ingestion window, mark it `manual_correction_required`; CSV/bulk upload is the operational fallback.
+
+Suggested `usageEvents` sync fields:
+
+```ts
+type UsageEventChargebeeSync = {
+  status: 'pending' | 'synced' | 'failed' | 'manual_correction_required';
+  deduplicationId: string;
+  attempts: number;
+  lastAttemptAt?: Date;
+  nextAttemptAt?: Date;
+  syncedAt?: Date;
+  lastError?: string;
+};
+```
+
+Suggested workspace billing profile shape:
+
+```ts
+type WorkspaceBillingProfile = {
+  workspaceId: ObjectId;
+  status: 'draft' | 'active' | 'past_due' | 'cancelled' | 'sync_error';
+  chargebee: {
+    customerId?: string;
+    subscriptionId?: string;
+    subscriptionStatus?: string;
+    planId?: string;
+    planName?: string;
+    billingCadence?: 'monthly' | 'yearly';
+    currentTermStart?: Date;
+    currentTermEnd?: Date;
+    nextBillingAt?: Date;
+    addOns: Array<{ id: string; name?: string; quantity?: number }>;
+    invoices: Array<{ id: string; number?: string; status: string; amountDue?: number; amountPaid?: number; hostedUrl?: string; issuedAt?: Date }>;
+    lastSyncedAt?: Date;
+    lastSyncError?: string;
+  };
+  limits: {
+    enabled: boolean;
+    enforcementMode: 'block' | 'overage';
+    seats: number;
+    exports: number;
+    uploadMb: number;
+    ssoAllowed: boolean;
+  };
+  createdAt: Date;
+  updatedAt: Date;
+};
+```
+
+Key Phase 3 removals from the plan:
+
+- `BillingProviderSyncOutbox`
+- `BillingProviderEvent` as a user-visible/platform table
+- `billingDocuments` as a separate collection, unless a later review insists on historical document persistence
+- provider sync endpoint
+- approve snapshot endpoint
+- list provider events endpoint
+- create quote flow, unless the product still wants sales-assisted quotes in v1
+- provider sync UI and snapshot approval UI
+
+Key backend areas to replace/remove:
+
+- `[/Users/amit/Developer/Startup/uprevit-backend/src/utils/billing/chargebeeSync.ts](/Users/amit/Developer/Startup/uprevit-backend/src/utils/billing/chargebeeSync.ts)`
+- `[/Users/amit/Developer/Startup/uprevit-backend/src/utils/billing/providerOutbox.ts](/Users/amit/Developer/Startup/uprevit-backend/src/utils/billing/providerOutbox.ts)`
+- `[/Users/amit/Developer/Startup/uprevit-backend/src/utils/billing/snapshots.ts](/Users/amit/Developer/Startup/uprevit-backend/src/utils/billing/snapshots.ts)`
+- `[/Users/amit/Developer/Startup/uprevit-backend/src/utils/billing/reconciliation.ts](/Users/amit/Developer/Startup/uprevit-backend/src/utils/billing/reconciliation.ts)`
+- `[/Users/amit/Developer/Startup/uprevit-backend/src/controllers/platformAdmin/runProviderSync.ts](/Users/amit/Developer/Startup/uprevit-backend/src/controllers/platformAdmin/runProviderSync.ts)`
+- `[/Users/amit/Developer/Startup/uprevit-backend/src/controllers/platformAdmin/approveUsageSnapshot.ts](/Users/amit/Developer/Startup/uprevit-backend/src/controllers/platformAdmin/approveUsageSnapshot.ts)`
+- `[/Users/amit/Developer/Startup/uprevit-backend/src/controllers/platformAdmin/recomputeUsageSnapshot.ts](/Users/amit/Developer/Startup/uprevit-backend/src/controllers/platformAdmin/recomputeUsageSnapshot.ts)`
+- `[/Users/amit/Developer/Startup/uprevit-backend/src/controllers/platformAdmin/runReconciliation.ts](/Users/amit/Developer/Startup/uprevit-backend/src/controllers/platformAdmin/runReconciliation.ts)`
+
+## UI Plan
+
+Update the plan so UI has two separate workspace settings tabs:
+
+- `Usage` tab: internal usage this period, limits, enforcement status, over-limit warnings, freezes.
+- `Billing` tab: mirrored Chargebee subscription data, plan, cadence, add-ons, current term, next billing date, invoices/payment status.
+
+Remove from workspace `Usage` tab:
+
+- Billing documents section.
+- SSO add-on billing card if it is provider/billing data rather than internal usage.
+
+Platform admin UI keeps:
+
+- Workspace billing profile/linkage controls.
+- Internal limits and freezes.
+- Chargebee customer creation and subscription link.
+
+Platform admin UI removes:
+
+- Snapshot approval.
+- Trigger provider sync.
+- Recompute snapshot.
+- Run reconciliation.
+- Provider events table.
+
+Key UI files to reflect in the plan:
+
+- `[/Users/amit/Developer/Startup/uprevit-ui/apps/app/features/workspace/settings/UsageTab.tsx](/Users/amit/Developer/Startup/uprevit-ui/apps/app/features/workspace/settings/UsageTab.tsx)`
+- `[/Users/amit/Developer/Startup/uprevit-ui/apps/app/app/(app)/settings/page.tsx](/Users/amit/Developer/Startup/uprevit-ui/apps/app/app/(app)`/settings/page.tsx)
+- `[/Users/amit/Developer/Startup/uprevit-ui/apps/app/features/platform-admin/PlatformBillingSection.tsx](/Users/amit/Developer/Startup/uprevit-ui/apps/app/features/platform-admin/PlatformBillingSection.tsx)`
+- `[/Users/amit/Developer/Startup/uprevit-ui/apps/app/features/platform-admin/PlatformChargebeeSection.tsx](/Users/amit/Developer/Startup/uprevit-ui/apps/app/features/platform-admin/PlatformChargebeeSection.tsx)`
+
+## Acceptance Criteria For The Updated Plan
+
+- The plan no longer asks us to sync approved snapshots to Chargebee.
+- The plan no longer has reconciliation runs or snapshot approval workflows.
+- Export completion creates one internal usage event and attempts one Chargebee Usage Event.
+- Upload commit creates one internal usage event and attempts one Chargebee Usage Event.
+- Failed Chargebee sends are visible on the usage event and retried inside the documented 12-hour window.
+- Aged-out failed usage events become manual-correction items, with CSV/bulk import as fallback.
+- Seats are represented as Chargebee subscription/add-on quantity, not metered usage.
+- Workspace Usage and Billing tabs have separate responsibilities.
+- Internal usage summary still works if Chargebee is down.
+- Chargebee webhook failures do not block product usage, but they leave profile sync state visible.
+
+## Verification Plan To Include
+
+Backend:
+
+```txt
+npm --prefix src test -- billing
+npm --prefix src test -- platformAdmin
+npm --prefix src test -- chargebeeClient
+npm --prefix src run type-check
+```
+
+UI:
+
+```txt
+bun run lint
+bun run type-check
+```
+
+Manual E2E:
+
+- Complete an export and confirm local usage event is recorded.
+- Confirm the same export attempts Chargebee live ingestion.
+- Simulate Chargebee failure and confirm retry metadata is stored on the usage event.
+- Confirm failed event retry works before the 12-hour cutoff.
+- Confirm aged-out failed events surface as manual correction required.
+- Commit an upload and confirm internal and Chargebee usage paths.
+- Link a Chargebee subscription and confirm Billing tab shows mirrored plan/add-on/invoice data.
+- Change seat quantity in Chargebee or via platform-admin flow and confirm profile/limits mirror as expected.
+- Confirm block mode blocks exports/uploads/seats at limits.
+- Confirm overage mode allows usage and sends events to Chargebee.
+

--- a/.cursor/plans/chargebee_sandbox_setup_544fa1f1.plan.md
+++ b/.cursor/plans/chargebee_sandbox_setup_544fa1f1.plan.md
@@ -1,0 +1,355 @@
+---
+name: Chargebee Sandbox Setup
+overview: Handoff plan for another agent to configure a new Chargebee sandbox catalog (plans, add-ons, usage meters, webhooks, API keys) and wire six backend environment variables into local SAM, GitHub Actions deploy, and verify the already-implemented billing integration. Frontend needs no Chargebee secrets.
+todos:
+  - id: cb-create-sandbox
+    content: Create new Chargebee test site (PC2) and record subdomain
+    status: pending
+  - id: cb-catalog
+    content: Create plan, seat add-on, SSO add-on, and meters (exports, upload_mb) with item prices
+    status: pending
+  - id: cb-api-webhook
+    content: Generate API key; configure webhook URL + Basic Auth + event subscriptions
+    status: pending
+  - id: cb-handoff-doc
+    content: Deliver 6 env values + example subscription for first workspace test
+    status: pending
+  - id: backend-local-env
+    content: Fill env.json Parameters + ProcessProductExportJobFunction with 6 Chargebee values
+    status: pending
+  - id: backend-deploy-yml
+    content: Add Chargebee vars/secrets to GitHub environments and deploy.yml parameter-overrides
+    status: pending
+  - id: e2e-verify
+    content: Run link-subscription + export + upload + Usage/Billing tab verification
+    status: pending
+isProject: false
+---
+
+# Chargebee Sandbox + Environment Wiring Handoff
+
+Reference plan: [final_billing_plan_75f87ade.plan.md](/Users/amit/Developer/Startup/uprevit-ui/.cursor/plans/final_billing_plan_75f87ade.plan.md)
+
+Implementation is already done in both repos. This plan covers **external Chargebee setup** and **env/deployment wiring** only.
+
+**Scope decision:** one shared Chargebee **test/sandbox site** for local + `develop` + `demo`. Production gets its own site later.
+
+---
+
+## What the code expects (do not change without code updates)
+
+### Usage Events ingest API
+
+Backend posts to:
+
+```text
+POST https://{CHARGEBEE_SITE}.ingest.chargebee.com/api/v2/usage_events
+```
+
+Payload property names are **exact** (defined in `[chargebeeUsageEvents.ts](/Users/amit/Developer/Startup/uprevit-backend/src/utils/billing/chargebeeUsageEvents.ts)`):
+
+
+| Event            | `properties` sent                       |
+| ---------------- | --------------------------------------- |
+| Export completed | `{ exports: 1 }` (or N for adjustments) |
+| Upload committed | `{ upload_mb: ceil(bytes / 1MB) }`      |
+
+
+- `deduplication_id` max 36 chars (e.g. `export:{jobId}`, upload key hash)
+- `usage_timestamp` = event time in **milliseconds**
+- 12-hour retry window; after that → `manual_correction_required`
+
+### Webhook mirror
+
+Endpoint (already deployed via SAM): `POST /billing/webhooks/chargebee`
+
+Handler: `[chargebeeWebhook.ts](/Users/amit/Developer/Startup/uprevit-backend/src/controllers/billing/chargebeeWebhook.ts)`
+
+Processes:
+
+- `subscription_created`, `subscription_changed`, `subscription_renewed`, `subscription_activated`, `subscription_reactivated` → mirror plan, term dates, seat qty, SSO add-on
+- `invoice_generated`, `invoice_updated` (payment_due/not_paid) → `past_due`
+- `payment_succeeded` → clear past due
+
+Seat/SSO detection uses **item price IDs** from env vars matched against `subscription_items[].item_price_id` (`[chargebeeWebhooks.ts](/Users/amit/Developer/Startup/uprevit-backend/src/utils/billing/chargebeeWebhooks.ts)`).
+
+### Customer / subscription linking (platform admin)
+
+1. `POST /platform-admin/workspaces/{id}/chargebee/customer` → creates Chargebee customer id `ws_{workspaceId}`, `auto_collection: off`
+2. Create subscription **manually in Chargebee UI** for that customer
+3. `POST /platform-admin/workspaces/{id}/chargebee/subscription/link` with `{ subscriptionId }` → sets offline billing (`auto_collection: off`, `invoice_immediately: false`), mirrors profile, retries `pending_link` events
+
+Plan item price IDs are **not** env vars — they are read from the linked subscription via webhook/API mirror.
+
+---
+
+## Part A — Chargebee sandbox catalog setup (agent task)
+
+### A1. Create the sandbox site
+
+1. Log into [Chargebee](https://www.chargebee.com/) → create a **new test site** (not reusing any legacy `exports-USD-Monthly` catalog).
+2. Record the **site subdomain** only (e.g. if URL is `https://uprevit-dev-test.chargebee.com`, site = `uprevit-dev-test`).
+3. Confirm **Product Catalog 2.0** (PC2) is active (Items / Item Prices model, not legacy Plans-only UI).
+
+### A2. Product family and items
+
+Create one product family, e.g. **Uprevit Platform**.
+
+
+| Item type                          | Suggested item ID  | Suggested name   | Description                                       |
+| ---------------------------------- | ------------------ | ---------------- | ------------------------------------------------- |
+| Plan                               | `uprevit-platform` | Uprevit Platform | Base workspace subscription                       |
+| Add-on                             | `-seats`           | Additional Seats | Per-seat licensing (non-metered)                  |
+| Add-on                             | `sso`              | SSO              | Single sign-on entitlement (non-metered, qty 0/1) |
+| Metered charge (or metered add-on) | `exports`          | Exports          | Usage-based export billing                        |
+| Metered charge (or metered add-on) | `upload-usage`     | Upload usage     | Usage-based upload billing (MB)                   |
+
+
+### A3. Usage meters (critical)
+
+In Chargebee **Usage Events / Meters** (or Features & Meters in PC2), create two meters with these **exact property names**:
+
+
+| Meter property name | Aggregation | Unit label | Used by code                        |
+| ------------------- | ----------- | ---------- | ----------------------------------- |
+| `exports`           | Sum         | exports    | Export jobs + export adjustments    |
+| `upload_mb`         | Sum         | MB         | Upload commits + upload adjustments |
+
+
+Attach metered pricing to the export/upload items. Sandbox pricing can be nominal (e.g. $0.01/export, $0.001/MB) — commercial rates are a business decision.
+
+### A4. Item prices (monthly minimum; yearly optional)
+
+Create item prices. Suggested IDs (match test conventions in `[chargebeeWebhooks.test.ts](/Users/amit/Developer/Startup/uprevit-backend/src/tests/unit/chargebeeWebhooks.test.ts)`):
+
+
+| Item price ID                  | Item          | Period  | Pricing model                         | Qty      |
+| ------------------------------ | ------------- | ------- | ------------------------------------- | -------- |
+| `uprevit-platform-USD-Monthly` | Platform plan | Monthly | Flat fee                              | 1        |
+| `uprevit-platform-USD-Yearly`  | Platform plan | Yearly  | Flat fee                              | 1        |
+| `additional-seats-USD-Monthly` | Seats add-on  | Monthly | Per unit                              | variable |
+| `additional-seats-USD-Yearly`  | Seats add-on  | Yearly  | Per unit                              | variable |
+| `sso-USD-Monthly`              | SSO add-on    | Monthly | Flat or per unit                      | 0 or 1   |
+| `sso-USD-Yearly`               | SSO add-on    | Yearly  | Flat or per unit                      | 0 or 1   |
+| `exports-USD-Monthly`          | Exports meter | Monthly | Metered (linked to `exports` meter)   | —        |
+| `upload-usage-USD-Monthly`     | Upload meter  | Monthly | Metered (linked to `upload_mb` meter) | —        |
+
+
+**Env vars needed from this step:**
+
+- `CHARGEBEE_SEAT_ADDON_ITEM_PRICE_ID` → monthly seat price ID (e.g. `additional-seats-USD-Monthly`)
+- `CHARGEBEE_SSO_ADDON_ITEM_PRICE_ID` → monthly SSO price ID (e.g. `sso-USD-Monthly`)
+
+If subscriptions will be yearly, still set env to the **monthly** addon IDs unless you standardize on yearly — webhook matching is by exact `item_price_id`. Document which cadence platform ops will use when creating subscriptions.
+
+### A5. Subscription template for test customers
+
+When creating a test subscription in Chargebee for customer `ws_{workspaceId}`:
+
+- Base plan item (qty 1)
+- Seat add-on (qty = purchased seats, e.g. 10)
+- SSO add-on (optional, qty 1)
+- Metered export item
+- Metered upload item
+- **Offline-friendly:** `auto_collection = off` (code also enforces this on link)
+
+### A6. API key
+
+1. Chargebee → **Settings → Configure Chargebee → API Keys and Webhooks → API Keys**
+2. Create a **Full Access** key for the sandbox site
+3. Save as `CHARGEBEE_API_KEY` (never commit)
+
+URL pattern: `https://{site}.chargebee.com/apikeys_and_webhooks/api`
+
+### A7. Webhook
+
+1. Same page → **Webhooks → Add Webhook**
+2. **URL:** `https://{API_GATEWAY_ID}.execute-api.us-east-1.amazonaws.com/Prod/billing/webhooks/chargebee`
+  - Get `{API_GATEWAY_ID}` from CloudFormation stack output `ApiBaseUrl` for the target backend stack (`develop` / `demo`)
+  - For **local SAM**, webhooks require a tunnel (ngrok/Cloudflare) pointing at `http://127.0.0.1:3000/billing/webhooks/chargebee` — optional for initial catalog setup
+3. **Authentication:** HTTP Basic Auth
+  - Choose a username → `CHARGEBEE_WEBHOOK_USERNAME` (e.g. `uprevit-webhook`)
+  - Generate a strong password → `CHARGEBEE_WEBHOOK_PASSWORD`
+4. **Events to enable** (minimum):
+  - `subscription_created`, `subscription_changed`, `subscription_renewed`, `subscription_activated`, `subscription_reactivated`
+  - `invoice_generated`, `invoice_updated`
+  - `payment_succeeded`
+5. Save and use Chargebee’s “Test webhook” if available
+
+Auth validation in code: `[chargebeeWebhook.ts](/Users/amit/Developer/Startup/uprevit-backend/src/controllers/billing/chargebeeWebhook.ts)` — fails closed if username/password env vars are missing or mismatch.
+
+### A8. Deliverables from Chargebee agent
+
+Produce a short setup record (markdown or table) with:
+
+```text
+CHARGEBEE_SITE=<subdomain>
+CHARGEBEE_API_KEY=<secret>
+CHARGEBEE_WEBHOOK_USERNAME=<username>
+CHARGEBEE_WEBHOOK_PASSWORD=<secret>
+CHARGEBEE_SEAT_ADDON_ITEM_PRICE_ID=<monthly-seat-item-price-id>
+CHARGEBEE_SSO_ADDON_ITEM_PRICE_ID=<monthly-sso-item-price-id>
+```
+
+Plus: example subscription ID used for first test, and confirmation that meters use `exports` and `upload_mb`.
+
+---
+
+## Part B — Backend environment variables (6 total)
+
+All defined in `[chargebeeConfig.ts](/Users/amit/Developer/Startup/uprevit-backend/src/config/chargebeeConfig.ts)` and `[env.example.json](/Users/amit/Developer/Startup/uprevit-backend/env.example.json)`.
+
+
+| Variable                             | Secret? | Purpose                                   |
+| ------------------------------------ | ------- | ----------------------------------------- |
+| `CHARGEBEE_SITE`                     | No      | Site subdomain only (no `.chargebee.com`) |
+| `CHARGEBEE_API_KEY`                  | **Yes** | REST API + Usage Events ingest            |
+| `CHARGEBEE_WEBHOOK_USERNAME`         | No      | Webhook Basic Auth user                   |
+| `CHARGEBEE_WEBHOOK_PASSWORD`         | **Yes** | Webhook Basic Auth password               |
+| `CHARGEBEE_SEAT_ADDON_ITEM_PRICE_ID` | No      | Match seat add-on on subscription         |
+| `CHARGEBEE_SSO_ADDON_ITEM_PRICE_ID`  | No      | Detect SSO add-on on subscription         |
+
+
+### B1. Local development (`env.json`)
+
+Backend does **not** use a simple `.env` file. It uses gitignored `[env.json](/Users/amit/Developer/Startup/uprevit-backend/env.example.json)` → normalized to `.sam-local-env.json` by `[scripts/prepare-sam-env.mjs](/Users/amit/Developer/Startup/uprevit-backend/scripts/prepare-sam-env.mjs)`.
+
+Steps:
+
+1. Copy `env.example.json` → `env.json` (if not already present)
+2. Fill all six keys under `Parameters`
+3. Also duplicate `CHARGEBEE_SITE` + `CHARGEBEE_API_KEY` under `ProcessProductExportJobFunction` (export worker syncs usage on job completion — see `[template.yaml` L875-887](/Users/amit/Developer/Startup/uprevit-backend/template.yaml))
+4. Run `npm run start:local` from repo root (or `npm run start:local` in `src/`)
+
+SAM globals inject all six vars into most Lambdas; export worker explicitly needs site + API key.
+
+### B2. AWS deployed environments (develop + demo) — **requires code change**
+
+`[template.yaml](/Users/amit/Developer/Startup/uprevit-backend/template.yaml)` already declares CloudFormation parameters `ChargebeeSite`, `ChargebeeApiKey`, etc. and injects them into Lambda globals.
+
+**Gap:** `[.github/workflows/deploy.yml](/Users/amit/Developer/Startup/uprevit-backend/.github/workflows/deploy.yml)` does **not** pass Chargebee params to `sam deploy` yet. Must add:
+
+**GitHub environment variables** (per `develop` and `demo` — can share same sandbox values initially):
+
+- `CHARGEBEE_SITE`
+- `CHARGEBEE_WEBHOOK_USERNAME`
+- `CHARGEBEE_SEAT_ADDON_ITEM_PRICE_ID`
+- `CHARGEBEE_SSO_ADDON_ITEM_PRICE_ID`
+
+**GitHub environment secrets:**
+
+- `CHARGEBEE_API_KEY`
+- `CHARGEBEE_WEBHOOK_PASSWORD`
+
+**Update `deploy.yml`** `sam deploy --parameter-overrides` block to include:
+
+```bash
+"ChargebeeSite=${{ vars.CHARGEBEE_SITE }}" \
+"ChargebeeApiKey=${{ secrets.CHARGEBEE_API_KEY }}" \
+"ChargebeeWebhookUsername=${{ vars.CHARGEBEE_WEBHOOK_USERNAME }}" \
+"ChargebeeWebhookPassword=${{ secrets.CHARGEBEE_WEBHOOK_PASSWORD }}" \
+"ChargebeeSeatAddonItemPriceId=${{ vars.CHARGEBEE_SEAT_ADDON_ITEM_PRICE_ID }}" \
+"ChargebeeSsoAddonItemPriceId=${{ vars.CHARGEBEE_SSO_ADDON_ITEM_PRICE_ID }}"
+```
+
+Also add these names to the “Validate deploy configuration” required-vars check (secrets validated by presence at deploy time).
+
+After merge + deploy, **re-register webhook URL** if API Gateway ID changed.
+
+### B3. Manual one-off SAM deploy (alternative)
+
+```bash
+sam deploy \
+  --stack-name uprevit-test \
+  --parameter-overrides \
+    "ChargebeeSite=..." \
+    "ChargebeeApiKey=..." \
+    "ChargebeeWebhookUsername=..." \
+    "ChargebeeWebhookPassword=..." \
+    "ChargebeeSeatAddonItemPriceId=..." \
+    "ChargebeeSsoAddonItemPriceId=..."
+```
+
+---
+
+## Part C — Frontend (no Chargebee env vars)
+
+The product app talks to the backend only. **No `CHARGEBEE_`* variables** in `[apps/app/.env.example](/Users/amit/Developer/Startup/uprevit-ui/apps/app/.env.example)`.
+
+Existing vars remain:
+
+- `API_PROXY_TARGET` → backend API base URL (local)
+- Cognito `NEXT_PUBLIC_`* vars
+
+For Amplify (`develop` / `demo` branches): no Chargebee secrets needed. Ensure `API_PROXY_TARGET` (or equivalent backend URL config) points at the stack where Chargebee env is configured.
+
+Customer-facing UI already hides “Chargebee” branding in Billing/Usage tabs; platform-admin UI still says “Chargebee” (operator-only).
+
+---
+
+## Part D — End-to-end verification checklist
+
+After catalog + env wiring:
+
+```mermaid
+sequenceDiagram
+  participant PA as PlatformAdmin
+  participant API as UprevitBackend
+  participant CB as Chargebee
+  participant User as WorkspaceUser
+
+  PA->>API: Create billing account
+  PA->>API: Create Chargebee customer
+  API->>CB: POST /customers (auto_collection off)
+  PA->>CB: Create subscription (plan+seats+meters)
+  PA->>API: Link subscriptionId
+  API->>CB: Update offline billing + mirror
+  CB-->>API: Webhook subscription_created
+  User->>API: Complete export
+  API->>API: Insert usageEvent
+  API->>CB: POST ingest usage_events exports:1
+  User->>API: Open Settings Usage tab
+  API-->>User: Term dates from mirror
+  User->>API: Open Settings Billing tab
+  API->>CB: GET invoices on demand
+```
+
+
+
+
+| Step | Action                                                             | Expected                                                        |
+| ---- | ------------------------------------------------------------------ | --------------------------------------------------------------- |
+| 1    | Deploy backend with all 6 Chargebee params                         | Lambdas have env vars (check one function in AWS console)       |
+| 2    | Platform admin → workspace → create billing account                | Account in `draft`                                              |
+| 3    | Create Chargebee customer                                          | Customer `ws_{workspaceId}` in Chargebee                        |
+| 4    | In Chargebee, create subscription with plan + seat + metered items | Active subscription                                             |
+| 5    | Link subscription in platform admin                                | `chargebee.subscriptionId` set; seats/SSO mirrored              |
+| 6    | Run export to completion                                           | `usageEvents` row + `chargebeeSync.status = synced`             |
+| 7    | Upload a file                                                      | `usageEvents` row + `upload_mb` synced                          |
+| 8    | Workspace Settings → Usage                                         | “Subscription term” badge, correct period                       |
+| 9    | Workspace Settings → Billing                                       | Plan name, invoices list                                        |
+| 10   | Break API key temporarily                                          | Export still succeeds; sync status `failed`; manual retry works |
+| 11   | Webhook test from Chargebee                                        | 200 from `/billing/webhooks/chargebee`                          |
+
+
+Backend tests to run after env wiring: `npm --prefix src test -- billing chargebee platformAdmin`
+
+---
+
+## Part E — What is NOT in scope for the Chargebee agent
+
+- Code changes (except the `deploy.yml` parameter-overrides PR if assigned)
+- Production Chargebee site (separate site + keys when going live)
+- Quote/checkout flows (deferred in plan)
+- Workspace notification preferences (deferred)
+- CSV bulk upload for `manual_correction_required` events (document only)
+
+---
+
+## Summary for handoff
+
+**Chargebee agent:** Create sandbox site → PC2 catalog (plan, seat add-on, SSO add-on, `exports` + `upload_mb` meters) → API key → webhook with Basic Auth → return 6 env values + test subscription.
+
+**Backend agent / you:** Put values in `env.json` locally; add GitHub vars/secrets + update `deploy.yml` for develop/demo; redeploy; point webhook at API Gateway URL.
+
+**Frontend:** Nothing to add for Chargebee — only ensure backend URL is correct.

--- a/.cursor/plans/chargebee_usage_billing_19d1282a.plan.md
+++ b/.cursor/plans/chargebee_usage_billing_19d1282a.plan.md
@@ -1,0 +1,397 @@
+---
+name: Chargebee Usage Billing
+overview: "Sales-assisted billing: one Uprevit plan (quarterly or yearly), usage tracked in Uprevit first then synced to Chargebee, no auto-pay, contract limits and alerts in the app, quotes created in Chargebee for now."
+todos:
+  - id: phase0-chargebee-sandbox
+    content: "Chargebee sandbox: quarterly/yearly plan, meters (seats/exports/storage), SSO add-ons, quotes, auto_collection off, wire payment test, usage ingestion spike"
+    status: pending
+  - id: phase1-mongo-usage
+    content: billingAccounts (meteringEnabled, limits, enforcement), usageEvents/snapshots, platform-admin metering API, instrument seats/exports/storage across all upload scopes
+    status: pending
+  - id: phase2-chargebee-sync
+    content: Outbox worker, webhooks (period dates, past-due, documents), SSO add-on sync, daily reconciliation
+    status: pending
+  - id: phase3-apis-ui
+    content: Billing summary API, BillingTab + limits/enforcement settings, alerts 80%/100%, enforcement on invite/export/upload, marketing pricing
+    status: pending
+  - id: phase4-later
+    content: In-app quotes, Pay Online/virtual bank, support user billable flag, optional past-due lockout
+    status: pending
+isProject: false
+---
+
+# Usage tracking, billing, and Chargebee (updated)
+
+## What we are building (plain English)
+
+- **One product** on the website: Uprevit. No self-serve checkout. No Growth vs Enterprise tiers.
+- **Contract length:** Quarterly or yearly only.
+- **Who pays for what:** Each **workspace** is one customer for billing. One billing record in Uprevit, one customer in Chargebee.
+- **Usage:** Uprevit counts seats, exports, and storage first. Those numbers sync to Chargebee so invoices can include overage.
+- **Contract limits** (e.g. 56 seats, 100 exports): Stored **only in Uprevit**. Used for warnings, emails, and optional blocking. Chargebee does not store custom per-deal caps.
+- **Payments:** Customers pay by **bank wire** using instructions on the invoice. Finance marks paid in Chargebee. **Never** turn on auto-charge.
+- **Quotes:** Sales creates quotes in **Chargebee only** for v1. Uprevit shows quote/invoice status. In-app quoting comes later (Chargebee counts quotes and limits can bite).
+- **Metering is opt-in:** Existing workspaces do **not** start counting usage until your internal team turns it on. Test workspaces can turn on full billing features to validate tracking and Chargebee.
+
+Domain glossary (from grill session): [uprevit-backend/CONTEXT.md](file:///Users/amit/Developer/Startup/uprevit-backend/CONTEXT.md)
+
+---
+
+## Who does what
+
+
+| Party                                | Role                                                                                                                  |
+| ------------------------------------ | --------------------------------------------------------------------------------------------------------------------- |
+| **Uprevit (MongoDB)**                | Usage ledger, period summaries, limits, warnings, enforcement, mirror of quotes/invoices                              |
+| **Chargebee**                        | Customer, subscription, quote, invoice, wire payment recording, subscription status                                   |
+| **Sales / finance**                  | Quote in Chargebee, convert to subscription, **look at Uprevit usage**, send invoice in Chargebee, mark wire received |
+| **Workspace admin**                  | See billing tab, edit included limits, choose overage vs block, get alert emails                                      |
+| **Platform admin (Cognito `admin`)** | Turn metering on/off per workspace, link Chargebee customer, set pilot/test accounts                                  |
+
+
+```mermaid
+flowchart LR
+  subgraph uprevit [Uprevit]
+    Events[usageEvents]
+    Outbox[chargebeeUsageOutbox]
+    Snapshots[usageSnapshots]
+    Acct[billingAccounts]
+  end
+  subgraph cb [Chargebee]
+    Quote[Quote]
+    Sub[Subscription]
+    Inv[Invoice]
+  end
+  App[App actions] --> Events
+  Events --> Outbox
+  Outbox -->|when subscription exists| Sub
+  Events --> Snapshots
+  Quote --> Sub --> Inv
+  Inv -->|webhooks| Acct
+  Finance[Finance] --> Snapshots
+  Finance --> Inv
+```
+
+
+
+**Finance “review” (v1):** There is no approve button in Uprevit. Finance opens Uprevit to see usage for the subscription term, checks it against what Chargebee will bill, fixes anything in Chargebee if needed, then **sends the invoice from Chargebee**. Uprevit can flag if totals do not match Chargebee (reconciliation).
+
+---
+
+## Payments
+
+**Rule:** Auto-collection is **always off** on customer create and subscription create. Do not store or expose an auto-pay toggle in the app.
+
+**Default path:** Manual wire (`paymentMode: offline_wire` on billing account — metadata only, not a customer-facing switch).
+
+**Later (Phase 0 sandbox, not blocking engineering):** Pay Online link on invoice email, or virtual bank account. Document choice on billing account when you add it.
+
+---
+
+## Chargebee catalog (Phase 0 sandbox)
+
+1. Enable **quarterly** and **yearly** billing frequencies in Chargebee site settings (PC 2.0 custom frequencies).
+2. One plan item: **Uprevit** with price points e.g. `uprevit-quarterly-usd`, `uprevit-yearly-usd`.
+3. **Metered features** (names aligned in sandbox):
+  - `activated_seat_month`
+  - `completed_export`
+  - `storage_gb`
+4. **SSO:** Recurring **add-on** price points (`sso-quarterly`, `sso-yearly`) — **not** a usage meter. When `ssoEnabled` is true in Uprevit, attach add-on via API; remove when false.
+5. All recurring lines on a subscription use the **same** billing period (quarterly **or** yearly). Do not mix annual platform + monthly overage on one subscription unless you explicitly enable multi-frequency billing in Chargebee.
+6. Quotes + invoice emails in sandbox; test usage event ingestion (advanced / event-based if available).
+7. Confirm customer + subscription creation always sets `auto_collection: off`.
+
+**Chargebee docs:** [Usage billing](https://www.chargebee.com/docs/billing/2.0/usage-based-billing/understanding-usages), [Ingesting usage](https://www.chargebee.com/docs/billing/2.0/usage-based-billing/ingesting-usage-events-into-chargebee), [Quotes](https://www.chargebee.com/docs/billing/2.0/invoices-credit-notes-and-quotes/quotes)
+
+---
+
+## MongoDB collections
+
+### `billingAccounts` (one per workspace)
+
+
+| Field                                                        | Purpose                                                                             |
+| ------------------------------------------------------------ | ----------------------------------------------------------------------------------- |
+| `workspaceId`                                                | Unique link to workspace                                                            |
+| `meteringEnabled`                                            | **Default `false`.** When true, record usage and run sync. Platform admin toggles.  |
+| `status`                                                     | `draft` | `pilot` | `active` | `churned` (pilot = internal/test with full features) |
+| `chargebeeCustomerId`, `chargebeeSubscriptionId`             | Chargebee linkage                                                                   |
+| `billingCadence`                                             | `quarterly` | `yearly`                                                              |
+| `currency`, `netTermDays`                                    | Commercial terms                                                                    |
+| `paymentMode`                                                | Default `offline_wire`; optional later: `pay_now`, `virtual_bank`                   |
+| `ssoEnabled`                                                 | Contract SSO flag (sales/platform sets; not inferred from Cognito)                  |
+| `includedSeatMonths`, `includedExports`, `includedStorageGb` | Limits for UI, alerts, enforcement — **workspace admins can edit**                  |
+| `enforcementMode`                                            | `overage` (default) | `block` — workspace admin sets in Settings                    |
+| `periodStart`, `periodEnd`                                   | Copy of Chargebee subscription current term for snapshots/UI                        |
+| `createdAt`, `updatedAt`                                     |                                                                                     |
+
+
+**Indexes:** unique on `workspaceId`.
+
+**Legacy:** Keep `workspaces.plan*` for migration/display only; do not use for billing logic.
+
+**Do not create** billing accounts for every workspace automatically at launch. Create when platform admin sets up billing or enables metering. Internal test workspaces: `status: pilot`, `meteringEnabled: true`, full limits + enforcement + sandbox Chargebee IDs.
+
+### `usageEvents` (immutable ledger)
+
+Only written when `billingAccounts.meteringEnabled === true`.
+
+
+| Field                                                  | Purpose                                             |
+| ------------------------------------------------------ | --------------------------------------------------- |
+| `workspaceId`, `metric`, `quantity`, `unit`            |                                                     |
+| `occurredAt`, `billingPeriodStart`, `billingPeriodEnd` | Period = subscription term dates on billing account |
+| `source`, `sourceId`                                   | Traceability                                        |
+| `idempotencyKey`                                       | Unique dedupe                                       |
+| `chargebeeSyncStatus`                                  | `pending` | `synced` | `failed`                     |
+| `chargebeeEventId`                                     | After sync                                          |
+| `metadata`                                             |                                                     |
+
+
+**Metrics (v1):**
+
+- `activated_seat_month`
+- `completed_export`
+- `storage_bytes_snapshot` (daily point-in-time total)
+
+**Removed from original plan:** `sso_enabled` usage events — SSO uses add-on attach/detach instead.
+
+**Future:** `users.billable: false` for support staff in customer workspaces (excluded from seat-month).
+
+### `chargebeeUsageOutbox`
+
+Same as before; process only if `meteringEnabled` and `chargebeeSubscriptionId` present.
+
+### `usageSnapshots`
+
+One row per workspace per **subscription term** (`periodStart`–`periodEnd` from billing account / Chargebee webhook).
+
+Aggregates: seat-months (sum calendar-month events in term), exports, storage bytes/GB, `ssoEnabled` boolean for finance view.
+
+`reconciliationStatus`: `ok`  `mismatch`  `pending`.
+
+### `billingDocuments`, `chargebeeWebhookEvents`
+
+Unchanged intent: mirror quotes/invoices; idempotent webhooks.
+
+---
+
+## Usage rules
+
+### Seats (`activated_seat_month`)
+
+- Count when user becomes `**active`** ([onboardAndUpdateInvitedUser.ts](file:///Users/amit/Developer/Startup/uprevit-backend/src/controllers/onboarding/onboardAndUpdateInvitedUser.ts)) — not on invite alone.
+- **Everyone active counts**, including workspace admins.
+- **One seat-month per user per calendar month** when they first go active that month.
+- **No take-back** if deactivated mid-month.
+- **Idempotency:** `{workspaceId}:{userId}:activated_seat_month:{YYYY-MM}`
+- Skip users with `billable: false` when that field exists (support users — later).
+
+### Exports (`completed_export`)
+
+- Emit only after successful [markExportJobCompleted](file:///Users/amit/Developer/Startup/uprevit-backend/src/utils/exportJobs.ts) in [processExportJob.ts](file:///Users/amit/Developer/Startup/uprevit-backend/src/controllers/exports/processExportJob.ts).
+- **One completed job = one export** (product and report exports).
+- **Idempotency:** `exportJobId`.
+
+### Storage (`storage_bytes_snapshot`)
+
+- **Billable storage** = sum of bytes for:
+  - [sourceFiles](file:///Users/amit/Developer/Startup/uprevit-backend/src/models/sourceFiles.ts) — add `sizeBytes`, `contentType`
+  - Product assets (`uploads/{workspaceId}/product/...`)
+  - Workspace assets (`uploads/{workspaceId}/workspace/...`)
+- Add `sizeBytes` on create; pass `file.size` from [useUploadFilesToS3.ts](file:///Users/amit/Developer/Startup/uprevit-ui/apps/app/hooks/s3-storage/useUploadFilesToS3.ts) at all upload call sites.
+- **Daily snapshot** per workspace when metering on (GB for display; bytes in DB).
+- One-time S3/metadata backfill for existing files on pilot workspaces.
+
+### SSO
+
+- `billingAccounts.ssoEnabled` set by platform admin / sales.
+- Sync: attach or remove Chargebee SSO **add-on** on subscription (same cadence as plan).
+- Show SSO on/off in billing tab; no usage outbox for SSO.
+
+---
+
+## Alerts and past-due
+
+### Usage alerts
+
+- **Who:** All workspace admins (Cognito workspace admin group).
+- **When:** **80%** and **100%** of each included limit (seats, exports, storage).
+- **How:** In-app warning always; email when outbound email is wired (if no mail service yet, ship in-app first).
+- **Enforcement:** Both `overage` and `block` modes show warnings; only `block` stops new invites, exports, uploads.
+
+### Past-due invoice
+
+- From Chargebee webhooks → show **banner** to workspace admins in app.
+- **Do not** lock the workspace in v1.
+
+### Limit changes
+
+- Workspace admins edit included limits in Settings.
+- **Audit log** every change (who, when, field, old → new) using existing audit pattern.
+
+---
+
+## Chargebee sync
+
+1. App action → if `meteringEnabled` → `usageEvents` → `chargebeeUsageOutbox`.
+2. Worker with backoff; update event sync status.
+3. **Event sync (near real-time):** seat-months, exports.
+4. **Daily job:** storage snapshot, snapshot recompute, reconciliation vs Chargebee meters.
+5. **Webhooks:** Update billing account (status, period dates, past-due), `billingDocuments`, subscription IDs.
+
+**Reconciliation:** Compare Uprevit snapshot totals to Chargebee usage for the term; set `mismatch` so finance sees it before sending invoice.
+
+---
+
+## APIs ([uprevit-backend](file:///Users/amit/Developer/Startup/uprevit-backend))
+
+
+| Method | Path                          | Who             | Purpose                                                                                |
+| ------ | ----------------------------- | --------------- | -------------------------------------------------------------------------------------- |
+| GET    | `/billing/summary`            | Workspace admin | Account, usage, limits, period snapshot, documents, sync/reconciliation, past-due flag |
+| PUT    | `/billing/enforcement-mode`   | Workspace admin | `overage` | `block`                                                                    |
+| PUT    | `/billing/included-limits`    | Workspace admin | Update caps + audit                                                                    |
+| POST   | `/billing/metering`           | Platform admin  | Enable/disable metering, set status pilot/active                                       |
+| POST   | `/billing/chargebee/customer` | Platform admin  | Create/link customer, `auto_collection: off`                                           |
+| POST   | `/billing/chargebee/sso`      | Platform admin  | Toggle SSO add-on from `ssoEnabled`                                                    |
+| POST   | `/billing/usage/reconcile`    | Platform admin  | Recompute + compare Chargebee                                                          |
+| POST   | `/billing/usage/sync`         | Platform admin  | Retry outbox                                                                           |
+| POST   | `/billing/webhooks/chargebee` | Chargebee       | Signed, idempotent                                                                     |
+
+
+**Enforcement checks** (when `meteringEnabled` and over limit): invite ([createUser](file:///Users/amit/Developer/Startup/uprevit-backend/src/controllers/users/createUser.ts)), export enqueue, presign upload — respect `enforcementMode`.
+
+**Env:** `CHARGEBEE_SITE`, `CHARGEBEE_API_KEY`, `CHARGEBEE_WEBHOOK_SECRET`, item/meter/add-on IDs.
+
+**SAM:** Webhook Lambda, outbox worker, daily reconciliation in [template.yaml](file:///Users/amit/Developer/Startup/uprevit-backend/template.yaml).
+
+---
+
+## Frontend ([uprevit-ui](file:///Users/amit/Developer/Startup/uprevit-ui))
+
+### Marketing
+
+- [pricing/page.tsx](file:///Users/amit/Developer/Startup/uprevit-ui/apps/marketing/app/pricing/page.tsx): Single Uprevit plan; quarterly/yearly by quote after demo.
+- [PricingCalculatorCards.tsx](file:///Users/amit/Developer/Startup/uprevit-ui/apps/marketing/features/pricing/PricingCalculatorCards.tsx): **Estimate only**, not checkout.
+
+### App billing tab
+
+- Enable tab in [settings/page.tsx](file:///Users/amit/Developer/Startup/uprevit-ui/apps/app/app/(app)/settings/page.tsx).
+- Replace placeholder [BillingTab.tsx](file:///Users/amit/Developer/Startup/uprevit-ui/apps/app/features/workspace/settings/BillingTab.tsx) with API data.
+- Show: cadence, status, limits, usage vs limits, enforcement toggle, SSO flag (read-only for workspace admin unless you allow edit on limits only), latest quote/invoice links, sync/reconciliation, past-due banner.
+- No checkout CTA — contact billing / request quote update copy.
+
+### Hooks
+
+- `useGetBillingSummary`
+- `useUpdateBillingEnforcementMode`
+- `useUpdateBillingIncludedLimits`
+
+---
+
+## End-to-end flow
+
+```mermaid
+sequenceDiagram
+  participant Sales
+  participant PlatformAdmin
+  participant Uprevit
+  participant CB as Chargebee
+  participant WsAdmin as WorkspaceAdmin
+  participant Finance
+
+  Sales->>CB: Create quote and send PDF
+  Sales->>CB: Convert to subscription auto_collection_off
+  PlatformAdmin->>Uprevit: Enable metering link Chargebee IDs
+  CB->>Uprevit: Webhooks update billing account
+  Uprevit->>Uprevit: usageEvents and outbox
+  WsAdmin->>Uprevit: Set limits enforcement mode
+  Uprevit->>WsAdmin: Alerts at 80 and 100 percent
+  Finance->>Uprevit: Review snapshot
+  Finance->>CB: Send invoice
+  Customer->>CB: Wire payment
+  Finance->>CB: Record payment
+  CB->>Uprevit: Webhooks update invoice status
+```
+
+
+
+---
+
+## Phased delivery
+
+### Phase 0 — Chargebee sandbox (no app code)
+
+- Catalog: plan, quarterly/yearly, meters, SSO add-ons.
+- Quotes, invoices, auto-collection off, wire flow, test usage ingestion.
+
+### Phase 1 — Usage foundation
+
+- Collections + indexes.
+- `billingAccounts` with `meteringEnabled` default false.
+- Instrument seats, exports, storage (`sizeBytes` + uploads).
+- Snapshots job (no Chargebee yet).
+- Platform admin API to enable metering on test workspaces.
+
+### Phase 2 — Chargebee sync
+
+- Outbox worker, webhooks, reconciliation, `billingDocuments`.
+- SSO add-on attach/detach.
+- Period dates from subscription webhooks.
+
+### Phase 3 — APIs + UI
+
+- Billing tab, marketing pricing, enforcement on invite/export/upload.
+- Alerts (in-app; email if ready).
+- Included limits editor + audit.
+
+### Phase 4 — Later
+
+- In-app quote creation (watch Chargebee quote limits).
+- Pay Online / virtual bank.
+- Support user `billable: false`.
+- Optional lockout on past-due.
+- Past-due automation beyond banner.
+
+---
+
+## Test plan (unchanged intent, updated rules)
+
+**Backend unit**
+
+- No usage events when `meteringEnabled` false.
+- Seat on activation only; idempotency; no reversal on deactivate.
+- Export only after `markExportJobCompleted`.
+- Storage sums all three scopes; delete lowers total.
+- SSO does not create usage events; add-on API called on toggle.
+- Webhook/outbox idempotency; tenant isolation.
+
+**Integration**
+
+- Snapshot matches events for subscription term.
+- Reconciliation flags mismatch.
+- Limit change writes audit log.
+
+**Frontend**
+
+- Single marketing plan; calculator labeled estimate.
+- Billing tab states: no account, metering off, active, past-due banner, mismatch flag.
+- Enforcement toggle; limit edit; non-admins blocked.
+
+---
+
+## Assumptions (updated)
+
+- Workspace = billable tenant; no multi-workspace invoice in v1.
+- Metering opt-in by platform admin; test workspaces use full billing features.
+- Billing period = Chargebee subscription term; seat-months tagged by calendar month inside that term.
+- Included limits live in Uprevit only; Chargebee uses catalog defaults for overage math.
+- Workspace admins edit limits; changes audited.
+- Default enforcement: allow overage with warnings.
+- Default payment: manual wire; no auto-collection ever.
+- Quotes in Chargebee only for v1.
+- Finance reviews usage in Uprevit informally; invoice sent from Chargebee.
+- Storage v1 = daily GB snapshot, not byte-hours.
+- Support users excluded from seats when implemented.
+

--- a/.cursor/plans/chargebee_usage_billing_5f92bb90.plan.md
+++ b/.cursor/plans/chargebee_usage_billing_5f92bb90.plan.md
@@ -1,0 +1,425 @@
+---
+name: Chargebee Usage Billing
+overview: Sales-assisted billing with one Uprevit plan (quarterly/yearly), Chargebee quotes/invoices with auto-collection always disabled, Uprevit as the auditable usage ledger, and async sync to Chargebee via an outbox. Finance reviews usage before invoices are sent.
+todos:
+  - id: phase0-chargebee-sandbox
+    content: "Chargebee sandbox: catalog (quarterly/yearly), meters, quotes, auto_collection always off, payment path spike (Pay Now / virtual bank / offline wire)"
+    status: pending
+  - id: phase1-mongo-usage
+    content: Add billingAccounts, usageEvents, usageSnapshots, chargebeeUsageOutbox, billingDocuments, chargebeeWebhookEvents + instrument seats/exports/storage
+    status: pending
+  - id: phase2-chargebee-sync
+    content: Outbox worker, webhook Lambda, daily reconciliation, billingDocuments mirror
+    status: pending
+  - id: phase3-apis-ui
+    content: Billing APIs (/billing/summary, webhooks, admin endpoints), BillingTab + marketing pricing, enforcement mode
+    status: pending
+  - id: phase4-sales-ops
+    content: Optional internal quote/customer UI; past-due automation from webhooks
+    status: pending
+isProject: false
+---
+
+# Usage tracking, billing, and Chargebee integration
+
+## Goals
+
+- **One product:** Uprevit — no self-serve checkout, no Growth/Enterprise split on marketing.
+- **Cadence:** Quarterly and yearly contracts only (configure exact Chargebee catalog after you review their docs).
+- **Payments:** No auto-pay. Every Chargebee customer/subscription is created with **auto-collection disabled**. There is **no in-app or admin toggle** for auto-collection. Customers pay when finance sends an invoice (bank transfer preferred; exact gateway path chosen in Phase 0).
+- **Usage:** Uprevit records all usage first; Chargebee receives synced usage for invoicing. Finance **reviews usage before** approving/sending period invoices.
+- **Dimensions:** Activated seat-months, completed exports, storage (GB), SSO enabled.
+
+**Chargebee references:** [Usage thresholds](https://www.chargebee.com/docs/billing/2.0/usage-based-billing/understanding-usages), [Usage event ingestion](https://www.chargebee.com/docs/billing/2.0/usage-based-billing/ingesting-usage-events-into-chargebee), [Quotes](https://www.chargebee.com/docs/billing/2.0/invoices-credit-notes-and-quotes/quotes), [ACH via Stripe](https://www.chargebee.com/docs/payments/2.0/payment-gateways-and-configuration/ach-payments-stripe).
+
+---
+
+## System boundaries
+
+
+| System                | Responsibility                                                                           |
+| --------------------- | ---------------------------------------------------------------------------------------- |
+| **Uprevit (MongoDB)** | Immutable usage ledger, period snapshots, finance review UI, reconciliation vs Chargebee |
+| **Chargebee**         | Customer, quote, subscription, invoice, payment recording, subscription status           |
+| **Finance / sales**   | Quote negotiation, quote acceptance, invoice approval, payment follow-up                 |
+
+
+```mermaid
+flowchart LR
+  subgraph uprevit [Uprevit]
+    Events[usageEvents]
+    Outbox[chargebeeUsageOutbox]
+    Snapshots[usageSnapshots]
+    Acct[billingAccounts]
+  end
+  subgraph cb [Chargebee]
+    Quote[Quote]
+    Sub[Subscription]
+    Inv[Invoice]
+  end
+  App[App actions] --> Events
+  Events --> Outbox
+  Outbox -->|async sync| Sub
+  Events --> Snapshots
+  Quote --> Sub --> Inv
+  Inv -->|webhooks| Acct
+  Finance[Finance review] --> Snapshots
+  Finance --> Inv
+```
+
+
+
+---
+
+## Payments (no auto-collection)
+
+**Policy:** Auto-collection is **never** enabled. Do not store `autoCollection` on `billingAccounts` or expose it in the UI. When creating Chargebee customers/subscriptions via API, always set `auto_collection: off` (or equivalent in Product Catalog 2.0).
+
+**How customers pay (choose in Phase 0 sandbox — not blocked on engineering):**
+
+
+| Option                        | What it is                                                                                     | When to use                                                             |
+| ----------------------------- | ---------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
+| **A — Pay Now**               | Link on invoice email → Chargebee hosted page; card or ACH direct debit if gateway supports it | Customers who want to pay online without saving a card for auto-renewal |
+| **C — Virtual bank account**  | Per-customer bank details on invoice; Stripe/Chargebee reconciles incoming wire/ACH credit     | US B2B; less manual “record payment” work                               |
+| **D — Offline bank transfer** | Static wire instructions on PDF; finance uses **Record payment** in Chargebee                  | Fallback or non-US / no gateway reconciliation                          |
+
+
+`billingAccounts.paymentMode` (optional metadata only): `pending_evaluation | pay_now | virtual_bank | offline_wire` — documents which path was configured for that customer; **not** a user-facing switch.
+
+Enable Pay Now on invoice emails only if the selected gateway supports the methods you want.
+
+---
+
+## Chargebee catalog and billing alignment
+
+### Product catalog (v1 target)
+
+1. Enable **3-month (quarterly)** and **yearly** billing frequencies in Chargebee Product Catalog settings.
+2. One product family, one plan item: `**Uprevit`**.
+3. Two plan price points (names illustrative):
+  - `uprevit-quarterly-usd` — `period: 3`, `period_unit: month`
+  - `uprevit-yearly-usd` — `period: 1`, `period_unit: year`
+4. Metered features / item prices (align names with Chargebee after catalog review):
+  - `activated_seat_month`
+  - `completed_export`
+  - `storage_gb`
+  - `sso_enabled` (boolean/flag-style usage or recurring addon — confirm in catalog setup)
+
+**Alignment rule (avoids prior plan confusion):** For each customer subscription, **every recurring line item uses the same billing period** as the contract (quarterly **or** yearly). Platform plan, negotiated flat fees, and metered overage items all share that period. Do **not** mix annual platform + monthly overage on one subscription until Chargebee multi-frequency billing is explicitly enabled for your site.
+
+**Seat-month vs contract cadence:** Contract renews quarterly/yearly; **seat-month events still fire per calendar month** while the user is active (see Usage tracking). Chargebee meters aggregate seat-months across the invoice period.
+
+### Usage-based billing mode
+
+- Prefer **Advanced / event-based usage billing** if available on your site ([ingesting usage events](https://www.chargebee.com/docs/billing/2.0/usage-based-billing/ingesting-usage-events-into-chargebee)).
+- Chargebee documents high throughput (e.g. up to ~100M events/month); still implement `**chargebeeUsageOutbox`** so Chargebee downtime never loses usage.
+
+### Quotes and acceptance (no self-serve checkout)
+
+- Use **Chargebee Quotes** (evaluate **CPQ** if you need heavier deal desk; legacy Quotes are being sunset).
+- Default flow: **email quote PDF** → customer signature or manual acceptance after email/phone → finance converts to subscription/invoice in Chargebee.
+- **Do not** embed Hosted Checkout on the marketing site.
+- Hosted quote-accept links: enable only if they do **not** create an unwanted self-serve signup path.
+- If native quote signature is insufficient, evaluate **GetAccept / PandaDoc** before building custom e-sign.
+
+### Zero-dollar quotes
+
+Supported for pilots/POCs via $0 price points or coupons on quotes; finance still follows the same acceptance → subscription → invoice flow.
+
+---
+
+## MongoDB collections ([uprevit-backend](file:///Users/amit/Developer/Startup/uprevit-backend))
+
+### `billingAccounts` (one per workspace)
+
+Billing source of truth. Legacy `workspaces.plan`* fields remain for migration/display only.
+
+
+| Field                                                        | Purpose                                                                          |
+| ------------------------------------------------------------ | -------------------------------------------------------------------------------- |
+| `workspaceId`                                                | FK to workspace                                                                  |
+| `chargebeeCustomerId`, `chargebeeSubscriptionId`             | Chargebee linkage                                                                |
+| `billingCadence`                                             | `quarterly` | `yearly`                                                           |
+| `status`                                                     | `draft` | `active` | `past_due` | `suspended` | `churned` (synced from webhooks) |
+| `currency`, `netTermDays`                                    | Commercial terms                                                                 |
+| `paymentMode`                                                | Which payment path was configured (see Payments) — not auto-collection           |
+| `ssoEnabled`                                                 | Contract SSO flag (not inferred from Cognito)                                    |
+| `includedSeatMonths`, `includedExports`, `includedStorageGb` | Negotiated entitlements for UI/alerts (optional v1)                              |
+| `enforcementMode`                                            | `soft_overage` | `hard_limit` (workspace admin choice from earlier decision)     |
+| `createdAt`, `updatedAt`                                     |                                                                                  |
+
+
+Unique index: `workspaceId`.
+
+### `usageEvents` (immutable ledger)
+
+
+| Field                                                  | Purpose                                |
+| ------------------------------------------------------ | -------------------------------------- |
+| `workspaceId`, `metric`, `quantity`, `unit`            |                                        |
+| `occurredAt`, `billingPeriodStart`, `billingPeriodEnd` |                                        |
+| `source`, `sourceId`                                   | e.g. `user`, `exportJob`, `sourceFile` |
+| `idempotencyKey`                                       | Unique — dedupe                        |
+| `chargebeeSyncStatus`                                  | `pending` | `synced` | `failed`        |
+| `chargebeeEventId`                                     | After successful sync                  |
+| `metadata`                                             |                                        |
+
+
+**Metrics:** `activated_seat_month`, `completed_export`, `storage_bytes_delta`, `storage_bytes_snapshot`, `sso_enabled`.
+
+Unique index: `idempotencyKey`.
+
+### `chargebeeUsageOutbox`
+
+Reliable async sync to Chargebee.
+
+
+| Field                                            | Purpose                                        |
+| ------------------------------------------------ | ---------------------------------------------- |
+| `usageEventId`, `workspaceId`                    |                                                |
+| `chargebeeCustomerId`, `chargebeeSubscriptionId` |                                                |
+| `payload`                                        | Serialized Chargebee usage/event API body      |
+| `status`                                         | `pending` | `processing` | `synced` | `failed` |
+| `attempts`, `lastAttemptAt`, `syncedAt`, `error` |                                                |
+
+
+### `usageSnapshots` (period summaries)
+
+One row per workspace per billing period (quarterly or yearly window).
+
+
+| Field                                                                  | Purpose           |
+| ---------------------------------------------------------------------- | ----------------- |
+| `workspaceId`, `periodStart`, `periodEnd`                              |                   |
+| `activatedSeatMonths`, `completedExports`, `storageBytes`, `storageGb` |                   |
+| `ssoEnabled`                                                           |                   |
+| `chargebeeSyncStatus`, `reconciliationStatus`                          | `ok` | `mismatch` |
+| `lastCalculatedAt`                                                     |                   |
+
+
+### `billingDocuments`
+
+Local mirror of Chargebee quotes/invoices for the app billing tab.
+
+
+| Field                                        | Purpose             |
+| -------------------------------------------- | ------------------- |
+| `workspaceId`, `chargebeeDocumentId`, `type` | `quote` | `invoice` |
+| `status`, `amount`, `currency`               |                     |
+| `hostedUrl`, `pdfUrl`, `dueDate`             |                     |
+
+
+### `chargebeeWebhookEvents`
+
+Idempotency: `eventId` unique; store `eventType`, `receivedAt`, `processedAt`, `status`, `error`.
+
+---
+
+## Usage tracking rules
+
+### Seats — `activated_seat_month`
+
+- Bill **one seat-month per user per calendar month** when they first become **active** (invited user completes onboarding → `status: active` in `[onboardAndUpdateInvitedUser.ts](file:///Users/amit/Developer/Startup/uprevit-backend/src/controllers/onboarding/onboardAndUpdateInvitedUser.ts)`).
+- **No reversal** if the user is deactivated mid-month; that month still counts.
+- Each subsequent month the user remains active → one more event.
+- **Idempotency key:** `{workspaceId}:{userId}:activated_seat_month:{YYYY-MM}`.
+- Hook: user activation path (onboard), not invite-only.
+
+### Exports — `completed_export`
+
+- Source of truth: `[exportJobs](file:///Users/amit/Developer/Startup/uprevit-backend/src/models/exportJob.ts)`.
+- Emit **only** when `[markExportJobCompleted](file:///Users/amit/Developer/Startup/uprevit-backend/src/utils/exportJobs.ts)` succeeds in `[processExportJob.ts](file:///Users/amit/Developer/Startup/uprevit-backend/src/controllers/exports/processExportJob.ts)`.
+- Count completed product and report exports; ignore `queued` / `processing` / `failed`.
+- **Idempotency key:** `exportJobId`.
+
+### Storage
+
+- Add `sizeBytes`, `contentType` to `[sourceFiles](file:///Users/amit/Developer/Startup/uprevit-backend/src/models/sourceFiles.ts)`.
+- `[useUploadFilesToS3](file:///Users/amit/Developer/Startup/uprevit-ui/apps/app/hooks/s3-storage/useUploadFilesToS3.ts)` already returns `size: file.size` — pass it into `POST /source-files` when creating records (update all upload call sites).
+- Bill on **current total bytes** per workspace (sum of persisted file metadata + workspace/product assets if in scope).
+- Emit **daily** `storage_bytes_snapshot` per active `billingAccount`; v1 uses point-in-time GB, not byte-hours (unless finance later requires GB-month).
+- One-time **S3 backfill** for existing tenants without `sizeBytes`.
+
+### SSO — `sso_enabled`
+
+- Stored on `billingAccounts.ssoEnabled`; set by admin/sales when contract includes SSO.
+- Emit usage/snapshot when toggled; **do not** infer from Cognito groups.
+
+---
+
+## Chargebee usage sync
+
+1. **Write path:** App action → insert `usageEvents` → enqueue `chargebeeUsageOutbox`.
+2. **Worker:** Process outbox with exponential backoff; update `chargebeeSyncStatus` on event.
+3. **Sync modes:**
+  - **Event-level:** `activated_seat_month`, `completed_export` (as soon as outbox processes).
+  - **Daily:** `storage_bytes_snapshot`, `sso_enabled` (scheduled job).
+4. **Daily reconciliation job:**
+  - Recompute `usageSnapshots` from `usageEvents` + live DB totals.
+  - Compare totals to Chargebee metered usage for the period.
+  - Set `reconciliationStatus: mismatch` for finance before invoice send.
+
+Finance workflow at period close: review Uprevit snapshot + Chargebee → approve/close invoice in Chargebee → send invoice email.
+
+---
+
+## Backend APIs
+
+All tenant routes use existing auth (`requireTenantContext`) and **workspace admin** (`isWorkspaceAdmin`). Webhook is unauthenticated except Chargebee signature verification.
+
+
+| Method | Path                          | Who                                  | Purpose                                                                                          |
+| ------ | ----------------------------- | ------------------------------------ | ------------------------------------------------------------------------------------------------ |
+| `GET`  | `/billing/summary`            | Workspace admin                      | Account, current snapshot, period usage, latest quote/invoice mirror, sync/reconciliation status |
+| `POST` | `/billing/chargebee/customer` | Platform admin (v1: Chargebee UI ok) | Create/link Chargebee customer; always `auto_collection: off`                                    |
+| `POST` | `/billing/chargebee/quote`    | Platform admin                       | Create quote for cadence + negotiated terms                                                      |
+| `POST` | `/billing/usage/reconcile`    | Platform admin / internal            | Recompute snapshot + compare to Chargebee                                                        |
+| `POST` | `/billing/usage/sync`         | Platform admin / internal            | Retry outbox / force sync                                                                        |
+| `PUT`  | `/billing/enforcement-mode`   | Workspace admin                      | `soft_overage` | `hard_limit`                                                                    |
+| `POST` | `/billing/webhooks/chargebee` | Chargebee                            | Verify signature; idempotent handler; update `billingAccounts`, `billingDocuments`               |
+
+
+**Env vars:** `CHARGEBEE_SITE`, `CHARGEBEE_API_KEY`, `CHARGEBEE_WEBHOOK_SECRET`, plus item price / meter IDs for quarterly, yearly, and each metric.
+
+**SAM:** New Lambdas in `[template.yaml](file:///Users/amit/Developer/Startup/uprevit-backend/template.yaml)` for webhook, scheduled reconciliation, and outbox processor.
+
+**Enforcement (phase 3):** On invite, export enqueue, presign upload — check `billingAccounts.enforcementMode` against snapshot + entitlements; soft = warn + allow; hard = 402/403.
+
+---
+
+## End-to-end flow
+
+```mermaid
+sequenceDiagram
+  participant Sales
+  participant Uprevit
+  participant CB as Chargebee
+  participant Customer
+  participant Finance
+
+  Sales->>Uprevit: Workspace exists
+  Sales->>CB: Create customer auto_collection_off
+  Sales->>CB: Create quote quarterly_or_yearly
+  Sales->>Customer: Quote PDF email
+  Customer->>Sales: Accept signature_or_manual
+  Sales->>CB: Convert quote to subscription
+  CB->>Uprevit: Webhooks store billingAccounts
+  Uprevit->>Uprevit: usageEvents plus outbox
+  Finance->>Uprevit: Review usageSnapshots
+  Finance->>CB: Approve and send invoice
+  Customer->>CB: Pay bank_or_PayNow
+  CB->>Uprevit: payment webhooks update status
+```
+
+
+
+---
+
+## Frontend ([uprevit-ui](file:///Users/amit/Developer/Startup/uprevit-ui))
+
+### Marketing pricing
+
+- `[apps/marketing/app/pricing/page.tsx](apps/marketing/app/pricing/page.tsx)`: Remove Growth vs Enterprise split; **one Uprevit plan** — quarterly or yearly contracts, custom quote after demo.
+- `[PricingCalculatorCards.tsx](apps/marketing/features/pricing/PricingCalculatorCards.tsx)`: Keep as **estimate / sizing guide only** (not checkout, not final price).
+- FAQs: final pricing confirmed after demo and Chargebee quote.
+
+### App billing tab
+
+- Uncomment billing tab in `[settings/page.tsx](apps/app/app/(app)`/settings/page.tsx).
+- Replace hardcoded data in `[BillingTab.tsx](apps/app/features/workspace/settings/BillingTab.tsx)` with `GET /billing/summary`.
+- Show: cadence, status, payment terms, activated seat-months, exports this period, storage used, SSO, latest quote/invoice, sync/reconciliation flags.
+- **No checkout CTA** — “Contact billing” / “Request quote update” for admins only.
+
+### Hooks
+
+- `useGetBillingSummary` → `GET /billing/summary`
+- `useUpdateBillingEnforcementMode` → `PUT /billing/enforcement-mode` (phase 3)
+
+---
+
+## Current codebase gaps
+
+
+| Area                    | Today                                     | Needed                                      |
+| ----------------------- | ----------------------------------------- | ------------------------------------------- |
+| Chargebee               | None                                      | Full integration                            |
+| Billing collections     | None                                      | Five collections above                      |
+| `sourceFiles.sizeBytes` | Missing                                   | Add + pass `file.size` from uploads         |
+| Seats                   | Countable via `users`                     | `activated_seat_month` events on activation |
+| Exports                 | `exportJobs`                              | Hook at `markExportJobCompleted`            |
+| Marketing               | Growth + Enterprise + calculator as tiers | Single plan + estimate calculator           |
+| Billing UI              | Placeholder, tab hidden                   | Live summary from API                       |
+
+
+---
+
+## Phased delivery
+
+### Phase 0 — Chargebee sandbox (no app code)
+
+- Catalog: Uprevit plan, quarterly/yearly price points, metered features.
+- Quotes + invoice emails; **auto-collection off** on all test customers.
+- **Payment path spike:** test A (Pay Now), C (virtual bank), D (offline wire); pick default + fallback.
+- Advanced usage billing + test event ingestion.
+
+### Phase 1 — Usage foundation (backend)
+
+- Collections + indexes.
+- Instrument seats, exports, storage (`sizeBytes` + API payload).
+- `usageEvents` + `usageSnapshots` job (no Chargebee yet).
+
+### Phase 2 — Chargebee sync
+
+- `chargebeeUsageOutbox` worker.
+- Webhook Lambda + `billingAccounts` + `billingDocuments`.
+- Daily reconciliation.
+
+### Phase 3 — APIs + app UI
+
+- `/billing/summary` and admin endpoints.
+- Billing tab + marketing pricing refresh.
+- Enforcement mode + limits on invite/export/upload.
+
+### Phase 4 — Sales ops (optional)
+
+- Internal admin UI for customer/quote creation (or stay in Chargebee UI).
+- Past-due / suspension automation from webhooks.
+
+---
+
+## Test plan
+
+**Backend unit**
+
+- Seat event only when user becomes active; no duplicate same month (idempotency).
+- Deactivation does not remove current month’s seat-month.
+- Export event only after `markExportJobCompleted`.
+- Storage totals from `sizeBytes`; delete reduces total.
+- Webhook and outbox idempotency.
+- Billing routes reject non-admins and cross-workspace access.
+
+**Backend integration-style**
+
+- Snapshot sums match events for a period.
+- Outbox retry leaves no lost events.
+- Reconciliation flags mismatch when Chargebee totals differ.
+
+**Frontend manual QA**
+
+- Pricing: one plan, no Growth/Enterprise; calculator labeled estimate.
+- Billing tab: loading, no billing account, active, pending invoice, paid, sync mismatch.
+- Non-admins cannot change enforcement or see admin actions.
+
+---
+
+## Assumptions
+
+- Quarterly and yearly are the only **contract** cadences; seat-months are metered per calendar month.
+- Uprevit is the auditable usage source of truth; Chargebee receives synced usage for invoicing.
+- Finance reviews usage before invoices are finalized/sent.
+- Auto-collection is never used; no product feature references it.
+- Payment gateway choice (Pay Now vs virtual bank vs offline wire) is decided in Phase 0.
+- Storage v1 = current total GB snapshot, not byte-hours.
+- SSO billing follows `billingAccounts.ssoEnabled`, not Cognito configuration.
+

--- a/.cursor/plans/final_billing_plan_75f87ade.plan.md
+++ b/.cursor/plans/final_billing_plan_75f87ade.plan.md
@@ -1,0 +1,366 @@
+---
+name: Final Billing Plan
+overview: "Finalized three-phase billing plan: Phase 1 unchanged; Phase 2 simplified to usageEvents plus workspace billing profile with hybrid limits and freezes; Phase 3 uses Chargebee Usage Events API with immediate send + retry, Chargebee-mirrored seats/SSO/terms, on-demand invoice fetch, and hard reset before implementation on a new Chargebee sandbox."
+todos:
+  - id: rewrite-plan-doc-final
+    content: Rewrite `/Users/amit/Downloads/Updated 3 Phased Plan.md` with all finalized decisions from clarification session.
+    status: pending
+  - id: chargebee-sandbox-catalog
+    content: "Document Chargebee new sandbox prerequisite: platform plan, seat add-on, SSO add-on, Usage Events meters for `exports` and `upload_mb`."
+    status: pending
+  - id: phase2-simplify
+    content: Plan Phase 2 removal of snapshots/reconciliation/add-on events; extend usageEvents + billingAccounts profile; Chargebee term for usage period.
+    status: pending
+  - id: phase3-usage-events
+    content: Plan Phase 3 Usage Events ingest, immediate send in export/upload/adjustment handlers, pending_link, 12h retry Lambda + manual retry.
+    status: pending
+  - id: phase3-webhooks-ui
+    content: Plan slim webhooks (seats/SSO/term/status), on-demand invoice fetch, Usage + Billing tabs, platform-admin UI removals.
+    status: pending
+  - id: reset-and-implement
+    content: "After plan approval: hard reset both repos to HEAD, then implement in order sandbox → Phase 2 cleanup → Phase 3."
+    status: pending
+isProject: false
+---
+
+# Final Simplified Billing Plan
+
+## Decisions Locked (from clarification)
+
+
+| Topic                    | Decision                                                                                                                 |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------------ |
+| Chargebee usage API      | **Usage Events ingest API** (not legacy `POST /subscriptions/{id}/usages`)                                               |
+| Seats / SSO billing      | **Chargebee is source of truth** — Uprevit mirrors via webhooks; never pushes seat counts to Chargebee                   |
+| Usage period (Usage tab) | **Chargebee subscription term** (`current_term_start` / `current_term_end`) once linked                                  |
+| Unlinked workspaces      | Record `usageEvents`; `chargebeeSync.status = pending_link` until subscription linked                                    |
+| Limits                   | **Hybrid** — seats + SSO from Chargebee mirror; exports + upload limits editable by workspace admin (same `limits` fields; platform admin can also set/override) |
+| Invoices (Billing tab)   | **Fetch on demand** from Chargebee API when tab loads (short cache); no `billingDocuments` collection                    |
+| Usage adjustments        | **Keep** — platform admin adjustments write `usageEvents` (`platform_adjustment`) and use same Chargebee send/retry path |
+| Upload Chargebee unit    | **Integer MB, ceil per commit** — `properties: { upload_mb: N }`                                                         |
+| Export Chargebee unit    | **1 event per completed export** — `properties: { exports: 1 }`                                                          |
+| Retries                  | **Scheduled Lambda (10–15 min) + manual platform-admin retry** within 12-hour `usage_timestamp` window                   |
+| Enforcement mode         | **Workspace admin** — block vs overage on Usage tab; platform admin may override operationally                             |
+| Billing notifications    | **Deferred** — no workspace email/push for limit warnings in v1                                                          |
+| Quotes                   | **Deferred** — link existing customer/subscription only in v1                                                            |
+| SSO feature flag         | **Webhook-driven** — SSO add-on on subscription enables `limits.ssoAllowed` + workspace SSO config                       |
+| Freezes                  | **Keep** usage freeze and access freeze                                                                                  |
+| Offline/pilot billing    | **auto_collection off** / offline-friendly settings when linking subscriptions                                           |
+| Implementation start     | **Hard reset both repos to HEAD** — discard uncommitted Phase 3 work                                                     |
+| Chargebee environment    | **New sandbox site** with clean plans, meters, add-ons; update env/AWS after catalog setup                               |
+
+
+## Architecture
+
+```mermaid
+flowchart TB
+  subgraph productFlow [Product Flow]
+    exportDone[ExportJobCompleted]
+    uploadDone[UploadCommitted]
+    exportDone --> writeEvent[Insert usageEvents]
+    uploadDone --> writeEvent
+    writeEvent --> trySend[Try Chargebee UsageEvent ingest]
+    trySend --> synced[chargebeeSync synced]
+    trySend --> failed[chargebeeSync failed or pending_link]
+    failed --> retryJob[ScheduledRetryLambda]
+    failed --> manualRetry[PlatformAdminManualRetry]
+    retryJob --> trySend
+    manualRetry --> trySend
+    failed --> agedOut[manual_correction_required after 12h]
+  end
+
+  subgraph chargebeeMirror [Chargebee Mirror]
+    cbWebhook[ChargebeeWebhook]
+    cbWebhook --> profile[WorkspaceBillingProfile in billingAccounts]
+    profile --> limits[limits.seats ssoAllowed term dates]
+    profile --> billingTab[BillingTab fetch invoices on demand]
+  end
+
+  writeEvent --> usageTab[UsageTab aggregate usageEvents by Chargebee term]
+```
+
+
+
+## Phase 1: Platform Operator Control Plane
+
+**No changes.** Keep content from [Updated 3 Phased Plan.md](/Users/amit/Downloads/Updated%203%20Phased%20Plan.md):
+
+- Platform-operator triple gate (`platform-admin` Cognito + registry + active user)
+- Platform APIs via `requirePlatformOperator`
+- Audit rules unchanged
+- No billing complexity added to Phase 1
+
+## Phase 2: Internal Usage And Limits (Revised)
+
+### Purpose
+
+Internal source of truth for **usage capture**, **limit enforcement**, and **usage display**. No Chargebee API calls in Phase 2 code paths except what Phase 3 adds at event-write time.
+
+### Collections (only two)
+
+1. `**usageEvents` — ledger for exports, uploads, platform adjustments
+2. `**billingAccounts`** — physical collection; domain name `**WorkspaceBillingProfile\*\`*
+
+Remove from plan and implementation:
+
+- `usageSnapshots` / snapshot approval / recompute
+- `billingProviderSyncOutbox` / provider sync
+- `billingProviderEvents` (as UI/ops surface)
+- `billingDocuments` collection
+- reconciliation runs and `reconciliation_backfill` source (unless needed for one-time migration)
+- `billingAddOnEvents` (SSO history replaced by webhook mirror + profile state)
+
+Optional: drop `usageAdjustments` collection — adjustments write directly to `usageEvents` with audit metadata on the event.
+
+### WorkspaceBillingProfile shape (on `billingAccounts`)
+
+```ts
+type WorkspaceBillingProfile = {
+  workspaceId: ObjectId;
+  status: "draft" | "active" | "past_due" | "cancelled" | "sync_error";
+
+  chargebee: {
+    customerId?: string;
+    subscriptionId?: string;
+    subscriptionStatus?: string;
+    planId?: string;
+    planName?: string;
+    billingCadence?: "monthly" | "yearly";
+    currentTermStart?: Date;
+    currentTermEnd?: Date;
+    nextBillingAt?: Date;
+    addOns?: Array<{ itemPriceId: string; name?: string; quantity?: number }>;
+    lastSyncedAt?: Date;
+    lastSyncError?: string;
+  };
+
+  limits: {
+    enabled: boolean;
+    enforcementMode: "block" | "overage"; // workspace admin (platform admin override)
+    seats: number; // mirrored from Chargebee seat add-on qty (read-only for workspace admin)
+    exports: number; // workspace admin + platform admin
+    uploadGb: number; // workspace admin + platform admin (display); enforce in bytes
+    ssoAllowed: boolean; // mirrored from Chargebee SSO add-on
+  };
+
+  paymentMode: "offline_wire" | "provider_bank_transfer" | "manual_external";
+  sso: { enabled: boolean; enabledAt?: Date; disabledAt?: Date }; // driven by webhook when SSO add-on present
+
+  createdAt: Date;
+  updatedAt: Date;
+};
+```
+
+### usageEvents shape (add Chargebee sync)
+
+```ts
+type UsageEventChargebeeSync = {
+  status:
+    | "pending_link"
+    | "pending"
+    | "synced"
+    | "failed"
+    | "manual_correction_required";
+  deduplicationId: string; // max 36 chars, e.g. export:{jobId} or upload:{keyHash}
+  attempts: number;
+  lastAttemptAt?: Date;
+  nextAttemptAt?: Date;
+  syncedAt?: Date;
+  lastError?: string;
+};
+```
+
+### Usage semantics (keep from current Phase 2)
+
+- Export usage on job `completed` only ([exportJobs.ts](file:///Users/amit/Developer/Startup/uprevit-backend/src/utils/exportJobs.ts))
+- Upload on committed upload key ([uploadCommit.ts](file:///Users/amit/Developer/Startup/uprevit-backend/src/utils/billing/uploadCommit.ts))
+- Delete does not reduce period usage
+- Active seats = active workspace members; enforce against `limits.seats` in `block` mode ([enforcement.ts](file:///Users/amit/Developer/Startup/uprevit-backend/src/utils/billing/enforcement.ts))
+- Pending invites not blocked by seat count (freezes still apply)
+- **Usage tab period** = Chargebee `currentTermStart/End` when linked; show “not linked” state before linkage
+
+### Limits and enforcement
+
+- `**block`: Uprevit blocks export/upload/seat activation before action
+- `**overage`: allow action, record event, send to Chargebee
+- Chargebee calculates invoice amounts; Uprevit does not reconcile totals
+- Workspace admin sets `limits.exports`, `limits.uploadGb`, and `enforcementMode` via `PUT /billing/preferences`
+- Platform admin sets `limits.enabled`, can override export/upload limits and enforcement, and mirrors Chargebee
+- Platform admin does **not** set `limits.seats` manually in normal flow — updated from Chargebee webhook
+- Workspace admin cannot edit seats or SSO allowance
+
+### Freezes (keep)
+
+- `workspaceUsageFreeze` — blocks invites, exports, uploads, seat activation/reactivation
+- `workspaceAccessFreeze` — blocks tenant APIs (with read-only exceptions e.g. billing/usage summary)
+
+### Workspace APIs
+
+```txt
+GET /billing/summary          # Usage tab: internal usage + limits for current Chargebee term
+GET /billing/chargebee        # Billing tab: mirrored profile + on-demand invoice fetch
+PUT /billing/preferences      # workspace admin: enforcementMode, limits.exports, limits.uploadGb
+```
+
+### Platform admin APIs (simplified)
+
+**Keep:**
+
+```txt
+GET  /platform-admin/workspaces/{workspaceId}/billing-account
+POST /platform-admin/workspaces/{workspaceId}/billing-account
+PUT  /platform-admin/workspaces/{workspaceId}/billing-account
+POST /platform-admin/workspaces/{workspaceId}/usage-adjustments
+POST /platform-admin/workspaces/{workspaceId}/freezes
+GET  /platform-admin/workspaces/{workspaceId}/usage-events
+POST /platform-admin/workspaces/{workspaceId}/chargebee/customer
+POST /platform-admin/workspaces/{workspaceId}/chargebee/subscription/link
+POST /platform-admin/workspaces/{workspaceId}/billing/retry-usage-sync   # manual retry
+POST /billing/webhooks/chargebee
+```
+
+**Remove:**
+
+```txt
+POST .../usage-snapshots/recompute
+POST .../usage-snapshots/approve
+POST .../billing/reconciliation-runs
+POST .../billing/provider-sync
+GET  .../provider-events
+POST .../chargebee/quote
+```
+
+### Phase 2 files to adapt (after reset)
+
+- Keep/adapt: [billing.ts](file:///Users/amit/Developer/Startup/uprevit-backend/src/models/billing.ts), [usageRecording.ts](file:///Users/amit/Developer/Startup/uprevit-backend/src/utils/billing/usageRecording.ts), [uploadCommit.ts](file:///Users/amit/Developer/Startup/uprevit-backend/src/utils/billing/uploadCommit.ts), [enforcement.ts](file:///Users/amit/Developer/Startup/uprevit-backend/src/utils/billing/enforcement.ts), [getSummary.ts](file:///Users/amit/Developer/Startup/uprevit-backend/src/controllers/billing/getSummary.ts)
+- Remove references to snapshots/reconciliation in serializers and platform admin controllers
+
+## Phase 3: Chargebee Usage Events And Mirror (Revised)
+
+### Prerequisite: New Chargebee sandbox catalog
+
+Before coding Phase 3, set up **new sandbox site** with:
+
+- Base platform plan (monthly/yearly), qty 1
+- **Seat add-on** (non-metered, per-seat) — source for `limits.seats`
+- **SSO add-on** (non-metered) — source for `limits.ssoAllowed` + internal SSO enable
+- **Usage meters** for Usage Events API:
+  - `exports` — sum per period
+  - `upload_mb` — sum per period (integer)
+- Metered export/upload items on subscription if required by site config
+- Offline-friendly customer defaults (`auto_collection: off`)
+
+Update `env.example.json` and AWS stack parameters with **new sandbox** IDs after catalog is ready. Do not assume current `exports-USD-Monthly` item prices work with Usage Events ingest.
+
+### Usage event ingest (immediate + retry)
+
+**On export completion** (in export worker, same handler as `recordCompletedExport`):
+
+1. Insert `usageEvents` row
+2. If no `subscriptionId` → `chargebeeSync.status = pending_link`; stop
+3. Else POST Usage Event:
+
+- `subscription_id`, `usage_timestamp` = export completion (ms), `deduplication_id`, `properties: { exports: 1 }`
+
+1. On success → `synced`; on failure → `failed` with error + `nextAttemptAt`
+
+**On upload commit** (in `recordCommittedUploadBytes`):
+
+1. Insert `usageEvents` row (bytes internally)
+2. Same send logic with `properties: { upload_mb: ceil(bytes/1MB) }`
+
+**On platform adjustment** ([createUsageAdjustment.ts](file:///Users/amit/Developer/Startup/uprevit-backend/src/controllers/platformAdmin/createUsageAdjustment.ts)):
+
+1. Insert adjustment as `usageEvents` with `source: platform_adjustment`
+2. Same Chargebee send path (export delta as `exports: N`, upload delta as `upload_mb: ceil`)
+
+**Retry:**
+
+- Scheduled Lambda every 10–15 min: retry `pending`, `failed`, and `pending_link` (once linked) where `occurredAt` within ~11 hours
+- Platform admin manual retry endpoint per workspace
+- After 12-hour Chargebee window → `manual_correction_required`; operational fallback = CSV/bulk upload (document procedure, implement tooling later)
+
+**Important:** Do not fail export/upload product action if Chargebee send fails — only record sync failure.
+
+### Webhook mirror (slim)
+
+Handler: [chargebeeWebhook.ts](file:///Users/amit/Developer/Startup/uprevit-backend/src/controllers/billing/chargebeeWebhook.ts)
+
+Update profile on relevant events:
+
+- `subscription_created` / `subscription_changed` / `subscription_renewed` → plan, cadence, term dates, add-ons, seat qty → `limits.seats`
+- SSO add-on present → `limits.ssoAllowed = true`, enable `sso.enabled`; absent → disable
+- `invoice_generated` / `invoice_updated` / payment events → update `status`, `past_due` flags only (invoices fetched on demand for Billing tab, not stored in Mongo)
+
+Keep webhook auth fail-closed. Idempotent processing by `providerEventId` (lightweight dedupe on profile or small webhook receipt log if needed — not a user-facing collection).
+
+### Customer / subscription linking (platform admin only)
+
+- Create customer + link subscription (existing flows, simplified)
+- Apply offline billing params on link/update: `auto_collection: off`, `invoice_immediately: false`
+- After link: attempt to send `pending_link` usage events still inside 12h window
+
+### Phase 3 files (after reset — new or replace)
+
+- New: `chargebeeUsageEvents.ts` — ingest client for Usage Events API
+- New: `usageEventChargebeeSync.ts` — send + retry helpers
+- New: scheduled retry Lambda + manual retry controller
+- New: `getBillingChargebee.ts` — Billing tab API (profile + invoice fetch)
+- Adapt: [chargebeeClient.ts](file:///Users/amit/Developer/Startup/uprevit-backend/src/utils/billing/chargebeeClient.ts), [chargebeeWebhooks.ts](file:///Users/amit/Developer/Startup/uprevit-backend/src/utils/billing/chargebeeWebhooks.ts)
+- Do not rebuild: `chargebeeSync.ts`, `providerOutbox.ts`, `snapshots.ts`, `reconciliation.ts`
+
+## UI Plan
+
+### Workspace settings
+
+
+| Tab         | Content                                                                                                                                                               |
+| ----------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Usage**   | Period (Chargebee term), active seats, exports, upload volume, limits, over-limit warnings, freeze banners. Workspace admin edits enforcement mode + export/upload limits; seats read-only. |
+| **Billing** | Plan name, cadence, Chargebee customer/subscription IDs, term dates, next billing, add-ons (seats, SSO), invoice list (paid/open/overdue) from on-demand API fetch.   |
+
+
+Files:
+
+- Adapt [UsageTab.tsx](file:///Users/amit/Developer/Startup/uprevit-ui/apps/app/features/workspace/settings/UsageTab.tsx)
+- New `BillingTab.tsx`
+- Update [settings/page.tsx](file:///Users/amit/Developer/Startup/uprevit-ui/apps/app/app/(app)/settings/page.tsx) — restore Billing tab (stop redirecting `?tab=billing` to usage)
+
+### Platform admin
+
+**Keep:** [PlatformBillingSection.tsx](file:///Users/amit/Developer/Startup/uprevit-ui/apps/app/features/platform-admin/PlatformBillingSection.tsx) (limits, freezes, usage summary), simplified [PlatformChargebeeSection.tsx](file:///Users/amit/Developer/Startup/uprevit-ui/apps/app/features/platform-admin/PlatformChargebeeSection.tsx) (link customer/subscription, connection status, manual retry, failed sync count)
+
+**Remove:** snapshot approval, provider sync, recompute/reconcile ops, provider events table, quote UI
+
+## Implementation Sequence
+
+1. **Hard reset** both `uprevit-backend` and `uprevit-ui` to HEAD (per decision)
+2. **Rewrite plan doc** at `/Users/amit/Downloads/Updated 3 Phased Plan.md` with this final content
+3. **Chargebee sandbox setup** — new site, meters, plans, add-ons; document property names `exports` and `upload_mb`
+4. **Phase 2 cleanup** — remove snapshot/reconciliation code paths; extend `usageEvents` + profile model; term-based usage aggregation
+5. **Phase 3** — Usage Events client, immediate send in export/upload/adjustment paths, webhooks, retry Lambda, Billing tab API + UI
+6. **Env/AWS** — update parameters with new sandbox IDs (after catalog ready)
+
+## Acceptance Criteria
+
+- No snapshot approval, reconciliation, or provider outbox in codebase or plan
+- 1 completed export → 1 `usageEvents` row + 1 Chargebee Usage Event (`exports: 1`)
+- 1 upload commit → 1 `usageEvents` row + 1 Chargebee Usage Event (`upload_mb: ceil`)
+- Unlinked workspace: events stored with `pending_link`; no Chargebee call
+- Linked workspace: failed sends retry automatically and manually within 12h
+- Events older than 12h with failed sync → `manual_correction_required`
+- Seats and SSO limits update from Chargebee webhooks only
+- Export/upload limits and enforcement mode set by workspace admin (`PUT /billing/preferences`); platform admin can override
+- Seat limits mirrored from Chargebee only; workspace admin read-only
+- Usage and Billing tabs show consistent Chargebee term dates when linked
+- Billing tab shows invoices from Chargebee API fetch
+- Internal usage summary works when Chargebee is down
+- Export/upload still succeed when Chargebee send fails
+
+## Verification
+
+Backend: `npm --prefix src test -- billing`, `platformAdmin`, new `chargebeeUsageEvents` tests, `type-check`
+
+UI: `bun run lint`, `bun run type-check`
+
+Manual E2E: export + upload + adjustment flows; pending_link; link subscription + backfill; retry; block vs overage; freezes; Billing tab invoices; webhook seat/SSO mirror

--- a/.cursor/rules/Branch-Merging-Strategy.mdc
+++ b/.cursor/rules/Branch-Merging-Strategy.mdc
@@ -1,0 +1,39 @@
+---
+alwaysApply: false
+---
+
+Gitflow and `demo` branch (uprevit-ui & uprevit-backend)
+
+## Branches
+
+- `develop` — integration (features merge here)
+- `release/x.y.z` — release fixes only
+- `main` — production (deploy prod)
+- `demo` — demo environment; must be the **same commit as `main`**, not `develop`
+
+## Release flow
+
+1. Merge `release/x.y.z` → `main`, tag `vx.y.z` on `main`.
+2. **One PR:** `main` → `develop` (back-merge).
+3. Sync `demo` to `main` with a ref push — **no PR:**
+
+```bash
+git fetch origin
+git push origin origin/main:demo
+If rejected:
+
+git diff origin/main origin/demo --stat   # must be empty
+git push origin origin/main:demo --force-with-lease
+Local: git fetch origin && git checkout demo && git reset --hard origin/demo
+
+Verify:
+
+git rev-parse origin/main origin/demo    # identical SHA
+git rev-list --left-right --count origin/main...origin/demo   # 0 0
+Never
+Do not open a PR main → demo (adds a merge commit; demo looks ahead of main).
+Do not git push origin origin/develop:demo for releases (demo must match main, not develop).
+Expected graph
+main, demo, origin/demo — same commit (release merge).
+develop — one commit ahead of main (back-merge only). That is normal; do not try to align develop with main on the graph.
+```

--- a/.gitignore
+++ b/.gitignore
@@ -48,5 +48,4 @@ next-env.d.ts
 .vscode/
 /staging-e2e
 monorepo*
-.cursor
 .source/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -129,3 +129,5 @@ Located at `../uprevit-backend`:
 - **`@/lib/utils`**: Contains `cn()` for Tailwind class merging
 - **`@/utils/isAdmin`**: Contains `isAdminProfile()` for admin role checks
 - **`@/components/ui`**: shadcn/ui component library
+
+- Billing tab is hidden for the time being, Later on we will introduce a new user group called as manager who can who other stuff and billing, check and download invoices but can't do any other CRUD operation in the app

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.1] - 2026-06-21
+
+### Updated
+
+- Temporarily hid the Billing tab in workspace settings while a dedicated manager user group is planned.
+- Updated AGENTS.md with notes on the future manager user group and billing access.
+- Updated monorepo package versions to `0.5.1`.
+
+### Fixed
+
+- Fixed product workbook redline compare grids to remain read-only.
+
 ## [0.5.0] - 2026-06-19
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,34 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.0] - 2026-06-19
+
+### Added
+
+- Added platform operator control plane UI with workspace detail, logs, and billing management screens.
+- Added workspace usage tab, billing summary, and Chargebee-backed invoice detail with PDF download.
+- Added workspace access frozen and removed eligibility screens with auth and onboarding integration.
+- Added product workbook unsaved-change guard with navigation prompts and label tag status indicators.
+- Added user removal controls and inactive member list management in workspace settings.
+- Added Product Overview documentation page and consolidated seven-tab product guides.
+- Added shared billing types, hooks, and utilities for workspace and platform-admin billing flows.
+
+### Updated
+
+- Updated platform admin dashboard layout, workspace detail, usage events, and billing tooling.
+- Updated marketing pricing calculator for Chargebee usage pricing and yearly usage estimates.
+- Updated redline styling with shared dark mode support across product views and workbook cells.
+- Updated label tags editor with CORS image loading, keyboard shortcuts, and source-file link warnings.
+- Updated documentation videos to use next-video player and refreshed compare-versions clip.
+- Updated monorepo package versions to `0.5.0`.
+
+### Fixed
+
+- Fixed dashboard department and project card overflow on smaller viewports.
+- Fixed product table row expansion to occur only when a component image exists.
+- Fixed platform admin billing UI states for empty accounts, past due mirroring, and usage form staleness.
+- Fixed TypeScript and Amplify build errors across platform admin and product workbook flows.
+
 ## [0.4.0] - 2026-05-28
 
 ### Added

--- a/apps/app/app/(app)/settings/page.tsx
+++ b/apps/app/app/(app)/settings/page.tsx
@@ -116,16 +116,12 @@ function SettingsPage() {
                   <PiChartBarDuotone className="mr-2 h-4 w-4" />
                   Usage
                 </TabsTrigger>
-                <TabsTrigger value="billing">
+                {/* <TabsTrigger value="billing">
                   <PiCreditCardDuotone className="mr-2 h-4 w-4" />
                   Billing
-                </TabsTrigger>
+                </TabsTrigger> */}
               </>
             ) : null}
-            {/* <TabsTrigger value="security">
-              <PiShieldCheckDuotone className="mr-2 h-4 w-4" />
-              Security
-            </TabsTrigger> */}
           </TabsList>
 
           <TabsContent value="profile" className="mt-6">
@@ -148,12 +144,9 @@ function SettingsPage() {
             {activeTab === "usage" && <UsageTab />}
           </TabsContent>
 
-          <TabsContent value="billing" className="mt-6">
+          {/* Billing Tab is kept hidden, it is disabled for now. Later on we will add new user group as manager which is not billed who can only handle this billing tab and can't do any other activities*/}
+          {/* <TabsContent value="billing" className="mt-6">
             {activeTab === "billing" && <BillingTab />}
-          </TabsContent>
-
-          {/* <TabsContent value="security" className="mt-6">
-            <SecurityTab />
           </TabsContent> */}
         </Tabs>
       </div>

--- a/apps/app/app/(app)/settings/page.tsx
+++ b/apps/app/app/(app)/settings/page.tsx
@@ -40,9 +40,12 @@ function SettingsPage() {
   const router = useRouter();
   const auth = useAuth();
   const isAdmin = isAdminProfile(auth.user?.profile);
-  const adminTabs = ["admins", "workspace", "usage", "billing", "security"];
+  const adminTabs = ["admins", "workspace", "usage", "security"];
+  const resolvedTab = tab === "billing" ? "usage" : tab;
   const activeTab =
-    tab && (!adminTabs.includes(tab) || isAdmin) ? tab : "profile";
+    resolvedTab && (!adminTabs.includes(resolvedTab) || isAdmin)
+      ? resolvedTab
+      : "profile";
   const [pendingTab, setPendingTab] = useState<string | null>(null);
   const [syncedActiveTab, setSyncedActiveTab] = useState(activeTab);
 

--- a/apps/app/features/workspace/products/product/product-data-table/ProductWorkbookTabPage.tsx
+++ b/apps/app/features/workspace/products/product/product-data-table/ProductWorkbookTabPage.tsx
@@ -256,7 +256,7 @@ export function ProductWorkbookTabPage({
           }
           onSaveSuccess={editor.registerClearHistoryOnSave}
           isRedlineView={isRedlineView}
-          isReadOnly={isSubmitted}
+          isReadOnly={isSubmitted || isRedlineView}
           redlineMode={redlineMode}
           redlineBaseData={redlineBaseData}
         />

--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uprevit/app",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "private": true,
   "scripts": {
     "dev": "next dev -p 8080",

--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uprevit/app",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "private": true,
   "scripts": {
     "dev": "next dev -p 8080",

--- a/apps/marketing/package.json
+++ b/apps/marketing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uprevit/marketing",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "private": true,
   "scripts": {
     "dev": "next dev -p 3001",

--- a/apps/marketing/package.json
+++ b/apps/marketing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uprevit/marketing",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "private": true,
   "scripts": {
     "dev": "next dev -p 3001",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uprevit-ui",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "private": true,
   "packageManager": "bun@1.3.11",
   "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uprevit-ui",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "private": true,
   "packageManager": "bun@1.3.11",
   "workspaces": [

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uprevit/ui",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "private": true,
   "scripts": {
     "build": "tsc --noEmit",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uprevit/ui",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "private": true,
   "scripts": {
     "build": "tsc --noEmit",


### PR DESCRIPTION
## Updated

- Temporarily hid the Billing tab in workspace settings while a dedicated manager user group is planned.
- Updated AGENTS.md with notes on the future manager user group and billing access.
- Updated monorepo package versions to `0.5.1`.

## Fixed

- Fixed product workbook redline compare grids to remain read-only.