### PR TITLE
Chore/bump version 0.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.2] - 2026-06-30
+
+### HOTFIX
+
+- Temporarily hid the Pricing calculator on the pricing page of the marketing app
+- Updated monorepo package versions to `0.5.2`.
+
 ## [0.5.1] - 2026-06-21
 
 ### Updated

--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uprevit/app",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "private": true,
   "scripts": {
     "dev": "next dev -p 8080",

--- a/apps/marketing/package.json
+++ b/apps/marketing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uprevit/marketing",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "private": true,
   "scripts": {
     "dev": "next dev -p 3001",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uprevit-ui",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "private": true,
   "packageManager": "bun@1.3.11",
   "workspaces": [

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uprevit/ui",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "private": true,
   "scripts": {
     "build": "tsc --noEmit",


### PR DESCRIPTION
- Temporarily hid the Pricing calculator on the pricing page of the marketing app
- Updated monorepo package versions to `0.5.2`.